### PR TITLE
Add tabbed glossary with score explanations and a first-run discovery…

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -134,4 +134,32 @@ describe("App", () => {
     expect(screen.getByRole("heading", { name: "Glossary" })).toBeInTheDocument();
     expect(screen.getByText("Subagent")).toBeInTheDocument();
   });
+
+  it("shows the first-run glossary hint and dismisses it on 'Got it'", async () => {
+    renderApp();
+
+    expect(await screen.findByText("Not sure what a term means?")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+
+    expect(screen.queryByText("Not sure what a term means?")).not.toBeInTheDocument();
+    expect(localStorage.getItem("ccfr-glossary-hint-seen")).toBe("1");
+  });
+
+  it("retires the glossary hint once the glossary is opened", async () => {
+    renderApp();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open glossary" }));
+
+    expect(screen.queryByText("Not sure what a term means?")).not.toBeInTheDocument();
+    expect(localStorage.getItem("ccfr-glossary-hint-seen")).toBe("1");
+  });
+
+  it("hides the hint when it has already been seen", async () => {
+    localStorage.setItem("ccfr-glossary-hint-seen", "1");
+    renderApp();
+
+    await screen.findByRole("button", { name: "Open glossary" });
+    expect(screen.queryByText("Not sure what a term means?")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Sidebar from "./shell/Sidebar";
 import type { View } from "./shell/navConfig";
 import { DEFAULT_TECHNIQUE } from "./discover/techniques";
 import { useCollapsed } from "./shell/useCollapsed";
+import { useGlossaryHint } from "./shell/useGlossaryHint";
 import { useTheme } from "./theme/useTheme";
 
 function App() {
@@ -23,6 +24,7 @@ function App() {
   const [selectedSession, setSelectedSession] = React.useState<SessionCard | null>(null);
   const { theme, toggle } = useTheme();
   const { collapsed, toggle: toggleCollapsed } = useCollapsed();
+  const { seen: glossaryHintSeen, dismiss: dismissGlossaryHint } = useGlossaryHint();
   const [glossaryOpen, setGlossaryOpen] = React.useState(false);
   const autoRouted = React.useRef(false);
 
@@ -50,7 +52,12 @@ function App() {
     setView("discover");
   };
 
-  const openGlossary = () => setGlossaryOpen(true);
+  // Opening the glossary (from the button or the hint's CTA) counts as
+  // discovery, so retire the first-run hint at the same time.
+  const openGlossary = () => {
+    setGlossaryOpen(true);
+    dismissGlossaryHint();
+  };
 
   return (
     <div className="app-shell">
@@ -65,6 +72,8 @@ function App() {
         onToggleCollapsed={toggleCollapsed}
         onToggleTheme={toggle}
         onOpenGlossary={openGlossary}
+        glossaryHint={!glossaryHintSeen}
+        onDismissGlossaryHint={dismissGlossaryHint}
       />
 
       <main className="app-main">

--- a/frontend/src/glossary/GlossaryDialog.test.tsx
+++ b/frontend/src/glossary/GlossaryDialog.test.tsx
@@ -3,15 +3,27 @@ import { describe, expect, it, vi } from "vitest";
 import GlossaryDialog from "./GlossaryDialog";
 
 describe("GlossaryDialog", () => {
-  it("renders category headings and a sample term with its definition when open", () => {
+  it("renders the default Structure tab with a sample term and its definition", () => {
     render(<GlossaryDialog open onClose={vi.fn()} />);
 
     expect(screen.getByRole("heading", { name: "Glossary" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Structure" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Structure" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText("Subagent")).toBeInTheDocument();
     expect(
       screen.getByText(/secondary agent the main thread spawns/i),
     ).toBeInTheDocument();
+  });
+
+  it("switches panels when another tab is selected, revealing that tab's terms and score detail", () => {
+    render(<GlossaryDialog open onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Risk" }));
+
+    // The Risk score term and its computed-mechanics detail are now shown.
+    expect(screen.getByText("Risk score")).toBeInTheDocument();
+    expect(screen.getByText(/Alerts/)).toBeInTheDocument();
+    // Structure-only terms are no longer rendered in the active panel.
+    expect(screen.queryByText("Subagent")).not.toBeInTheDocument();
   });
 
   it("calls onClose when the close button is clicked", () => {

--- a/frontend/src/glossary/GlossaryDialog.tsx
+++ b/frontend/src/glossary/GlossaryDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { X } from "lucide-react";
-import { CATEGORY_ORDER, GLOSSARY_TERMS } from "./glossaryTerms";
+import { CATEGORY_ORDER, GLOSSARY_TERMS, type GlossaryCategory } from "./glossaryTerms";
 
 interface Props {
   open: boolean;
@@ -9,16 +9,23 @@ interface Props {
 
 // A single shared glossary, rendered once at the app shell so every view gets
 // the same definitions. Uses the native <dialog> element for focus trapping,
-// Esc-to-close, and a backdrop without extra JS.
+// Esc-to-close, and a backdrop without extra JS. Content is split across tabs
+// (one per category) so each panel stays short and scannable.
 export default function GlossaryDialog({ open, onClose }: Props) {
   const ref = React.useRef<HTMLDialogElement>(null);
+  const [activeTab, setActiveTab] = React.useState<GlossaryCategory>(CATEGORY_ORDER[0]);
 
-  // Drive the dialog's modal state from the `open` prop.
+  // Drive the dialog's modal state from the `open` prop, and reset to the first
+  // tab on each open so it never reopens on a stale tab.
   React.useEffect(() => {
     const dialog = ref.current;
     if (!dialog) return;
-    if (open && !dialog.open) dialog.showModal();
-    else if (!open && dialog.open) dialog.close();
+    if (open && !dialog.open) {
+      setActiveTab(CATEGORY_ORDER[0]);
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
   }, [open]);
 
   // Esc and backdrop dismissal both fire the dialog's native close event;
@@ -30,6 +37,8 @@ export default function GlossaryDialog({ open, onClose }: Props) {
   const handleClick = (event: React.MouseEvent<HTMLDialogElement>) => {
     if (event.target === ref.current) onClose();
   };
+
+  const terms = GLOSSARY_TERMS.filter((t) => t.category === activeTab);
 
   return (
     <dialog
@@ -51,24 +60,43 @@ export default function GlossaryDialog({ open, onClose }: Props) {
             <X size={16} />
           </button>
         </header>
-        <div className="glossary-body">
-          {CATEGORY_ORDER.map((category) => {
-            const terms = GLOSSARY_TERMS.filter((t) => t.category === category);
-            if (terms.length === 0) return null;
-            return (
-              <section key={category} className="glossary-section">
-                <h3 className="glossary-category">{category}</h3>
-                <dl className="glossary-terms">
-                  {terms.map((t) => (
-                    <div key={t.term} className="glossary-entry">
-                      <dt>{t.term}</dt>
-                      <dd>{t.definition}</dd>
-                    </div>
-                  ))}
-                </dl>
-              </section>
-            );
-          })}
+        <div className="glossary-tabs" role="tablist" aria-label="Glossary categories">
+          {CATEGORY_ORDER.map((category) => (
+            <button
+              type="button"
+              role="tab"
+              key={category}
+              id={`glossary-tab-${category}`}
+              aria-controls="glossary-tabpanel"
+              aria-selected={activeTab === category}
+              className={activeTab === category ? "active" : ""}
+              onClick={() => setActiveTab(category)}
+            >
+              {category}
+            </button>
+          ))}
+        </div>
+        <div
+          className="glossary-body"
+          id="glossary-tabpanel"
+          role="tabpanel"
+          aria-labelledby={`glossary-tab-${activeTab}`}
+        >
+          <dl className="glossary-terms">
+            {terms.map((t) => (
+              <div key={t.term} className="glossary-entry">
+                <dt>{t.term}</dt>
+                <dd>{t.definition}</dd>
+                {t.detail && (
+                  <div className="glossary-detail" aria-label="How it's computed">
+                    {t.detail.map((line, index) => (
+                      <span key={index}>{line || " "}</span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </dl>
         </div>
       </div>
     </dialog>

--- a/frontend/src/glossary/glossaryTerms.ts
+++ b/frontend/src/glossary/glossaryTerms.ts
@@ -2,15 +2,30 @@
 // content here (rather than inline in the dialog) makes it the single place to
 // edit definitions and lets tests assert against the data directly.
 
-export type GlossaryCategory = "Structure" | "Activity" | "Cost";
+export type GlossaryCategory =
+  | "Structure"
+  | "Activity"
+  | "Risk"
+  | "Discovery"
+  | "Cost";
 
 export interface GlossaryTerm {
   category: GlossaryCategory;
   term: string;
   definition: string;
+  // Optional "how it's computed" lines, rendered as a monospace block beneath
+  // the definition. Used for the scores where the exact mechanics help a dev
+  // reconcile what they see on screen with how it was produced.
+  detail?: string[];
 }
 
-export const CATEGORY_ORDER: GlossaryCategory[] = ["Structure", "Activity", "Cost"];
+export const CATEGORY_ORDER: GlossaryCategory[] = [
+  "Structure",
+  "Activity",
+  "Risk",
+  "Discovery",
+  "Cost",
+];
 
 export const GLOSSARY_TERMS: GlossaryTerm[] = [
   // Structure — how a body of work is organized.
@@ -44,6 +59,18 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     definition:
       "One ingestion of session logs from a source folder into the database. Re-importing the same source updates existing sessions.",
   },
+  {
+    category: "Structure",
+    term: "Memory",
+    definition:
+      "A fact Claude Code persisted during a session so it carries across runs (for example a note written to a memory file). The Import page's \"Memory\" stat counts how many were captured across all sessions.",
+  },
+  {
+    category: "Structure",
+    term: "Large output",
+    definition:
+      "A tool output big enough that it was stored on its own rather than inline with the event — typically a heavy file read or verbose command output. The Import page's \"Large outputs\" stat counts these.",
+  },
 
   // Activity — what happens inside a session.
   {
@@ -70,6 +97,130 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     definition:
       "A stretch where the agent repeats a similar action without making progress. Flagged on the timeline as a possible stuck pattern worth reviewing.",
   },
+  {
+    category: "Activity",
+    term: "Loop span",
+    definition:
+      "The highlighted stretch drawn on the timeline that marks a detected loop — the visual span covering the repeated events.",
+  },
+  {
+    category: "Activity",
+    term: "Lane",
+    definition:
+      "Each horizontal row in the Session timeline. The top lane is the main thread; each lane below is one subagent, labelled with its agent ID (the short hex string).",
+  },
+  {
+    category: "Activity",
+    term: "Collapsed run (×N)",
+    definition:
+      "On the timeline, a run of N near-identical consecutive events folded into a single marker labelled ×N (e.g. ×50) to keep dense stretches readable. Toggle it with \"Group dense\".",
+  },
+  {
+    category: "Activity",
+    term: "Group dense",
+    definition:
+      "The timeline toggle that collapses dense runs of similar events into ×N markers. Turn it off to see every event individually.",
+  },
+  {
+    category: "Activity",
+    term: "Timeline spacing",
+    definition:
+      "How the timeline spaces events along the x-axis. Raw time uses real wall-clock gaps; Compressed gaps shortens long idle stretches so activity isn't squished; Event order ignores time and spaces events evenly.",
+  },
+
+  // Risk — the Triage rank and the findings/patterns behind it.
+  {
+    category: "Risk",
+    term: "Risk score",
+    definition:
+      "The Triage \"Risk\" number — a single rank for how much a session is worth reviewing. Higher means more (errors, stuck loops, heavy fan-out, size, or risky patterns). It's a relative sort key, not a probability.",
+    detail: [
+      "Weighted sum of 5 signals, each squashed to 0–1",
+      "via  value / (value + scale):",
+      "",
+      "  Alerts    ×3     errors + system events",
+      "  Loops     ×2     loop count × longest repeat",
+      "  Fanout    ×1.5   subagents + agent events",
+      "  Size      ×1     max of events / time / tokens",
+      "  Patterns  ×2     risky-pattern findings score",
+    ],
+  },
+  {
+    category: "Risk",
+    term: "Risk tiers (color)",
+    definition:
+      "The color of the Risk score reflects its tier. The thin segmented underline shows which signals are driving that score.",
+    detail: ["High    score ≥ 6", "Medium  score ≥ 3", "Low     score < 3"],
+  },
+  {
+    category: "Risk",
+    term: "Finding",
+    definition:
+      "A risky pattern detected in a session's sequence of tool calls. The top finding shows in Triage's \"Findings\" column, and findings feed the Patterns signal of the Risk score.",
+  },
+  {
+    category: "Risk",
+    term: "Finding types",
+    definition:
+      "Every finding is sorted into one of these categories, based on the tool-call sequence that triggered it.",
+    detail: [
+      "Unsafe write attempt   edit/write hit a safety error",
+      "Permission friction    tool denied or user-rejected",
+      "Environment mismatch   missing dep, timeout, validation",
+      "Subagent failure       error inside a delegated agent",
+      "Failed verification    test/lint failed, then a repair",
+      "Rare risky workflow    uncommon vs the local baseline",
+    ],
+  },
+
+  // Discovery — the Subgroup view that explains outcomes.
+  {
+    category: "Discovery",
+    term: "Subgroup (driver)",
+    definition:
+      "A set of conditions that, when they co-occur, line up with an outcome far more often than the average session does. Discovery surfaces the subgroups that most \"drive\" each outcome.",
+  },
+  {
+    category: "Discovery",
+    term: "Outcome",
+    definition:
+      "The thing a subgroup is being measured against — the tabs at the top of Discover: high Cost, high-cost Fanout, Tool errors, and Rejections.",
+  },
+  {
+    category: "Discovery",
+    term: "Selector / condition",
+    definition:
+      "One of the chips that defines a subgroup, e.g. \"uses claude-sonnet-4-6\" or \">10 subagents\". A subgroup is the sessions matching all of its selectors.",
+  },
+  {
+    category: "Discovery",
+    term: "Lift",
+    definition:
+      "How many times more often the subgroup hits the outcome than the average session. A 5.83× lift means sessions matching the conditions hit it 5.83 times as often as the baseline rate.",
+    detail: [
+      "lift =  (matches hitting outcome ÷ matches)",
+      "        ─────────────────────────────────",
+      "        (all hitting outcome ÷ all sessions)",
+    ],
+  },
+  {
+    category: "Discovery",
+    term: "Support / Min support",
+    definition:
+      "Support is how many sessions match the subgroup's conditions. The a/b figure (e.g. 70/79) is how many of those matches hit the outcome. \"Min support\" is the threshold a subgroup must clear to be reported — raise it to drop tiny, noisy subgroups.",
+  },
+  {
+    category: "Discovery",
+    term: "Subgroup vs baseline rate",
+    definition:
+      "The two comparison bars: how often the subgroup hits the outcome versus how often all sessions do. The gap between them is what the lift summarizes.",
+  },
+  {
+    category: "Discovery",
+    term: "95% confidence lower bound",
+    definition:
+      "The \"stays at or above X%\" figure. Even on a pessimistic reading of a small sample, the subgroup's rate is still expected to beat the baseline — a guard against being fooled by a handful of sessions.",
+  },
 
   // Cost — token usage and spend.
   {
@@ -77,6 +228,12 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     term: "Token",
     definition:
       "The unit models read and write text in. Cost and usage are measured in tokens; roughly a few characters each.",
+  },
+  {
+    category: "Cost",
+    term: "Total spend",
+    definition:
+      "The headline dollar figure on the Cost page: the summed cost across the sessions in the current time range and project filter.",
   },
   {
     category: "Cost",
@@ -92,8 +249,20 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
   },
   {
     category: "Cost",
+    term: "Cache saved / penalty",
+    definition:
+      "Net effect of caching versus paying full price for the same input: a saving when cache reads outweigh the write surcharge, a penalty when prefixes were cached but rarely reused.",
+  },
+  {
+    category: "Cost",
     term: "Spend spike",
     definition:
-      "A point in time where cost jumped sharply above the surrounding baseline. Highlighted on the cost charts so unusually expensive moments stand out.",
+      "A point in time where cost jumped sharply above the surrounding baseline. The Cost page's \"Largest spike\" names the date bucket and how much it jumped.",
+  },
+  {
+    category: "Cost",
+    term: "Outside target",
+    definition:
+      "From the turn-distribution chart: the count of sessions whose number of turns falls outside the healthy band — unusually short or unusually long — and may be worth a look.",
   },
 ];

--- a/frontend/src/shell/Sidebar.test.tsx
+++ b/frontend/src/shell/Sidebar.test.tsx
@@ -16,6 +16,7 @@ function setup(overrides: Partial<React.ComponentProps<typeof Sidebar>> = {}) {
     onToggleCollapsed: vi.fn(),
     onToggleTheme: vi.fn(),
     onOpenGlossary: vi.fn(),
+    onDismissGlossaryHint: vi.fn(),
     ...overrides,
   };
   render(<Sidebar {...props} />);
@@ -71,5 +72,26 @@ describe("Sidebar", () => {
   it("applies the collapsed class to the sidebar when collapsed", () => {
     setup({ collapsed: true });
     expect(screen.getByRole("complementary")).toHaveClass("is-collapsed");
+  });
+
+  it("does not show the glossary hint by default", () => {
+    setup();
+    expect(screen.queryByText("Not sure what a term means?")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open glossary" })).not.toHaveClass("is-hinted");
+  });
+
+  it("pulses the help button and shows a dismissable coachmark when hinted", () => {
+    const props = setup({ glossaryHint: true });
+
+    expect(screen.getByRole("button", { name: "Open glossary" })).toHaveClass("is-hinted");
+    expect(screen.getByText("Not sure what a term means?")).toBeInTheDocument();
+
+    // The coachmark CTA opens the glossary...
+    fireEvent.click(screen.getByRole("button", { name: "Browse glossary" }));
+    expect(props.onOpenGlossary).toHaveBeenCalled();
+
+    // ...and "Got it" dismisses the hint without opening it.
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    expect(props.onDismissGlossaryHint).toHaveBeenCalled();
   });
 });

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -14,6 +14,10 @@ interface Props {
   onToggleCollapsed: () => void;
   onToggleTheme: () => void;
   onOpenGlossary: () => void;
+  // First-run hint that surfaces the glossary. When true, the help button
+  // pulses and a dismissable coachmark is shown.
+  glossaryHint?: boolean;
+  onDismissGlossaryHint?: () => void;
 }
 
 export default function Sidebar({
@@ -27,6 +31,8 @@ export default function Sidebar({
   onToggleCollapsed,
   onToggleTheme,
   onOpenGlossary,
+  glossaryHint = false,
+  onDismissGlossaryHint,
 }: Props) {
   return (
     <aside className={`app-sidebar ${collapsed ? "is-collapsed" : ""}`} aria-label="Primary">
@@ -78,9 +84,30 @@ export default function Sidebar({
       </nav>
 
       <div className="sb-foot">
-        <button className="sb-action" onClick={onOpenGlossary} aria-label="Open glossary" title="Open glossary">
-          <HelpCircle size={16} />
-        </button>
+        <div className="sb-glossary">
+          <button
+            className={`sb-action ${glossaryHint ? "is-hinted" : ""}`}
+            onClick={onOpenGlossary}
+            aria-label="Open glossary"
+            title="Open glossary"
+          >
+            <HelpCircle size={16} />
+          </button>
+          {glossaryHint && (
+            <div className="glossary-hint" role="note" aria-labelledby="glossary-hint-title">
+              <h4 id="glossary-hint-title">Not sure what a term means?</h4>
+              <p>Open the glossary any time for plain-English definitions — and how each score is computed.</p>
+              <div className="glossary-hint-actions">
+                <button type="button" className="ghint-primary" onClick={onOpenGlossary}>
+                  Browse glossary
+                </button>
+                <button type="button" className="ghint-secondary" onClick={() => onDismissGlossaryHint?.()}>
+                  Got it
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
         <button
           className="sb-action"
           onClick={onToggleTheme}

--- a/frontend/src/shell/useGlossaryHint.test.ts
+++ b/frontend/src/shell/useGlossaryHint.test.ts
@@ -1,0 +1,25 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useGlossaryHint } from "./useGlossaryHint";
+
+describe("useGlossaryHint", () => {
+  afterEach(() => localStorage.clear());
+
+  it("is unseen by default", () => {
+    const { result } = renderHook(() => useGlossaryHint());
+    expect(result.current.seen).toBe(false);
+  });
+
+  it("marks seen and persists to localStorage when dismissed", () => {
+    const { result } = renderHook(() => useGlossaryHint());
+    act(() => result.current.dismiss());
+    expect(result.current.seen).toBe(true);
+    expect(localStorage.getItem("ccfr-glossary-hint-seen")).toBe("1");
+  });
+
+  it("reads the persisted value on init", () => {
+    localStorage.setItem("ccfr-glossary-hint-seen", "1");
+    const { result } = renderHook(() => useGlossaryHint());
+    expect(result.current.seen).toBe(true);
+  });
+});

--- a/frontend/src/shell/useGlossaryHint.ts
+++ b/frontend/src/shell/useGlossaryHint.ts
@@ -1,0 +1,29 @@
+import React from "react";
+
+// First-run discovery hint for the glossary. We pulse the help button and show
+// a one-time coachmark until the user either opens the glossary or dismisses
+// the hint; the "seen" flag is persisted so it never nags again.
+const STORAGE_KEY = "ccfr-glossary-hint-seen";
+
+function getInitial(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function useGlossaryHint() {
+  const [seen, setSeen] = React.useState<boolean>(getInitial);
+
+  const dismiss = React.useCallback(() => {
+    setSeen(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return { seen, dismiss };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -122,6 +122,57 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .app-sidebar.is-collapsed .sb-foot { flex-direction: column; align-items: center; }
 .app-sidebar.is-collapsed .sb-collapse { margin-left: 0; }
 
+/* Glossary discovery hint — pulse the help button and float a one-time
+   coachmark above it until the user opens the glossary or dismisses the hint. */
+.sb-glossary { position: relative; display: grid; }
+.sb-action.is-hinted {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-2));
+  animation: glossary-pulse 1.8s ease-out infinite;
+}
+@keyframes glossary-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 50%, transparent); }
+  70%  { box-shadow: 0 0 0 9px color-mix(in srgb, var(--accent) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 0%, transparent); }
+}
+.glossary-hint {
+  position: absolute; bottom: calc(100% + 12px); left: 0; z-index: 60;
+  width: 244px; padding: 13px 14px; text-align: left;
+  background: var(--raised); color: var(--text);
+  border: 1px solid var(--border-2); border-radius: 12px;
+  box-shadow: 0 18px 44px var(--shadow);
+  animation: glossary-hint-in .22s ease-out both;
+}
+@keyframes glossary-hint-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.glossary-hint h4 { margin: 0 0 5px; font-size: 12.5px; font-weight: 700; }
+.glossary-hint p { margin: 0; font-size: 11.5px; line-height: 1.5; color: var(--muted); }
+.glossary-hint-actions { display: flex; gap: 8px; margin-top: 12px; }
+.glossary-hint-actions button {
+  font-size: 11.5px; font-weight: 600; padding: 6px 11px; border-radius: 8px; cursor: pointer;
+  border: 1px solid transparent;
+}
+.ghint-primary { background: var(--accent); color: #fff; }
+.ghint-primary:hover { filter: brightness(1.06); }
+.ghint-secondary { background: var(--bg); color: var(--muted); border-color: var(--border); }
+.ghint-secondary:hover { color: var(--text); }
+/* Arrow pointing down to the help button. */
+.glossary-hint::after {
+  content: ""; position: absolute; top: 100%; left: 18px;
+  width: 12px; height: 12px; background: var(--raised);
+  border-right: 1px solid var(--border-2); border-bottom: 1px solid var(--border-2);
+  transform: translateY(-50%) rotate(45deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .sb-action.is-hinted {
+    animation: none;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
+  }
+  .glossary-hint { animation: none; }
+}
+
 /* Main content pane */
 .app-main { flex: 1 1 auto; min-width: 0; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
 
@@ -145,7 +196,7 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 /* Shared glossary modal — themed via the same CSS variables as the rest of
    the app so it follows light/dark automatically. */
 .glossary-dialog {
-  width: min(560px, calc(100vw - 32px)); max-height: min(80vh, 720px);
+  width: min(600px, calc(100vw - 32px)); height: min(80vh, 600px);
   padding: 0; border: 1px solid var(--border-2); border-radius: 16px;
   background: var(--surface); color: var(--text);
   box-shadow: 0 24px 60px var(--shadow);
@@ -154,10 +205,10 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .glossary-dialog::backdrop { background: rgba(4, 8, 14, .55); backdrop-filter: blur(2px); }
 /* Lock the page behind the modal so only the modal scrolls. */
 html:has(.glossary-dialog[open]) { overflow: hidden; }
-.glossary-panel { display: flex; flex-direction: column; max-height: min(80vh, 720px); }
+.glossary-panel { display: flex; flex-direction: column; height: 100%; }
 .glossary-header {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 16px 20px; border-bottom: 1px solid var(--border);
+  padding: 16px 20px 8px;
 }
 .glossary-header h2 { font-size: 15px; font-weight: 700; letter-spacing: -.01em; }
 .glossary-close {
@@ -169,15 +220,42 @@ html:has(.glossary-dialog[open]) { overflow: hidden; }
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border-2));
   background: color-mix(in srgb, var(--accent) 8%, var(--bg));
 }
-.glossary-body { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 20px 20px; }
-.glossary-section { margin-top: 16px; }
-.glossary-category {
-  font-size: 10.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
-  color: var(--fan); margin-bottom: 8px;
+/* Category tabs — mirror the .discover-tabs segmented control so the modal
+   matches the rest of the app and follows the theme. */
+.glossary-tabs {
+  display: flex; gap: 4px; margin: 8px 20px 0;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 11px; padding: 4px;
 }
-.glossary-terms { display: flex; flex-direction: column; gap: 12px; }
-.glossary-entry dt { font-size: 12.5px; font-weight: 700; color: var(--text); }
-.glossary-entry dd { margin: 2px 0 0; font-size: 12.5px; line-height: 1.5; color: var(--muted); }
+.glossary-tabs button {
+  flex: 1 1 0; white-space: nowrap; border: 0; background: transparent; color: var(--muted);
+  font-weight: 600; font-size: 11.5px; padding: 7px 10px; border-radius: 8px; cursor: pointer;
+}
+.glossary-tabs button:hover { color: var(--text); }
+.glossary-tabs button.active {
+  background: var(--accent); color: #fff;
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.glossary-body { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 20px 16px; }
+/* Light table layout — term in a left column, definition in the right, with a
+   hairline between rows. Reads as a clean struct rather than a stack of bold
+   headings. */
+.glossary-terms { display: flex; flex-direction: column; }
+.glossary-entry {
+  display: grid; grid-template-columns: 148px 1fr; column-gap: 18px;
+  padding: 11px 0; border-top: 1px solid var(--border);
+}
+.glossary-entry:first-child { border-top: 0; }
+.glossary-entry dt { font-size: 12px; font-weight: 600; color: var(--text); line-height: 1.45; }
+.glossary-entry dd { grid-column: 2; margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--muted); }
+/* "How it's computed" block — monospace so weight tables and formulas line up. */
+.glossary-detail {
+  grid-column: 2;
+  display: flex; flex-direction: column; margin-top: 8px; padding: 10px 12px;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px; line-height: 1.55; color: var(--text); white-space: pre;
+  overflow-x: auto;
+}
 
 .page { flex: 1; width: 100%; max-width: var(--page-max-width); margin: 0 auto; padding: 22px var(--page-gutter); }
 .import-page { overflow: auto; width: 100%; }


### PR DESCRIPTION
… hint

Glossary modal:
- Split definitions across 5 tabs (Structure, Activity, Risk, Discovery, Cost) in a constant-height, scrollable panel so it no longer jumps with content length
- Add exact "how it's computed" breakdowns for the Risk score and Discover lift, plus the previously unexplained jargon (xN collapsed runs, lift, support, findings, Memory, Large outputs, timeline spacing, etc.)
- Lighter two-column table layout with hairline separators instead of bold headers; centered even-width tabs; drop the header divider

Discoverability:
- Pulse the sidebar help button and show a dismissable coachmark on first run, persisted via localStorage (ccfr-glossary-hint-seen)
- Clears when the user opens the glossary or clicks "Got it"; honors prefers-reduced-motion