### PR TITLE
Add usage characteristics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,8 @@ jobs:
         run: npm test
 
       - name: Audit dependencies
-        run: npm audit --audit-level=moderate
+        # Audit production deps strictly — those are what ship to users. Build/test
+        # tooling (vite, esbuild, jsdom) never reaches the bundle. The one residual
+        # dev-only advisory (GHSA-gv7w-rqvm-qjhr in esbuild) has no fix compatible
+        # with vite 6 and is a Deno-install-path RCE not reachable via npm.
+        run: npm audit --omit=dev --audit-level=moderate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,6 @@ Frontend:
 ```powershell
 cd frontend
 npm install
-$env:VITE_API_BASE = "http://localhost:8000/api"
 npm run dev
 npm run test
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ If that returns `404`, an older backend process is still serving port `8000`. Th
 ```powershell
 cd frontend
 npm install
-$env:VITE_API_BASE = "http://localhost:8000/api"
 npm run dev
 ```
 
@@ -102,4 +101,4 @@ Open:
 http://localhost:5173
 ```
 
-`VITE_API_BASE` defaults to `http://localhost:8000/api` if unset. Set it before `npm run dev` when the backend runs on a different host or port.
+The dev server proxies `/api` to the backend (`http://localhost:8000`), so the frontend talks to it same-origin — no CORS setup, and the dev port doesn't matter. `VITE_API_BASE` is unset by default (relative `/api`); set it only when the backend isn't reachable via the dev proxy (a remote host, or a built/Docker frontend). If you previously exported `VITE_API_BASE`, unset it so the proxy is used.

--- a/backend/src/ccfr/analysis/usage_characteristics.py
+++ b/backend/src/ccfr/analysis/usage_characteristics.py
@@ -200,7 +200,7 @@ def usage_characteristics_analytics(
             "project_id": project_id,
             "window": {"date_from": date_from, "date_to": date_to},
             "total_usd": round(total_usd, 6),
-            "total_tokens": int(total_tokens),
+            "total_tokens": int(round(total_tokens)),
             "cost_available": cost_available,
             "costs_partial": any(not e.priced for e in events),
             "sessions_analyzed": len({e.session_db_id for e in events}),

--- a/backend/src/ccfr/analysis/usage_characteristics.py
+++ b/backend/src/ccfr/analysis/usage_characteristics.py
@@ -23,7 +23,6 @@ from ccfr.config import pricing_path
 
 # Thresholds pinned to /usage (tunable). Subagent-heavy ratio is our own choice
 # (/usage's exact definition is unknown) and documented as approximate.
-SUBAGENT_HEAVY_SESSION_RATIO = 0.5
 CONTEXT_BAND_TOKENS = 150_000
 LONG_SESSION_HOURS = 8
 AGENT_TYPE_MIN_SHARE = 0.05
@@ -40,9 +39,15 @@ TOKEN_BASIS_NOTE = (
 )
 
 GUIDANCE = {
+    "subagent_usage": (
+        "Work done inside subagent turns — each subagent runs its own requests. "
+        "This is the direct subagent share of usage; the rest is the main thread."
+    ),
     "subagent_sessions": (
-        "Each subagent runs its own requests. Be deliberate about spawning "
-        "them — and consider a cheaper model for simple subagents."
+        "The whole cost of every session that spawned at least one subagent "
+        "(main thread + subagents) — shows how pervasive subagents are in your "
+        "workflow, not how much they cost directly. Be deliberate about spawning "
+        "them, and consider a cheaper model for simple ones."
     ),
     "context_gt_150k": (
         "Longer sessions are more expensive even when cached. /compact "
@@ -104,6 +109,8 @@ def compute_characteristics(
     sess_cost: dict[int, float] = defaultdict(float)
     sess_weight: dict[int, float] = defaultdict(float)
     sess_sub_weight: dict[int, float] = defaultdict(float)
+    sub_weight_total = 0.0
+    sub_cost_total = 0.0
     ctx_weight = 0.0
     ctx_cost = 0.0
     type_weight: dict[str, float] = defaultdict(float)
@@ -114,6 +121,8 @@ def compute_characteristics(
         sess_cost[e.session_db_id] += e.cost
         sess_weight[e.session_db_id] += w
         if e.agent_id is not None:
+            sub_weight_total += w
+            sub_cost_total += e.cost
             sess_sub_weight[e.session_db_id] += w
             atype = agent_types.get((e.session_db_id, e.agent_id), "unspecified")
             type_weight[atype] += w
@@ -122,12 +131,13 @@ def compute_characteristics(
             ctx_weight += w
             ctx_cost += e.cost
 
-    heavy = [
-        sid for sid, wt in sess_weight.items()
-        if wt > 0 and sess_sub_weight.get(sid, 0.0) / wt >= SUBAGENT_HEAVY_SESSION_RATIO
-    ]
-    heavy_weight = sum(sess_weight[sid] for sid in heavy)
-    heavy_cost = sum(sess_cost[sid] for sid in heavy)
+    # Sessions that involve subagents at all: count the WHOLE session cost
+    # (main + subagent) whenever the session spawned >=1 subagent. Distinct from
+    # the direct attribution (sub_*_total) — this measures how pervasive
+    # subagents are in the workflow, not how much they cost directly.
+    uses_sub = [sid for sid, sw in sess_sub_weight.items() if sw > 0]
+    uses_weight = sum(sess_weight[sid] for sid in uses_sub)
+    uses_cost = sum(sess_cost[sid] for sid in uses_sub)
 
     long_sids = [
         sid for sid in sess_weight
@@ -137,8 +147,10 @@ def compute_characteristics(
     long_cost = sum(sess_cost[sid] for sid in long_sids)
 
     chars: list[dict[str, Any]] = [
-        _char("subagent_sessions", "subagent-heavy sessions", "session",
-              heavy_weight, heavy_cost, total),
+        _char("subagent_usage", "subagent turns", "subagent",
+              sub_weight_total, sub_cost_total, total),
+        _char("subagent_sessions", "sessions that use subagents", "session",
+              uses_weight, uses_cost, total),
         _char("context_gt_150k", f">{CONTEXT_BAND_TOKENS // 1000}k context", "call",
               ctx_weight, ctx_cost, total),
         _char("duration_gte_8h", f"sessions active for {LONG_SESSION_HOURS}+ hours",

--- a/backend/src/ccfr/analysis/usage_characteristics.py
+++ b/backend/src/ccfr/analysis/usage_characteristics.py
@@ -1,0 +1,149 @@
+"""Usage Characteristics: overlapping (non-partition) properties of usage.
+
+Mirrors /usage's "what's contributing to your limits usage?" panel: each entry
+is an independent characteristic ("N% of usage came from X"), not a breakdown,
+so shares may overlap and need not sum to 1. Cost-weighted (token-weighted when
+no pricing); thresholds are pinned to /usage for visual comparability.
+
+Built on usage_map.load_events so the denominator equals the usage-map total.
+Computation is on-demand from the rebuildable SQLite cache, like discovery.py.
+Design doc: docs/superpowers/specs/2026-06-16-usage-characteristics-design.md
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from ccfr.analysis.pricing import load_price_table
+from ccfr.analysis.usage_map import EventRec, load_events
+from ccfr.config import pricing_path
+
+# Thresholds pinned to /usage (tunable). Subagent-heavy ratio is our own choice
+# (/usage's exact definition is unknown) and documented as approximate.
+SUBAGENT_HEAVY_SESSION_RATIO = 0.5
+CONTEXT_BAND_TOKENS = 150_000
+LONG_SESSION_HOURS = 8
+AGENT_TYPE_MIN_SHARE = 0.05
+
+BASIS_NOTE = (
+    "Shares are weighted by cost (USD). Claude Code's /usage weights by "
+    "rate-limit consumption, so expect directional, not exact, agreement."
+)
+
+GUIDANCE = {
+    "subagent_sessions": (
+        "Each subagent runs its own requests. Be deliberate about spawning "
+        "them — and consider a cheaper model for simple subagents."
+    ),
+    "context_gt_150k": (
+        "Longer sessions are more expensive even when cached. /compact "
+        "mid-task, /clear when switching tasks."
+    ),
+    "duration_gte_8h": (
+        "Often background or loop sessions. Continuous usage adds up — make "
+        "sure it is intentional."
+    ),
+    "agent_type": (
+        "If this runs frequently, consider a cheaper model or tighter prompts "
+        "for this subagent type."
+    ),
+}
+
+
+def _span_hours(first_ts: str | None, last_ts: str | None) -> float:
+    """Wall-clock hours between two ISO timestamps; 0.0 for missing/unparseable."""
+    if not first_ts or not last_ts:
+        return 0.0
+    try:
+        a = datetime.fromisoformat(first_ts.replace("Z", "+00:00"))
+        b = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 0.0
+    return max(0.0, (b - a).total_seconds() / 3600)
+
+
+def _char(key: str, headline: str, kind: str,
+          weight_num: float, cost_sum: float, total: float) -> dict[str, Any]:
+    guidance = GUIDANCE.get("agent_type" if key.startswith("agent_type:") else key, "")
+    return {
+        "key": key,
+        "headline": headline,
+        "kind": kind,
+        "share": round(weight_num / total, 6) if total > 0 else 0.0,
+        "cost_usd": round(cost_sum, 6),
+        "guidance": guidance,
+    }
+
+
+def compute_characteristics(
+    events: list[EventRec],
+    *,
+    session_spans: dict[int, tuple[str | None, str | None]],
+    agent_types: dict[tuple[int, str], str],
+    use_cost: bool,
+) -> list[dict[str, Any]]:
+    """Overlapping characteristics over already-loaded events. Pure: no DB.
+
+    `weight` is the share basis (cost when use_cost else raw tokens); `cost_usd`
+    is always the USD sum. Returned list is sorted by share descending.
+    """
+    def weight(e: EventRec) -> float:
+        return e.cost if use_cost else float(e.tokens)
+
+    total = sum(weight(e) for e in events)
+
+    sess_cost: dict[int, float] = defaultdict(float)
+    sess_weight: dict[int, float] = defaultdict(float)
+    sess_sub_weight: dict[int, float] = defaultdict(float)
+    ctx_weight = 0.0
+    ctx_cost = 0.0
+    type_weight: dict[str, float] = defaultdict(float)
+    type_cost: dict[str, float] = defaultdict(float)
+
+    for e in events:
+        w = weight(e)
+        sess_cost[e.session_db_id] += e.cost
+        sess_weight[e.session_db_id] += w
+        if e.agent_id is not None:
+            sess_sub_weight[e.session_db_id] += w
+            atype = agent_types.get((e.session_db_id, e.agent_id), "unspecified")
+            type_weight[atype] += w
+            type_cost[atype] += e.cost
+        if e.input_context_tokens > CONTEXT_BAND_TOKENS:
+            ctx_weight += w
+            ctx_cost += e.cost
+
+    heavy = [
+        sid for sid, wt in sess_weight.items()
+        if wt > 0 and sess_sub_weight.get(sid, 0.0) / wt >= SUBAGENT_HEAVY_SESSION_RATIO
+    ]
+    heavy_weight = sum(sess_weight[sid] for sid in heavy)
+    heavy_cost = sum(sess_cost[sid] for sid in heavy)
+
+    long_sids = [
+        sid for sid in sess_weight
+        if _span_hours(*session_spans.get(sid, (None, None))) >= LONG_SESSION_HOURS
+    ]
+    long_weight = sum(sess_weight[sid] for sid in long_sids)
+    long_cost = sum(sess_cost[sid] for sid in long_sids)
+
+    chars: list[dict[str, Any]] = [
+        _char("subagent_sessions", "subagent-heavy sessions", "session",
+              heavy_weight, heavy_cost, total),
+        _char("context_gt_150k", f">{CONTEXT_BAND_TOKENS // 1000}k context", "call",
+              ctx_weight, ctx_cost, total),
+        _char("duration_gte_8h", f"sessions active for {LONG_SESSION_HOURS}+ hours",
+              "session", long_weight, long_cost, total),
+    ]
+    for atype, wt in type_weight.items():
+        share = wt / total if total > 0 else 0.0
+        if share >= AGENT_TYPE_MIN_SHARE:
+            chars.append(_char(
+                f"agent_type:{atype}", f'subagents under "{atype}"', "subagent",
+                wt, type_cost[atype], total))
+
+    chars.sort(key=lambda c: c["share"], reverse=True)
+    return chars

--- a/backend/src/ccfr/analysis/usage_characteristics.py
+++ b/backend/src/ccfr/analysis/usage_characteristics.py
@@ -33,6 +33,12 @@ BASIS_NOTE = (
     "rate-limit consumption, so expect directional, not exact, agreement."
 )
 
+TOKEN_BASIS_NOTE = (
+    "Shares are weighted by total tokens (no pricing table loaded). Claude "
+    "Code's /usage weights by rate-limit consumption, so expect directional, "
+    "not exact, agreement."
+)
+
 GUIDANCE = {
     "subagent_sessions": (
         "Each subagent runs its own requests. Be deliberate about spawning "
@@ -205,7 +211,7 @@ def usage_characteristics_analytics(
             "costs_partial": any(not e.priced for e in events),
             "sessions_analyzed": len({e.session_db_id for e in events}),
             "share_basis": "cost" if use_cost else "tokens",
-            "basis_note": BASIS_NOTE,
+            "basis_note": BASIS_NOTE if use_cost else TOKEN_BASIS_NOTE,
         },
         "characteristics": characteristics,
     }

--- a/backend/src/ccfr/analysis/usage_characteristics.py
+++ b/backend/src/ccfr/analysis/usage_characteristics.py
@@ -147,3 +147,65 @@ def compute_characteristics(
 
     chars.sort(key=lambda c: c["share"], reverse=True)
     return chars
+
+
+def _session_spans(
+    conn: sqlite3.Connection, project_id: int | None,
+) -> dict[int, tuple[str | None, str | None]]:
+    sql = "SELECT id, first_ts, last_ts FROM sessions"
+    params: list[Any] = []
+    if project_id is not None:
+        sql += " WHERE project_id = ?"
+        params.append(project_id)
+    return {row["id"]: (row["first_ts"], row["last_ts"])
+            for row in conn.execute(sql, params).fetchall()}
+
+
+def _agent_types(
+    conn: sqlite3.Connection, project_id: int | None,
+) -> dict[tuple[int, str], str]:
+    sql = ("SELECT sa.parent_session_id AS sid, sa.agent_id, sa.agent_type "
+           "FROM subagents sa JOIN sessions s ON s.id = sa.parent_session_id")
+    params: list[Any] = []
+    if project_id is not None:
+        sql += " WHERE s.project_id = ?"
+        params.append(project_id)
+    return {(row["sid"], row["agent_id"]): (row["agent_type"] or "unspecified")
+            for row in conn.execute(sql, params).fetchall()}
+
+
+def usage_characteristics_analytics(
+    conn: sqlite3.Connection,
+    *,
+    project_id: int | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> dict[str, Any]:
+    """Overlapping-characteristics payload for the filtered corpus."""
+    table = load_price_table(pricing_path())
+    cost_available = bool(table)
+    events = load_events(conn, table, project_id=project_id,
+                         date_from=date_from, date_to=date_to)
+    total_usd = sum(e.cost for e in events)
+    total_tokens = sum(e.tokens for e in events)
+    use_cost = cost_available and total_usd > 0
+    characteristics = compute_characteristics(
+        events,
+        session_spans=_session_spans(conn, project_id),
+        agent_types=_agent_types(conn, project_id),
+        use_cost=use_cost,
+    )
+    return {
+        "meta": {
+            "project_id": project_id,
+            "window": {"date_from": date_from, "date_to": date_to},
+            "total_usd": round(total_usd, 6),
+            "total_tokens": int(total_tokens),
+            "cost_available": cost_available,
+            "costs_partial": any(not e.priced for e in events),
+            "sessions_analyzed": len({e.session_db_id for e in events}),
+            "share_basis": "cost" if use_cost else "tokens",
+            "basis_note": BASIS_NOTE,
+        },
+        "characteristics": characteristics,
+    }

--- a/backend/src/ccfr/analysis/usage_map.py
+++ b/backend/src/ccfr/analysis/usage_map.py
@@ -134,7 +134,8 @@ def aggregate_phases(events: list[EventRec]) -> dict[str, dict[str, Any]]:
     """
     acc: dict[str, dict[str, Any]] = {
         key: {"cost_usd": 0.0, "tokens": 0.0, "tool_count": 0, "sessions": set(),
-              "tools": {}}
+              "tools": {}, "main_cost": 0.0, "subagent_cost": 0.0,
+              "main_tokens": 0.0, "subagent_tokens": 0.0}
         for key in PHASE_KEYS
     }
     for event in events:
@@ -143,6 +144,12 @@ def aggregate_phases(events: list[EventRec]) -> dict[str, dict[str, Any]]:
             bucket["cost_usd"] += event.cost * weight
             bucket["tokens"] += event.tokens * weight
             bucket["sessions"].add(event.session_db_id)
+            if event.agent_id is None:
+                bucket["main_cost"] += event.cost * weight
+                bucket["main_tokens"] += event.tokens * weight
+            else:
+                bucket["subagent_cost"] += event.cost * weight
+                bucket["subagent_tokens"] += event.tokens * weight
         share = 1.0 / len(event.tool_calls) if event.tool_calls else 0.0
         for call in event.tool_calls:
             bucket = acc[classify_tool_call(call.tool_name, call.command)]
@@ -700,6 +707,10 @@ def usage_map_analytics(
             "label": spec["label"],
             "cost_usd": round(bucket["cost_usd"], 6),
             "tokens": int(round(bucket["tokens"])),
+            "main_cost_usd": round(bucket["main_cost"], 6),
+            "subagent_cost_usd": round(bucket["subagent_cost"], 6),
+            "main_tokens": int(round(bucket["main_tokens"])),
+            "subagent_tokens": int(round(bucket["subagent_tokens"])),
             "share": round(numerator / denominator, 6) if denominator > 0 else 0.0,
             "tool_count": bucket["tool_count"],
             "session_count": len(bucket["sessions"]),

--- a/backend/src/ccfr/analysis/usage_map.py
+++ b/backend/src/ccfr/analysis/usage_map.py
@@ -106,6 +106,8 @@ class EventRec:
     tokens: int            # total billed tokens on the message
     priced: bool
     tool_calls: tuple[ToolCallRec, ...] = ()
+    agent_id: str | None = None
+    input_context_tokens: int = 0  # base + 5m + 1h + read (no output)
 
 
 def event_phase_weights(event: EventRec) -> dict[str, float]:
@@ -193,6 +195,7 @@ def load_events(
     rows = conn.execute(
         f"""
         SELECT e.id AS event_id, e.session_id AS session_db_id, e.timestamp AS ts,
+               e.agent_id AS agent_id,
                m.model,
                COALESCE(m.base_input_tokens, 0) AS base,
                COALESCE(m.cache_5m_tokens, 0) AS c5,
@@ -287,6 +290,8 @@ def load_events(
             tokens=tokens,
             priced=price is not None or tokens == 0,
             tool_calls=tuple(calls_by_event.get(row["event_id"], [])),
+            agent_id=row["agent_id"],
+            input_context_tokens=row["base"] + row["c5"] + row["c1"] + row["cr"],
         ))
     return events
 

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -15,6 +15,7 @@ from ccfr.analysis.context_economics import (
 )
 from ccfr.analysis.discovery import discovery_analytics
 from ccfr.analysis.usage_map import usage_map_analytics, usage_map_evidence
+from ccfr.analysis.usage_characteristics import usage_characteristics_analytics
 from ccfr.api.schemas import (
     CacheStatsResponse,
     ContextEconomicsResponse,
@@ -35,6 +36,7 @@ from ccfr.api.schemas import (
     TimelineItem,
     TurnCostBreakdown,
     TraceResponse,
+    UsageCharacteristicsResponse,
     UsageMapEvidenceResponse,
     UsageMapResponse,
 )
@@ -309,3 +311,16 @@ def get_usage_map_evidence(
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=f"Unknown node: {node}") from exc
     return UsageMapEvidenceResponse(**payload)
+
+
+@router.get("/analytics/usage-characteristics", response_model=UsageCharacteristicsResponse)
+def get_usage_characteristics(
+    project_id: int | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    conn: Connection = Depends(get_db),
+) -> UsageCharacteristicsResponse:
+    return UsageCharacteristicsResponse(
+        **usage_characteristics_analytics(conn, project_id=project_id,
+                                          date_from=date_from, date_to=date_to)
+    )

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -588,6 +588,10 @@ class UsagePhase(BaseModel):
     label: str
     cost_usd: float = 0
     tokens: int = 0
+    main_cost_usd: float = 0
+    subagent_cost_usd: float = 0
+    main_tokens: int = 0
+    subagent_tokens: int = 0
     share: float = 0
     tool_count: int = 0
     session_count: int = 0

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -637,3 +637,29 @@ class UsageMapEvidenceResponse(BaseModel):
     rule: str = ""
     cost_usd: float = 0
     sessions: list[UsageEvidenceSession] = Field(default_factory=list)
+
+
+class UsageCharacteristic(BaseModel):
+    key: str
+    headline: str = ""
+    share: float = 0
+    cost_usd: float = 0
+    kind: str = ""
+    guidance: str = ""
+
+
+class UsageCharacteristicsMeta(BaseModel):
+    project_id: int | None = None
+    window: UsageMapWindow = Field(default_factory=UsageMapWindow)
+    total_usd: float = 0
+    total_tokens: int = 0
+    cost_available: bool = False
+    costs_partial: bool = False
+    sessions_analyzed: int = 0
+    share_basis: str = "cost"
+    basis_note: str = ""
+
+
+class UsageCharacteristicsResponse(BaseModel):
+    meta: UsageCharacteristicsMeta = Field(default_factory=UsageCharacteristicsMeta)
+    characteristics: list[UsageCharacteristic] = Field(default_factory=list)

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import sqlite3
+
+from ccfr.analysis import usage_map as um
 from ccfr.analysis.usage_characteristics import (
     SUBAGENT_HEAVY_SESSION_RATIO,
     compute_characteristics,
+    usage_characteristics_analytics,
     _span_hours,
 )
 from ccfr.analysis.usage_map import EventRec, ToolCallRec
+from ccfr.storage import init_db
 
 
 def _ev(event_id: int, *, session: int, cost: float, agent_id: str | None = None,
@@ -113,13 +118,6 @@ def test_span_hours_handles_missing_timestamps() -> None:
     assert _span_hours(None, "2026-06-01T01:00:00Z") == 0.0
     assert _span_hours("2026-06-01T00:00:00Z", None) == 0.0
     assert _span_hours("2026-06-01T00:00:00Z", "2026-06-01T08:00:00Z") == 8.0
-
-
-import sqlite3
-
-from ccfr.analysis import usage_map as um
-from ccfr.analysis.usage_characteristics import usage_characteristics_analytics
-from ccfr.storage import init_db
 
 
 def _conn() -> sqlite3.Connection:

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -178,6 +178,7 @@ def test_analytics_token_basis_when_no_pricing(monkeypatch) -> None:
     payload = usage_characteristics_analytics(conn)
     assert payload["meta"]["share_basis"] == "tokens"
     assert payload["meta"]["cost_available"] is False
+    assert "token" in payload["meta"]["basis_note"].lower()
 
 
 def test_analytics_reads_agent_type_from_subagents(monkeypatch) -> None:
@@ -206,5 +207,6 @@ def test_endpoint_returns_characteristics(monkeypatch) -> None:
     body = resp.json()
     assert "characteristics" in body
     assert body["meta"]["basis_note"]
+    assert "cost" in body["meta"]["basis_note"].lower()
     keys = [c["key"] for c in body["characteristics"]]
     assert "subagent_sessions" in keys

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -6,7 +6,6 @@ from fastapi.testclient import TestClient
 
 from ccfr.analysis import usage_map as um
 from ccfr.analysis.usage_characteristics import (
-    SUBAGENT_HEAVY_SESSION_RATIO,
     compute_characteristics,
     usage_characteristics_analytics,
     _span_hours,
@@ -31,27 +30,33 @@ def _by_key(chars: list[dict]) -> dict[str, dict]:
     return {c["key"]: c for c in chars}
 
 
-def test_subagent_heavy_session_counts_full_cost() -> None:
+def test_sessions_that_use_subagents_count_full_session_cost() -> None:
     events = [
-        _ev(1, session=1, cost=4.0),                       # main
-        _ev(2, session=1, cost=6.0, agent_id="a1"),        # subagent (60% of session 1)
+        _ev(1, session=1, cost=4.0),                       # main turn of session 1
+        _ev(2, session=1, cost=6.0, agent_id="a1"),        # subagent turn of session 1
         _ev(3, session=2, cost=10.0),                      # main-only session
     ]
     chars = _by_key(compute_characteristics(
         events, session_spans={}, agent_types={}, use_cost=True))
-    heavy = chars["subagent_sessions"]
-    assert heavy["cost_usd"] == 10.0           # full cost of session 1
-    assert heavy["share"] == round(10.0 / 20.0, 6)
+    # Session 1 used a subagent -> its WHOLE cost (10) counts; session 2 excluded.
+    assert chars["subagent_sessions"]["cost_usd"] == 10.0
+    assert chars["subagent_sessions"]["share"] == round(10.0 / 20.0, 6)
+    # Direct attribution counts only the subagent turn (6), not the whole session.
+    assert chars["subagent_usage"]["cost_usd"] == 6.0
+    assert chars["subagent_usage"]["share"] == round(6.0 / 20.0, 6)
 
 
-def test_session_below_ratio_is_not_heavy() -> None:
+def test_low_subagent_session_counts_full_for_sessions_but_direct_for_usage() -> None:
+    # A session only 40% subagent still "uses subagents": its full cost lands in
+    # the session metric, but only the subagent turn lands in the direct metric.
     events = [
         _ev(1, session=1, cost=6.0),                       # main
         _ev(2, session=1, cost=4.0, agent_id="a1"),        # 40% subagent
     ]
     chars = _by_key(compute_characteristics(
         events, session_spans={}, agent_types={}, use_cost=True))
-    assert chars["subagent_sessions"]["cost_usd"] == 0.0
+    assert chars["subagent_sessions"]["cost_usd"] == 10.0   # whole session
+    assert chars["subagent_usage"]["cost_usd"] == 4.0       # subagent turn only
 
 
 def test_context_band_counts_only_large_calls() -> None:

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sqlite3
 
+from fastapi.testclient import TestClient
+
 from ccfr.analysis import usage_map as um
 from ccfr.analysis.usage_characteristics import (
     SUBAGENT_HEAVY_SESSION_RATIO,
@@ -10,6 +12,8 @@ from ccfr.analysis.usage_characteristics import (
     _span_hours,
 )
 from ccfr.analysis.usage_map import EventRec, ToolCallRec
+from ccfr.api.deps import get_db
+from ccfr.main import create_app
 from ccfr.storage import init_db
 
 
@@ -186,3 +190,21 @@ def test_analytics_reads_agent_type_from_subagents(monkeypatch) -> None:
     monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
     keys = [c["key"] for c in usage_characteristics_analytics(conn)["characteristics"]]
     assert "agent_type:general-purpose" in keys
+
+
+def test_endpoint_returns_characteristics(monkeypatch) -> None:
+    conn = _conn()
+    _seed(conn)
+    _add(conn, 1, 1)
+    _add(conn, 2, 1, agent_id="a1")
+    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: conn
+    client = TestClient(app)
+    resp = client.get("/api/analytics/usage-characteristics")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "characteristics" in body
+    assert body["meta"]["basis_note"]
+    keys = [c["key"] for c in body["characteristics"]]
+    assert "subagent_sessions" in keys

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from ccfr.analysis.usage_characteristics import (
+    SUBAGENT_HEAVY_SESSION_RATIO,
+    compute_characteristics,
+    _span_hours,
+)
+from ccfr.analysis.usage_map import EventRec, ToolCallRec
+
+
+def _ev(event_id: int, *, session: int, cost: float, agent_id: str | None = None,
+        ctx: int = 0, tokens: int = 1000) -> EventRec:
+    return EventRec(
+        event_id=event_id, session_db_id=session, session_title="S",
+        project_name="alpha", ts="2026-06-01T10:00:00Z", model="m",
+        cost=cost, tokens=tokens, priced=True, tool_calls=(),
+        agent_id=agent_id, input_context_tokens=ctx,
+    )
+
+
+def _by_key(chars: list[dict]) -> dict[str, dict]:
+    return {c["key"]: c for c in chars}
+
+
+def test_subagent_heavy_session_counts_full_cost() -> None:
+    events = [
+        _ev(1, session=1, cost=4.0),                       # main
+        _ev(2, session=1, cost=6.0, agent_id="a1"),        # subagent (60% of session 1)
+        _ev(3, session=2, cost=10.0),                      # main-only session
+    ]
+    chars = _by_key(compute_characteristics(
+        events, session_spans={}, agent_types={}, use_cost=True))
+    heavy = chars["subagent_sessions"]
+    assert heavy["cost_usd"] == 10.0           # full cost of session 1
+    assert heavy["share"] == round(10.0 / 20.0, 6)
+
+
+def test_session_below_ratio_is_not_heavy() -> None:
+    events = [
+        _ev(1, session=1, cost=6.0),                       # main
+        _ev(2, session=1, cost=4.0, agent_id="a1"),        # 40% subagent
+    ]
+    chars = _by_key(compute_characteristics(
+        events, session_spans={}, agent_types={}, use_cost=True))
+    assert chars["subagent_sessions"]["cost_usd"] == 0.0
+
+
+def test_context_band_counts_only_large_calls() -> None:
+    events = [
+        _ev(1, session=1, cost=5.0, ctx=160_000),
+        _ev(2, session=1, cost=5.0, ctx=100_000),
+    ]
+    chars = _by_key(compute_characteristics(
+        events, session_spans={}, agent_types={}, use_cost=True))
+    assert chars["context_gt_150k"]["cost_usd"] == 5.0
+    assert chars["context_gt_150k"]["share"] == round(5.0 / 10.0, 6)
+
+
+def test_duration_band_uses_full_session_span() -> None:
+    events = [_ev(1, session=1, cost=8.0), _ev(2, session=2, cost=2.0)]
+    spans = {
+        1: ("2026-06-01T00:00:00Z", "2026-06-01T09:00:00Z"),  # 9h -> long
+        2: ("2026-06-01T00:00:00Z", "2026-06-01T01:00:00Z"),  # 1h
+    }
+    chars = _by_key(compute_characteristics(
+        events, session_spans=spans, agent_types={}, use_cost=True))
+    assert chars["duration_gte_8h"]["cost_usd"] == 8.0
+
+
+def test_agent_type_expansion_and_floor() -> None:
+    events = [
+        _ev(1, session=1, cost=20.0, agent_id="a1"),   # general-purpose
+        _ev(2, session=1, cost=2.0, agent_id="a2"),    # rare -> below 5% floor
+        _ev(3, session=1, cost=78.0),                  # main
+    ]
+    agent_types = {(1, "a1"): "general-purpose", (1, "a2"): "rare"}
+    chars = _by_key(compute_characteristics(
+        events, session_spans={}, agent_types=agent_types, use_cost=True))
+    assert 'agent_type:general-purpose' in chars
+    assert chars['agent_type:general-purpose']['headline'] == 'subagents under "general-purpose"'
+    assert 'agent_type:rare' not in chars   # 2/100 = 2% < 5% floor
+
+
+def test_shares_may_overlap_above_one() -> None:
+    events = [_ev(1, session=1, cost=10.0, agent_id="a1", ctx=200_000)]
+    chars = _by_key(compute_characteristics(
+        events, session_spans={}, agent_types={}, use_cost=True))
+    assert chars["subagent_sessions"]["share"] == 1.0
+    assert chars["context_gt_150k"]["share"] == 1.0
+
+
+def test_empty_events_yield_zero_shares() -> None:
+    chars = compute_characteristics([], session_spans={}, agent_types={}, use_cost=True)
+    assert all(c["share"] == 0.0 for c in chars)
+
+
+def test_span_hours_handles_missing_timestamps() -> None:
+    assert _span_hours(None, "2026-06-01T01:00:00Z") == 0.0
+    assert _span_hours("2026-06-01T00:00:00Z", None) == 0.0
+    assert _span_hours("2026-06-01T00:00:00Z", "2026-06-01T08:00:00Z") == 8.0

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -113,3 +113,78 @@ def test_span_hours_handles_missing_timestamps() -> None:
     assert _span_hours(None, "2026-06-01T01:00:00Z") == 0.0
     assert _span_hours("2026-06-01T00:00:00Z", None) == 0.0
     assert _span_hours("2026-06-01T00:00:00Z", "2026-06-01T08:00:00Z") == 8.0
+
+
+import sqlite3
+
+from ccfr.analysis import usage_map as um
+from ccfr.analysis.usage_characteristics import usage_characteristics_analytics
+from ccfr.storage import init_db
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    return conn
+
+
+def _seed(conn: sqlite3.Connection) -> None:
+    conn.execute("INSERT INTO imports (id, source_path, imported_at, file_count, status) "
+                 "VALUES (1, '/x', '2026-06-01T00:00:00Z', 1, 'complete')")
+    conn.execute("INSERT INTO projects (id, import_id, export_name, inferred_cwd) "
+                 "VALUES (1, 1, 'd--Alpha', '/workspace/alpha')")
+    conn.execute("INSERT INTO sessions (id, project_id, session_id, title, first_ts, last_ts) "
+                 "VALUES (1, 1, 's1', 'S1', '2026-06-01T00:00:00Z', '2026-06-01T10:00:00Z')")
+    conn.commit()
+
+
+def _add(conn, event_id, session_id, *, agent_id=None, base=200_000, out=40_000,
+         model="claude-opus-4-8") -> None:
+    conn.execute(
+        "INSERT INTO events (id, session_id, source_path, line_no, uuid, type, timestamp, agent_id, raw_json) "
+        "VALUES (?, ?, 'x.jsonl', 1, ?, 'assistant', '2026-06-01T10:00:00Z', ?, '{}')",
+        (event_id, session_id, f"u{event_id}", agent_id))
+    conn.execute(
+        "INSERT INTO messages (event_id, role, model, base_input_tokens, output_tokens) "
+        "VALUES (?, 'assistant', ?, ?, ?)", (event_id, model, base, out))
+    conn.commit()
+
+
+PRICE = {"claude-opus-4-8": um.ModelPrice(base_input=5, cache_write_5m=6.25,
+                                          cache_write_1h=10, cache_read=0.5, output=25)}
+
+
+def test_analytics_total_matches_usage_map(monkeypatch) -> None:
+    conn = _conn()
+    _seed(conn)
+    _add(conn, 1, 1)
+    _add(conn, 2, 1, agent_id="a1")
+    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
+    monkeypatch.setattr("ccfr.analysis.usage_map.load_price_table", lambda _p: PRICE)
+
+    chars_total = usage_characteristics_analytics(conn)["meta"]["total_usd"]
+    map_total = um.usage_map_analytics(conn)["meta"]["total_usd"]
+    assert chars_total == map_total
+
+
+def test_analytics_token_basis_when_no_pricing(monkeypatch) -> None:
+    conn = _conn()
+    _seed(conn)
+    _add(conn, 1, 1)
+    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: {})
+    payload = usage_characteristics_analytics(conn)
+    assert payload["meta"]["share_basis"] == "tokens"
+    assert payload["meta"]["cost_available"] is False
+
+
+def test_analytics_reads_agent_type_from_subagents(monkeypatch) -> None:
+    conn = _conn()
+    _seed(conn)
+    _add(conn, 1, 1, agent_id="a1")
+    conn.execute("INSERT INTO subagents (parent_session_id, agent_id, agent_type) "
+                 "VALUES (1, 'a1', 'general-purpose')")
+    conn.commit()
+    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
+    keys = [c["key"] for c in usage_characteristics_analytics(conn)["characteristics"]]
+    assert "agent_type:general-purpose" in keys

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -94,6 +94,21 @@ def test_empty_events_yield_zero_shares() -> None:
     assert all(c["share"] == 0.0 for c in chars)
 
 
+def test_token_basis_weights_by_tokens_not_cost() -> None:
+    # With use_cost=False, shares weight by tokens; cost_usd still reports USD.
+    events = [
+        _ev(1, session=1, cost=1.0, tokens=300, agent_id="a1"),  # subagent
+        _ev(2, session=2, cost=99.0, tokens=100),                # main-only
+    ]
+    chars = _by_key(compute_characteristics(
+        events, session_spans={}, agent_types={}, use_cost=False))
+    heavy = chars["subagent_sessions"]
+    # session 1 is 100% subagent -> heavy. Token share = 300 / 400.
+    assert heavy["share"] == round(300 / 400, 6)
+    # cost_usd is still the USD sum of the heavy session, not the token weight.
+    assert heavy["cost_usd"] == 1.0
+
+
 def test_span_hours_handles_missing_timestamps() -> None:
     assert _span_hours(None, "2026-06-01T01:00:00Z") == 0.0
     assert _span_hours("2026-06-01T00:00:00Z", None) == 0.0

--- a/backend/tests/test_usage_map.py
+++ b/backend/tests/test_usage_map.py
@@ -1014,6 +1014,18 @@ def test_load_events_captures_agent_id_and_input_context() -> None:
     assert third.input_context_tokens == 135  # 100 + 10 + 5 + 20, output excluded
 
 
+def test_aggregate_phases_splits_cost_by_origin() -> None:
+    main = _event(1, [ToolCallRec(tool_name="Read")], cost=3.0)          # agent_id None
+    sub = _event(2, [ToolCallRec(tool_name="Read")], cost=1.0)
+    sub = EventRec(**{**sub.__dict__, "agent_id": "a1"})
+    acc = aggregate_phases([main, sub])
+    bucket = acc["explore"]
+    assert bucket["main_cost"] == pytest.approx(3.0)
+    assert bucket["subagent_cost"] == pytest.approx(1.0)
+    # Conservation: origin split sums to the phase cost.
+    assert bucket["main_cost"] + bucket["subagent_cost"] == pytest.approx(bucket["cost_usd"])
+
+
 def test_tool_evidence_requires_a_valid_phase_qualifier(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(usage_map, "pricing_path", lambda: _pricing_csv(tmp_path))
     conn = _conn()

--- a/backend/tests/test_usage_map.py
+++ b/backend/tests/test_usage_map.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 import sqlite3
 
@@ -1017,13 +1018,14 @@ def test_load_events_captures_agent_id_and_input_context() -> None:
 def test_aggregate_phases_splits_cost_by_origin() -> None:
     main = _event(1, [ToolCallRec(tool_name="Read")], cost=3.0)          # agent_id None
     sub = _event(2, [ToolCallRec(tool_name="Read")], cost=1.0)
-    sub = EventRec(**{**sub.__dict__, "agent_id": "a1"})
+    sub = dataclasses.replace(sub, agent_id="a1")
     acc = aggregate_phases([main, sub])
     bucket = acc["explore"]
     assert bucket["main_cost"] == pytest.approx(3.0)
     assert bucket["subagent_cost"] == pytest.approx(1.0)
     # Conservation: origin split sums to the phase cost.
     assert bucket["main_cost"] + bucket["subagent_cost"] == pytest.approx(bucket["cost_usd"])
+    assert bucket["main_tokens"] + bucket["subagent_tokens"] == pytest.approx(bucket["tokens"])
 
 
 def test_tool_evidence_requires_a_valid_phase_qualifier(tmp_path, monkeypatch) -> None:

--- a/backend/tests/test_usage_map.py
+++ b/backend/tests/test_usage_map.py
@@ -986,6 +986,24 @@ def test_tool_evidence_unknown_tool_is_empty_not_error(tmp_path, monkeypatch) ->
     assert payload["cost_usd"] == 0.0
 
 
+def test_load_events_captures_agent_id_and_input_context() -> None:
+    conn = _conn()
+    _seed_base(conn)
+    # main-thread event
+    _add_assistant_event(conn, 1, 1, "2026-06-01T10:00:00Z", [])
+    # subagent event: set agent_id directly
+    _add_assistant_event(conn, 2, 1, "2026-06-01T10:01:00Z", [])
+    conn.execute("UPDATE events SET agent_id = 'agent-xyz' WHERE id = 2")
+    conn.commit()
+
+    events = load_events(conn, PRICE_TABLE)
+
+    assert events[0].agent_id is None
+    assert events[1].agent_id == "agent-xyz"
+    # input context = base + 5m + 1h + read (no output). Helper sets base=200_000.
+    assert events[0].input_context_tokens == 200_000
+
+
 def test_tool_evidence_requires_a_valid_phase_qualifier(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(usage_map, "pricing_path", lambda: _pricing_csv(tmp_path))
     conn = _conn()

--- a/backend/tests/test_usage_map.py
+++ b/backend/tests/test_usage_map.py
@@ -994,6 +994,14 @@ def test_load_events_captures_agent_id_and_input_context() -> None:
     # subagent event: set agent_id directly
     _add_assistant_event(conn, 2, 1, "2026-06-01T10:01:00Z", [])
     conn.execute("UPDATE events SET agent_id = 'agent-xyz' WHERE id = 2")
+    # Cover all four input-context columns (not just base) so a dropped/added
+    # cache column would be caught.
+    _add_assistant_event(conn, 3, 1, "2026-06-01T10:02:00Z", [])
+    conn.execute(
+        "UPDATE messages SET base_input_tokens = 100, cache_5m_tokens = 10, "
+        "cache_1h_tokens = 5, cache_read_tokens = 20, output_tokens = 999 "
+        "WHERE event_id = 3"
+    )
     conn.commit()
 
     events = load_events(conn, PRICE_TABLE)
@@ -1002,6 +1010,8 @@ def test_load_events_captures_agent_id_and_input_context() -> None:
     assert events[1].agent_id == "agent-xyz"
     # input context = base + 5m + 1h + read (no output). Helper sets base=200_000.
     assert events[0].input_context_tokens == 200_000
+    third = next(e for e in events if e.event_id == 3)
+    assert third.input_context_tokens == 135  # 100 + 10 + 5 + 20, output excluded
 
 
 def test_tool_evidence_requires_a_valid_phase_qualifier(tmp_path, monkeypatch) -> None:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "jsdom": "^25.0.1",
         "typescript": "^5.6.3",
-        "vite": "^6.4.2",
+        "vite": "^6.4.3",
         "vitest": "^4.1.8"
       }
     },
@@ -2036,16 +2036,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3107,10 +3108,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "jsdom": "^25.0.1",
     "typescript": "^5.6.3",
-    "vite": "^6.4.2",
+    "vite": "^6.4.3",
     "vitest": "^4.1.8"
   }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,7 @@ import type {
   TraceResponse,
   UsageMapResponse,
   UsageMapEvidenceResponse,
+  UsageCharacteristicsResponse,
 } from "./types";
 
 const API_BASE = (import.meta.env.VITE_API_BASE ?? "http://localhost:8000/api").replace(/\/$/, "");
@@ -186,4 +187,11 @@ export function getUsageMapEvidence(node: string, filters: UsageMapFilters = {})
   const params = usageMapParams(filters);
   params.set("node", node);
   return request<UsageMapEvidenceResponse>(`/analytics/usage-map/evidence?${params}`);
+}
+
+export function getUsageCharacteristics(filters: UsageMapFilters = {}) {
+  const query = usageMapParams(filters).toString();
+  return request<UsageCharacteristicsResponse>(
+    `/analytics/usage-characteristics${query ? `?${query}` : ""}`,
+  );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -24,7 +24,10 @@ import type {
   UsageCharacteristicsResponse,
 } from "./types";
 
-const API_BASE = (import.meta.env.VITE_API_BASE ?? "http://localhost:8000/api").replace(/\/$/, "");
+// Relative by default so dev goes through the vite proxy (/api -> backend),
+// keeping API calls same-origin. Override with VITE_API_BASE only when the
+// backend isn't reachable via the proxy (e.g. a built/Docker frontend).
+const API_BASE = (import.meta.env.VITE_API_BASE ?? "/api").replace(/\/$/, "");
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -572,6 +572,10 @@ export interface UsagePhase {
   label: string;
   cost_usd: number;
   tokens: number;
+  main_cost_usd: number;
+  subagent_cost_usd: number;
+  main_tokens: number;
+  subagent_tokens: number;
   share: number;
   tool_count: number;
   session_count: number;
@@ -612,4 +616,30 @@ export interface UsageMapEvidenceResponse {
   rule: string;
   cost_usd: number;
   sessions: UsageEvidenceSession[];
+}
+
+export interface UsageCharacteristic {
+  key: string;
+  headline: string;
+  share: number;
+  cost_usd: number;
+  kind: string;
+  guidance: string;
+}
+
+export interface UsageCharacteristicsMeta {
+  project_id: number | null;
+  window: { date_from: string | null; date_to: string | null };
+  total_usd: number;
+  total_tokens: number;
+  cost_available: boolean;
+  costs_partial: boolean;
+  sessions_analyzed: number;
+  share_basis: "cost" | "tokens";
+  basis_note: string;
+}
+
+export interface UsageCharacteristicsResponse {
+  meta: UsageCharacteristicsMeta;
+  characteristics: UsageCharacteristic[];
 }

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.test.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { UsageCharacteristicsResponse } from "../../api/types";
+import { getUsageCharacteristics } from "../../api/client";
 import UsageCharacteristicsDialog from "./UsageCharacteristicsDialog";
 
 const payload: UsageCharacteristicsResponse = {
@@ -52,5 +53,11 @@ describe("UsageCharacteristicsDialog", () => {
     await screen.findByText(/89%/);
     expect(screen.getByRole("button", { name: "Week" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Day" })).toBeInTheDocument();
+  });
+
+  it("shows an error message when the query fails", async () => {
+    vi.mocked(getUsageCharacteristics).mockRejectedValueOnce(new Error("boom"));
+    renderDialog();
+    expect(await screen.findByText(/Could not load usage characteristics\./)).toBeInTheDocument();
   });
 });

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.test.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { UsageCharacteristicsResponse } from "../../api/types";
@@ -48,11 +48,23 @@ describe("UsageCharacteristicsDialog", () => {
     expect(await screen.findByText(/weighted by cost/)).toBeInTheDocument();
   });
 
-  it("exposes Day and Week window presets", async () => {
+  it("exposes Day, Week, Month, and All window presets", async () => {
     renderDialog();
     await screen.findByText(/89%/);
-    expect(screen.getByRole("button", { name: "Week" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Day" })).toBeInTheDocument();
+    for (const name of ["Day", "Week", "Month", "All"]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument();
+    }
+  });
+
+  it("queries the full history (no date filter) for the All preset", async () => {
+    renderDialog();
+    await screen.findByText(/89%/);
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    await waitFor(() => {
+      expect(vi.mocked(getUsageCharacteristics)).toHaveBeenCalledWith(
+        expect.objectContaining({ dateFrom: null, dateTo: null }),
+      );
+    });
   });
 
   it("shows an error message when the query fails", async () => {

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.test.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { UsageCharacteristicsResponse } from "../../api/types";
+import UsageCharacteristicsDialog from "./UsageCharacteristicsDialog";
+
+const payload: UsageCharacteristicsResponse = {
+  meta: {
+    project_id: null, window: { date_from: "2026-06-10", date_to: "2026-06-16" },
+    total_usd: 100, total_tokens: 0, cost_available: true, costs_partial: false,
+    sessions_analyzed: 5, share_basis: "cost",
+    basis_note: "Shares are weighted by cost (USD).",
+  },
+  characteristics: [
+    { key: "subagent_sessions", headline: "subagent-heavy sessions", share: 0.89,
+      cost_usd: 89, kind: "session", guidance: "Be deliberate about spawning them." },
+    { key: "context_gt_150k", headline: ">150k context", share: 0.65,
+      cost_usd: 65, kind: "call", guidance: "Longer sessions cost more." },
+  ],
+};
+
+vi.mock("../../api/client", () => ({
+  getUsageCharacteristics: vi.fn(() => Promise.resolve(payload)),
+}));
+
+function renderDialog(open = true) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <UsageCharacteristicsDialog open={open} onClose={vi.fn()} projectId={null} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("UsageCharacteristicsDialog", () => {
+  it("renders one block per characteristic with rounded percentages", async () => {
+    renderDialog();
+    expect(await screen.findByText(/89%/)).toBeInTheDocument();
+    expect(screen.getByText(/subagent-heavy sessions/)).toBeInTheDocument();
+    expect(screen.getByText(/65%/)).toBeInTheDocument();
+    expect(screen.getByText(/Be deliberate about spawning them\./)).toBeInTheDocument();
+  });
+
+  it("shows the cost-vs-limits caveat", async () => {
+    renderDialog();
+    expect(await screen.findByText(/weighted by cost/)).toBeInTheDocument();
+  });
+
+  it("exposes Day and Week window presets", async () => {
+    renderDialog();
+    await screen.findByText(/89%/);
+    expect(screen.getByRole("button", { name: "Week" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Day" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { X } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { getUsageCharacteristics } from "../../api/client";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  projectId: number | null;
+}
+
+type Preset = "day" | "week";
+
+// Day = today only; Week = last 7 days inclusive — mirrors /usage's Day/Week toggle.
+function windowFor(preset: Preset): { dateFrom: string; dateTo: string } {
+  const today = new Date();
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  const from = new Date(today);
+  if (preset === "week") from.setDate(from.getDate() - 6);
+  return { dateFrom: iso(from), dateTo: iso(today) };
+}
+
+// A /usage-style "what's contributing to your limits usage?" panel. Independent,
+// overlapping characteristics — not a breakdown. Native <dialog> for focus
+// trapping, Esc, and a backdrop (same pattern as GlossaryDialog).
+export default function UsageCharacteristicsDialog({ open, onClose, projectId }: Props) {
+  const ref = React.useRef<HTMLDialogElement>(null);
+  const [preset, setPreset] = React.useState<Preset>("week");
+
+  React.useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    else if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  const win = windowFor(preset);
+  const query = useQuery({
+    queryKey: ["usage-characteristics", projectId, preset],
+    queryFn: () => getUsageCharacteristics({
+      projectId, dateFrom: win.dateFrom, dateTo: win.dateTo,
+    }),
+    enabled: open,
+    refetchOnWindowFocus: false,
+    staleTime: 60_000,
+  });
+
+  const handleClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    if (event.target === ref.current) onClose();
+  };
+
+  const data = query.data;
+
+  return (
+    <dialog
+      ref={ref}
+      className="glossary-dialog usage-characteristics-dialog"
+      aria-labelledby="usage-characteristics-title"
+      onClose={onClose}
+      onClick={handleClick}
+    >
+      <div className="glossary-panel">
+        <header className="glossary-header">
+          <h2 id="usage-characteristics-title">What's contributing to your usage?</h2>
+          <button type="button" className="glossary-close"
+                  aria-label="Close" onClick={onClose}>
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="segmented-control" role="group" aria-label="Window">
+          {(["day", "week"] as const).map((p) => (
+            <button key={p} type="button" aria-pressed={preset === p}
+                    className={preset === p ? "active" : ""}
+                    onClick={() => setPreset(p)}>
+              {p === "day" ? "Day" : "Week"}
+            </button>
+          ))}
+        </div>
+        <p className="uc-subtitle">
+          These are independent characteristics of your usage, not a breakdown.
+        </p>
+
+        <div className="uc-body">
+          {query.isPending && <p className="uc-note">Loading…</p>}
+          {data && data.characteristics.length === 0 && (
+            <p className="uc-note">No usage in this window.</p>
+          )}
+          {data && data.characteristics.map((c) => (
+            <div key={c.key} className="uc-row">
+              <p className="uc-headline">
+                <strong>{Math.round(c.share * 100)}%</strong> of your usage came from {c.headline}
+              </p>
+              {c.guidance && <p className="uc-guidance">{c.guidance}</p>}
+            </div>
+          ))}
+        </div>
+
+        {data && <p className="uc-caveat">{data.meta.basis_note}</p>}
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
@@ -69,7 +69,7 @@ export default function UsageCharacteristicsDialog({ open, onClose, projectId }:
     >
       <div className="glossary-panel">
         <header className="glossary-header">
-          <h2 id="usage-characteristics-title">What's contributing to your usage?</h2>
+          <h2 id="usage-characteristics-title">What's driving your usage</h2>
           <button type="button" className="glossary-close"
                   aria-label="Close" onClick={onClose}>
             <X size={16} />
@@ -86,7 +86,8 @@ export default function UsageCharacteristicsDialog({ open, onClose, projectId }:
           ))}
         </div>
         <p className="uc-subtitle">
-          These are independent characteristics of your usage, not a breakdown.
+          Independent characteristics of your usage — not a breakdown. Day and Week
+          mirror Claude Code's /usage; Month and All draw on your full history.
         </p>
 
         <div className="uc-body">

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
@@ -9,14 +9,22 @@ interface Props {
   projectId: number | null;
 }
 
-type Preset = "day" | "week";
+type Preset = "day" | "week" | "month" | "all";
 
-// Day = today only; Week = last 7 days inclusive — mirrors /usage's Day/Week toggle.
-function windowFor(preset: Preset): { dateFrom: string; dateTo: string } {
+const PRESET_LABELS: Record<Preset, string> = {
+  day: "Day", week: "Week", month: "Month", all: "All",
+};
+
+// Day = today; Week = last 7d; Month = last 30d (all inclusive). "All" is the
+// whole history (no date filter) — something /usage can't do, since it reports
+// rate-limit windows; here we read the full export.
+function windowFor(preset: Preset): { dateFrom: string | null; dateTo: string | null } {
+  if (preset === "all") return { dateFrom: null, dateTo: null };
   const today = new Date();
   const iso = (d: Date) => d.toISOString().slice(0, 10);
   const from = new Date(today);
   if (preset === "week") from.setDate(from.getDate() - 6);
+  else if (preset === "month") from.setDate(from.getDate() - 29);
   return { dateFrom: iso(from), dateTo: iso(today) };
 }
 
@@ -69,11 +77,11 @@ export default function UsageCharacteristicsDialog({ open, onClose, projectId }:
         </header>
 
         <div className="segmented-control" role="group" aria-label="Window">
-          {(["day", "week"] as const).map((p) => (
+          {(["day", "week", "month", "all"] as const).map((p) => (
             <button key={p} type="button" aria-pressed={preset === p}
                     className={preset === p ? "active" : ""}
                     onClick={() => setPreset(p)}>
-              {p === "day" ? "Day" : "Week"}
+              {PRESET_LABELS[p]}
             </button>
           ))}
         </div>

--- a/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
+++ b/frontend/src/discover/mindmap/UsageCharacteristicsDialog.tsx
@@ -83,6 +83,9 @@ export default function UsageCharacteristicsDialog({ open, onClose, projectId }:
 
         <div className="uc-body">
           {query.isPending && <p className="uc-note">Loading…</p>}
+          {query.isError && (
+            <p className="uc-note">Could not load usage characteristics.</p>
+          )}
           {data && data.characteristics.length === 0 && (
             <p className="uc-note">No usage in this window.</p>
           )}

--- a/frontend/src/discover/mindmap/UsageMindmap.test.tsx
+++ b/frontend/src/discover/mindmap/UsageMindmap.test.tsx
@@ -217,7 +217,7 @@ describe("UsageMindmap", () => {
   it("opens the usage-characteristics dialog from the toolbar", async () => {
     renderPage();
     await screen.findByText("My usage");
-    fireEvent.click(screen.getByRole("button", { name: /Compare to \/usage/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Usage drivers/ }));
     expect(await screen.findByText(/89%/)).toBeInTheDocument();
   });
 

--- a/frontend/src/discover/mindmap/UsageMindmap.test.tsx
+++ b/frontend/src/discover/mindmap/UsageMindmap.test.tsx
@@ -11,6 +11,7 @@ import UsageMindmap from "./UsageMindmap";
 const PHASES: UsagePhase[] = [
   {
     key: "explore", label: "Explore", cost_usd: 50, tokens: 0, share: 0.5,
+    main_cost_usd: 10, subagent_cost_usd: 40, main_tokens: 0, subagent_tokens: 0,
     tool_count: 10, session_count: 3,
     habits: [{ key: "re-reads", phase: "explore", label: "Repeated file re-reads",
                polarity: "anti", status: "confirmed", cost_usd: 5, count: 4,
@@ -21,10 +22,12 @@ const PHASES: UsagePhase[] = [
               session_count: 2 }],
   },
   { key: "implement", label: "Implement", cost_usd: 30, tokens: 0, share: 0.3,
+    main_cost_usd: 30, subagent_cost_usd: 0, main_tokens: 0, subagent_tokens: 0,
     tool_count: 6, session_count: 3, habits: [],
     tools: [{ key: "Edit", label: "Edit", cost_usd: 30, tokens: 0, count: 6,
               session_count: 3 }] },
   { key: "verify", label: "Verify", cost_usd: 20, tokens: 0, share: 0.2,
+    main_cost_usd: 20, subagent_cost_usd: 0, main_tokens: 0, subagent_tokens: 0,
     tool_count: 4, session_count: 2, habits: [],
     tools: [{ key: "Bash", label: "Bash", cost_usd: 20, tokens: 0, count: 4,
               session_count: 2 }] },
@@ -39,12 +42,16 @@ const mapPayload: UsageMapResponse = {
   },
   phases: PHASES.concat([
     { key: "plan", label: "Plan", cost_usd: 0, tokens: 0, share: 0,
+      main_cost_usd: 0, subagent_cost_usd: 0, main_tokens: 0, subagent_tokens: 0,
       tool_count: 0, session_count: 0, habits: [], tools: [] },
     { key: "operate", label: "Operate", cost_usd: 0, tokens: 0, share: 0,
+      main_cost_usd: 0, subagent_cost_usd: 0, main_tokens: 0, subagent_tokens: 0,
       tool_count: 0, session_count: 0, habits: [], tools: [] },
     { key: "delegate", label: "Delegate", cost_usd: 0, tokens: 0, share: 0,
+      main_cost_usd: 0, subagent_cost_usd: 0, main_tokens: 0, subagent_tokens: 0,
       tool_count: 0, session_count: 0, habits: [], tools: [] },
     { key: "converse", label: "Converse", cost_usd: 0, tokens: 0, share: 0,
+      main_cost_usd: 0, subagent_cost_usd: 0, main_tokens: 0, subagent_tokens: 0,
       tool_count: 0, session_count: 0, habits: [], tools: [] },
   ]),
 };
@@ -60,6 +67,14 @@ const evidencePayload: UsageMapEvidenceResponse = {
 vi.mock("../../api/client", () => ({
   getUsageMap: vi.fn(() => Promise.resolve(mapPayload)),
   getUsageMapEvidence: vi.fn(() => Promise.resolve(evidencePayload)),
+  getUsageCharacteristics: vi.fn(() => Promise.resolve({
+    meta: { project_id: null, window: { date_from: null, date_to: null },
+            total_usd: 100, total_tokens: 0, cost_available: true,
+            costs_partial: false, sessions_analyzed: 5, share_basis: "cost",
+            basis_note: "weighted by cost" },
+    characteristics: [{ key: "subagent_sessions", headline: "subagent-heavy sessions",
+                        share: 0.89, cost_usd: 89, kind: "session", guidance: "g" }],
+  })),
 }));
 
 function renderPage(onOpenSession = vi.fn()) {
@@ -196,6 +211,22 @@ describe("UsageMindmap", () => {
     await waitFor(() => {
       expect(vi.mocked(getUsageMapEvidence)).toHaveBeenCalledWith(
         "tool:Read@explore", expect.anything());
+    });
+  });
+
+  it("opens the usage-characteristics dialog from the toolbar", async () => {
+    renderPage();
+    await screen.findByText("My usage");
+    fireEvent.click(screen.getByRole("button", { name: /Compare to \/usage/ }));
+    expect(await screen.findByText(/89%/)).toBeInTheDocument();
+  });
+
+  it("rescales phase shares when the origin filter is set to Subagents", async () => {
+    renderPage();
+    await screen.findByText("My usage");
+    fireEvent.click(screen.getByRole("button", { name: "Subagents" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Explore: 100%/ })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/discover/mindmap/UsageMindmap.tsx
+++ b/frontend/src/discover/mindmap/UsageMindmap.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
-import { FileJson, ImageDown } from "lucide-react";
+import { FileJson, ImageDown, Gauge } from "lucide-react";
 import { getUsageMap, type UsageMapFilters } from "../../api/client";
 import type { Project } from "../../api/types";
 import EvidencePanel from "./EvidencePanel";
 import { exportJson, exportPng } from "./exportMap";
-import { phaseNode, type LeafMode, type MapNode } from "./forceModel";
+import { phaseNode, deriveOriginPhases, type LeafMode, type MapNode, type OriginFilter } from "./forceModel";
+import UsageCharacteristicsDialog from "./UsageCharacteristicsDialog";
 import MindmapCanvas from "./MindmapCanvas";
 
 interface Props {
@@ -22,6 +23,8 @@ export default function UsageMindmap({ projects }: Props) {
   const [selectedNode, setSelectedNode] = React.useState<MapNode | null>(null);
   const [compare, setCompare] = React.useState(false);
   const [leafMode, setLeafMode] = React.useState<LeafMode>("habits");
+  const [origin, setOrigin] = React.useState<OriginFilter>("all");
+  const [usageOpen, setUsageOpen] = React.useState(false);
   const boardRef = React.useRef<HTMLDivElement>(null);
 
   // A selection from the previous filter window may not exist in the new data;
@@ -97,9 +100,14 @@ export default function UsageMindmap({ projects }: Props) {
     );
   }
 
+  const basis = meta.share_basis;
+  const { phases: displayedPhases, total: displayedTotal } =
+    deriveOriginPhases(phases, origin, basis);
+  const splitEmpty = origin !== "all" && displayedTotal === 0;
+
   // Default selection: the costliest phase, so the evidence card is never empty.
   const fallbackNode = ((): MapNode | null => {
-    const top = [...phases].sort((a, b) => b.share - a.share)[0];
+    const top = [...displayedPhases].sort((a, b) => b.share - a.share)[0];
     if (!top || top.share === 0) return null;
     return phaseNode(top);
   })();
@@ -142,6 +150,16 @@ export default function UsageMindmap({ projects }: Props) {
                 </button>
               ))}
             </div>
+            <div className="segmented-control" role="group" aria-label="Origin">
+              {(["all", "main", "subagent"] as const).map((o) => (
+                <button key={o} type="button"
+                        aria-pressed={origin === o}
+                        className={origin === o ? "active" : ""}
+                        onClick={() => { setOrigin(o); setSelectedNode(null); }}>
+                  {o === "all" ? "All" : o === "main" ? "Main" : "Subagents"}
+                </button>
+              ))}
+            </div>
             <button type="button" className="ghost-action"
                     onClick={() => exportJson(query.data!)}>
               <FileJson size={14} />
@@ -156,6 +174,11 @@ export default function UsageMindmap({ projects }: Props) {
               <ImageDown size={14} />
               <span>Export PNG</span>
             </button>
+            <button type="button" className="ghost-action"
+                    onClick={() => setUsageOpen(true)}>
+              <Gauge size={14} />
+              <span>Compare to /usage</span>
+            </button>
           </div>
         </div>
 
@@ -167,25 +190,38 @@ export default function UsageMindmap({ projects }: Props) {
         )}
 
         <div className="mindmap-stage" ref={boardRef}>
-          <MindmapCanvas
-            phases={phases}
-            totalUsd={meta.total_usd}
-            costAvailable={meta.cost_available}
-            selectedNodeId={activeNode?.id ?? null}
-            onSelectNode={setSelectedNode}
-            previousShares={previousShares}
-            leafMode={leafMode}
-          />
-          {activeNode && (
-            <EvidencePanel
-              node={activeNode}
-              phases={phases}
-              filters={filters}
-              costAvailable={meta.cost_available}
-              previousShares={previousShares}
-            />
+          {splitEmpty ? (
+            <div className="empty-state">
+              No {origin === "main" ? "main-thread" : "subagent"} spend in this window.
+            </div>
+          ) : (
+            <>
+              <MindmapCanvas
+                phases={displayedPhases}
+                totalUsd={displayedTotal}
+                costAvailable={meta.cost_available}
+                selectedNodeId={activeNode?.id ?? null}
+                onSelectNode={setSelectedNode}
+                previousShares={origin === "all" ? previousShares : undefined}
+                leafMode={leafMode}
+              />
+              {activeNode && (
+                <EvidencePanel
+                  node={activeNode}
+                  phases={phases}
+                  filters={filters}
+                  costAvailable={meta.cost_available}
+                  previousShares={origin === "all" ? previousShares : undefined}
+                />
+              )}
+            </>
           )}
         </div>
+        <UsageCharacteristicsDialog
+          open={usageOpen}
+          onClose={() => setUsageOpen(false)}
+          projectId={projectId}
+        />
       </div>
     </main>
   );

--- a/frontend/src/discover/mindmap/UsageMindmap.tsx
+++ b/frontend/src/discover/mindmap/UsageMindmap.tsx
@@ -177,7 +177,7 @@ export default function UsageMindmap({ projects }: Props) {
             <button type="button" className="ghost-action"
                     onClick={() => setUsageOpen(true)}>
               <Gauge size={14} />
-              <span>Compare to /usage</span>
+              <span>Usage drivers</span>
             </button>
           </div>
         </div>

--- a/frontend/src/discover/mindmap/forceModel.test.ts
+++ b/frontend/src/discover/mindmap/forceModel.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { UsageHabit, UsagePhase, UsageTool } from "../../api/types";
 import {
-  buildForceModel, groupSmallLeaves, habitRadius, labelTier, phaseNode, phaseRadius,
+  buildForceModel, deriveOriginPhases, groupSmallLeaves, habitRadius, labelTier,
+  phaseNode, phaseRadius,
 } from "./forceModel";
 
 function habit(key: string, costUsd: number, polarity: "good" | "anti" = "anti"): UsageHabit {
@@ -10,9 +11,12 @@ function habit(key: string, costUsd: number, polarity: "good" | "anti" = "anti")
 }
 
 function phase(key: string, share: number, habits: UsageHabit[] = [],
-               tools: UsageTool[] = []): UsagePhase {
-  return { key, label: key[0].toUpperCase() + key.slice(1), cost_usd: share * 100,
-           tokens: 1000, share, tool_count: 10, session_count: 3, habits, tools };
+               tools: UsageTool[] = [], split?: Partial<UsagePhase>): UsagePhase {
+  const cost = share * 100;
+  return { key, label: key[0].toUpperCase() + key.slice(1), cost_usd: cost,
+           tokens: 1000, share, tool_count: 10, session_count: 3, habits, tools,
+           main_cost_usd: cost, subagent_cost_usd: 0,
+           main_tokens: 1000, subagent_tokens: 0, ...split };
 }
 
 function tool(key: string, costUsd: number, count = 3): UsageTool {
@@ -194,5 +198,34 @@ describe("buildForceModel tool lens", () => {
     const habits = buildForceModel([zeroShare],
       { totalUsd: 100, costAvailable: true, leafMode: "habits" });
     expect(habits.nodes.some((n) => n.id === "phase:operate")).toBe(false);
+  });
+});
+
+describe("deriveOriginPhases", () => {
+  const phases: UsagePhase[] = [
+    phase("explore", 0.8, [], [], { main_cost_usd: 20, subagent_cost_usd: 60 }),
+    phase("implement", 0.2, [], [], { main_cost_usd: 20, subagent_cost_usd: 0 }),
+  ];
+
+  it("returns phases unchanged for 'all'", () => {
+    const { phases: out, total } = deriveOriginPhases(phases, "all", "cost");
+    expect(total).toBe(100);            // cost_usd 80 + 20
+    expect(out[0].share).toBe(0.8);
+  });
+
+  it("rescales to the subagent subset", () => {
+    const { phases: out, total } = deriveOriginPhases(phases, "subagent", "cost");
+    expect(total).toBe(60);             // 60 + 0
+    expect(out[0].cost_usd).toBe(60);
+    expect(out[0].share).toBe(1);       // all subagent cost is in explore
+    expect(out[1].share).toBe(0);
+    expect(out[0].habits).toEqual([]);  // leaves hidden in split mode
+  });
+
+  it("rescales to the main subset", () => {
+    const { phases: out, total } = deriveOriginPhases(phases, "main", "cost");
+    expect(total).toBe(40);             // 20 + 20
+    expect(out[0].share).toBe(0.5);
+    expect(out[1].share).toBe(0.5);
   });
 });

--- a/frontend/src/discover/mindmap/forceModel.ts
+++ b/frontend/src/discover/mindmap/forceModel.ts
@@ -8,6 +8,38 @@ import type { UsageHabit, UsagePhase, UsageTool } from "../../api/types";
 
 export type LabelTier = "inside" | "split" | "below";
 export type LeafMode = "habits" | "tools";
+export type OriginFilter = "all" | "main" | "subagent";
+
+/**
+ * Rescale phases to one origin subset for the map's Origin filter. "all" is the
+ * identity; "main"/"subagent" replace each phase's cost/tokens with that
+ * subset's value, recompute share against the subset total, and clear leaves
+ * (the tools/habits breakdown is all-origin and would be misleading here).
+ */
+export function deriveOriginPhases(
+  phases: UsagePhase[],
+  origin: OriginFilter,
+  basis: "cost" | "tokens",
+): { phases: UsagePhase[]; total: number } {
+  const value = (p: UsagePhase): number => {
+    if (origin === "all") return basis === "cost" ? p.cost_usd : p.tokens;
+    if (origin === "main") return basis === "cost" ? p.main_cost_usd : p.main_tokens;
+    return basis === "cost" ? p.subagent_cost_usd : p.subagent_tokens;
+  };
+  const total = phases.reduce((sum, p) => sum + value(p), 0);
+  if (origin === "all") return { phases, total };
+  return {
+    total,
+    phases: phases.map((p) => ({
+      ...p,
+      cost_usd: origin === "main" ? p.main_cost_usd : p.subagent_cost_usd,
+      tokens: origin === "main" ? p.main_tokens : p.subagent_tokens,
+      share: total > 0 ? value(p) / total : 0,
+      habits: [],
+      tools: [],
+    })),
+  };
+}
 
 /** Minimal shape an overflow leaf needs to list its members. Both UsageHabit
     and UsageTool satisfy it structurally. */

--- a/frontend/src/glossary/GlossaryDialog.test.tsx
+++ b/frontend/src/glossary/GlossaryDialog.test.tsx
@@ -26,6 +26,20 @@ describe("GlossaryDialog", () => {
     expect(screen.queryByText("Subagent")).not.toBeInTheDocument();
   });
 
+  it("shows the Usage Mindmap phase/habit terms on the Workflow tab", () => {
+    render(<GlossaryDialog open onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Workflow" }));
+
+    // The phase term and its list of the seven phases are shown.
+    expect(screen.getByText("Workflow phase")).toBeInTheDocument();
+    expect(screen.getByText(/Synthesize/)).toBeInTheDocument();
+    // The distinction entry that the per-node tooltips never spell out.
+    expect(screen.getByText("Phase vs. habit")).toBeInTheDocument();
+    // Risk-only terms are no longer rendered in the active panel.
+    expect(screen.queryByText("Risk score")).not.toBeInTheDocument();
+  });
+
   it("calls onClose when the close button is clicked", () => {
     const onClose = vi.fn();
     render(<GlossaryDialog open onClose={onClose} />);

--- a/frontend/src/glossary/glossaryTerms.ts
+++ b/frontend/src/glossary/glossaryTerms.ts
@@ -5,6 +5,7 @@
 export type GlossaryCategory =
   | "Structure"
   | "Activity"
+  | "Workflow"
   | "Risk"
   | "Discovery"
   | "Cost";
@@ -22,6 +23,7 @@ export interface GlossaryTerm {
 export const CATEGORY_ORDER: GlossaryCategory[] = [
   "Structure",
   "Activity",
+  "Workflow",
   "Risk",
   "Discovery",
   "Cost",
@@ -126,6 +128,41 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
     term: "Timeline spacing",
     definition:
       "How the timeline spaces events along the x-axis. Raw time uses real wall-clock gaps; Compressed gaps shortens long idle stretches so activity isn't squished; Event order ignores time and spaces events evenly.",
+  },
+
+  // Workflow — the Usage Mindmap's phases and habits.
+  {
+    category: "Workflow",
+    term: "Usage Mindmap",
+    definition:
+      "The graph on Discover that splits all spend in the current filter into workflow phases (the inner ring) and the behavior habits detected within them (the leaves). Click any node to see the rule behind it and the sessions that fed it.",
+  },
+  {
+    category: "Workflow",
+    term: "Workflow phase",
+    definition:
+      "The kind of work an assistant turn was doing, decided from the tools it called. Every turn lands in exactly one of seven phases, so the phases partition all spend and sum to 100%. The percentage on a phase is its share of the corpus's spend (or tokens, when pricing is unavailable).",
+    detail: [
+      "Explore     reading & searching (Read, Grep, web)",
+      "Plan        planning (TodoWrite, plan mode, ask)",
+      "Implement   edits & writes (Edit, Write)",
+      "Verify      test / build / lint commands",
+      "Operate     other shell commands",
+      "Delegate    work handed to subagents (Task)",
+      "Synthesize  text-only turns; anything else",
+    ],
+  },
+  {
+    category: "Workflow",
+    term: "Habit (good / anti)",
+    definition:
+      "A recurring behavior pattern detected across a session's turns — for example planning before a burst of edits, or retrying a failing command unchanged. Each habit hangs off its home phase as a leaf, marked good (a pattern worth keeping) or anti (a pattern worth fixing). Its cost is the size of the behavior itself, not a hypothetical saving.",
+  },
+  {
+    category: "Workflow",
+    term: "Phase vs. habit",
+    definition:
+      "Phases and habits answer different questions. The phases are a partition: every dollar of spend lands in exactly one phase, so they sum to 100%. Habits are an overlay on top — a single habit can span several phases and deliberately counts the work across them, so habit shares overlap each other and the phases and do not sum to 100%. Read a phase as \"how much spend was this kind of work\"; read a habit as \"how much spend is involved in this pattern.\"",
   },
 
   // Risk — the Triage rank and the findings/patterns behind it.

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -259,12 +259,18 @@ html:has(.glossary-dialog[open]) { overflow: hidden; }
 
 /* Usage Characteristics modal — /usage-style overlapping-characteristics list.
    Frame styles are inherited from .glossary-dialog/.glossary-panel. */
+.usage-characteristics-dialog { height: auto; max-height: min(80vh, 640px); }
+.usage-characteristics-dialog .segmented-control { margin: 10px 20px 0; }
 .usage-characteristics-dialog .uc-subtitle {
-  margin: 4px 0 14px;
+  margin: 6px 20px 12px;
   color: var(--muted);
   font-size: 12px;
 }
 .usage-characteristics-dialog .uc-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 20px;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -292,8 +298,8 @@ html:has(.glossary-dialog[open]) { overflow: hidden; }
   font-size: 13px;
 }
 .usage-characteristics-dialog .uc-caveat {
-  margin-top: 16px;
-  padding-top: 10px;
+  margin: 0;
+  padding: 12px 20px 16px;
   border-top: 1px solid var(--border);
   color: var(--faint);
   font-size: 11px;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -257,6 +257,49 @@ html:has(.glossary-dialog[open]) { overflow: hidden; }
   overflow-x: auto;
 }
 
+/* Usage Characteristics modal — /usage-style overlapping-characteristics list.
+   Frame styles are inherited from .glossary-dialog/.glossary-panel. */
+.usage-characteristics-dialog .uc-subtitle {
+  margin: 4px 0 14px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.usage-characteristics-dialog .uc-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.usage-characteristics-dialog .uc-row {
+  border-left: 2px solid var(--border-2);
+  padding-left: 10px;
+}
+.usage-characteristics-dialog .uc-headline {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text);
+}
+.usage-characteristics-dialog .uc-headline strong {
+  font-variant-numeric: tabular-nums;
+}
+.usage-characteristics-dialog .uc-guidance {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.usage-characteristics-dialog .uc-note {
+  color: var(--muted);
+  font-size: 13px;
+}
+.usage-characteristics-dialog .uc-caveat {
+  margin-top: 16px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  color: var(--faint);
+  font-size: 11px;
+  font-style: italic;
+}
+
 .page { flex: 1; width: 100%; max-width: var(--page-max-width); margin: 0 auto; padding: 22px var(--page-gutter); }
 .import-page { overflow: auto; width: 100%; }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,16 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: 5174,
+    // Same-origin API in dev: forward /api to the backend so the browser never
+    // makes a cross-origin call. Removes the CORS dependency and makes the dev
+    // port irrelevant (the frontend talks to its own origin's /api).
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary

Adds **Usage drivers** — a `/usage`-style view of the *overlapping characteristics*
that drive spend (subagent usage, large-context turns, long sessions, per-agent-type),
plus a **main-vs-subagent "origin" filter** on the usage map. Where `/usage` is limited
to rate-limit Day/Week windows, this reads the full local export, so it also offers
Month and All-time windows and a direct subagent-attribution metric `/usage` doesn't expose.

The headline partitioned usage map (workflow phases) is unchanged and stays the default;
this adds a second, complementary lens.

## Why

`/usage` shows what's contributing to limits usage, but only for the last day/week and
only as a fixed list. We already index the whole export, so we can (a) compute the same
characteristics over arbitrary windows, (b) attribute cost to subagents directly, and
(c) cross-check our numbers against `/usage` on the overlapping windows. The view leads
with its own value; `/usage` is kept as a recognition anchor, not the headline.

## What's included

**Backend — new analysis module**
- `analysis/usage_characteristics.py`: overlapping (non-partition) characteristics over the
  filtered corpus, built on the existing `usage_map.load_events` so the panel's `total_usd`
  is identical to the map's — a tested cross-consistency invariant. Cost-weighted, with a
  token-weighted fallback when no pricing table is present.
- Characteristics: **subagent turns** (direct cost of subagent turns ÷ total),
  **sessions that use subagents** (full cost of any session that spawned a subagent),
  **>150k context**, **8h+ sessions**, and **per-agent-type** subagent shares (≥5% floor).
- `usage_map.py`: `EventRec` now carries `agent_id` and `input_context_tokens`;
  `aggregate_phases` splits each phase's cost/tokens into main vs subagent (conserving),
  surfaced on `UsagePhase`.
- New endpoint `GET /api/analytics/usage-characteristics`.

**Frontend**
- `UsageCharacteristicsDialog` — a native `<dialog>` "Usage drivers" panel with a
  Day/Week/Month/All window toggle; Day/Week mirror `/usage`, Month/All use the full history.
- `UsageMindmap` — "Usage drivers" toolbar button + an `Origin: [All | Main | Subagents]`
  filter that rescales phases via the pure `deriveOriginPhases` helper (split views hide
  leaves and show an empty state when a subset has no spend).
- API types/client additions.

## Design notes

- **Two subagent metrics, kept distinct on purpose.** "subagent turns" (~19% on my corpus)
  is the work done *inside* subagent turns; "sessions that use subagents" (~80%) is usage
  occurring in sessions that involve subagents at all. They answer different questions and
  the guidance text spells out the difference. We deliberately dropped a single
  "≥50% subagent-heavy" threshold, which was arbitrary and misleadingly small.
- **Basis honesty.** Shares are cost-weighted; the caveat notes `/usage` weights by
  rate-limit consumption, so agreement is directional, not exact. The note switches to
  token-weighting wording when no pricing is available.
- **Cross-validation, not matching.** On overlapping windows the numbers land close to
  `/usage` (8h sessions, general-purpose agent type, context band), which validates the
  pipeline; the aim is understanding, not forcing a match.

## Bundled dev-infra fix

The dev frontend now reaches the backend through a **vite `/api` proxy** (same-origin)
instead of a direct cross-origin call, removing the CORS dependency that broke data loading
when the dev port wasn't `5173`. `VITE_API_BASE` defaults to relative `/api`;
README/CONTRIBUTING updated. Docker (which sets `VITE_API_BASE` explicitly) is unaffected.

## Testing

- Backend: `uv run pytest` — full suite green (251). New `test_usage_characteristics.py`
  covers each characteristic, the cross-consistency invariant, token-basis fallback, and the
  endpoint; `test_usage_map.py` covers the new event fields and the phase origin split (with
  conservation).
- Frontend: `npx tsc --noEmit` clean; `npx vitest run` — 214 pass. Covers
  `deriveOriginPhases`, the dialog (render/presets/All-time/error), and the map wiring.

## Out of scope / follow-ups

- **Skill & plugin attribution** (the remaining `/usage` lines) — needs ingest capture of
  skill/slash-command invocations; deferred.
- Evidence card shows all-origin cost in a split origin view (documented limitation).

## Note for reviewers

This branch was cut from `docs/glossary-workflow-terms`, so it includes one unrelated commit
(`665d0cb`, glossary terms — `glossaryTerms.ts`, `GlossaryDialog.test.tsx`). If you'd prefer
a clean diff, rebase onto `main` before merging.