### PR TITLE
Feat/historical pricing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/superpowers/*
 .DS_Store
 docs/PROJECT_STATE.md
 docker-compose-local.yml
+/pricing

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ That makes it a base for deeper work on coding-agent usage patterns, optimizatio
 | --- | --- | --- |
 | ![Import page showing mounted source, cache totals, and project import controls](docs/screenshots/import.png) | ![Session workspace showing event density, subagents, tool usage, trace lanes, loops, and token chart](docs/screenshots/session-workspace.png) | ![Cost outlier view showing turn distribution and the selected expensive turn drivers](docs/screenshots/cost-analytics-2.png) |
 
+## Historical (time-aware) pricing
+
+Model prices change over time, so the cost views can value each session either at the rate in effect on its date or at today's rate. A **Historical pricing** toggle in the sidebar flips between the two:
+
+- **On** (default) — each session's spend is priced at the rates effective on its own date.
+- **Off** — every session is valued at the current rate.
+
+Prices come from CSVs of US dollars per million tokens:
+
+- `pricing.csv` (repo root) is the **undated baseline**, effective from the beginning of time.
+- Each `pricing/pricing-YYYY-MM-DD.csv` is a full price snapshot that takes effect on the date in its filename. A session is priced by the baseline overlaid with every snapshot whose date is on or before the session's date (later snapshots win per model).
+
+To record a price change, drop a new `pricing/pricing-YYYY-MM-DD.csv` with the same columns as `pricing.csv` — never edit old snapshots. Both `pricing.csv` and the `pricing/` directory are mounted read-only into the Docker backend and reloaded per request, so price edits take effect on the next request without a rebuild. With no `pricing/` directory the app prices everything at the baseline.
+
 ## Project Docs
 
 - [Contributing](CONTRIBUTING.md)

--- a/backend/src/ccfr/analysis/context_economics.py
+++ b/backend/src/ccfr/analysis/context_economics.py
@@ -238,30 +238,17 @@ def calibrate_contributors(
     return contributors
 
 
-def accrue_tax(
-    thread: ThreadRec,
-    timeline: PriceTimeline | dict[str, Any],
-    *,
-    historical: bool = True,
-) -> bool:
+def accrue_tax(thread: ThreadRec, timeline: PriceTimeline, *, historical: bool = True) -> bool:
     """Price each contributor's carry: one 5m cache write at entry, then one
     cache read per subsequent call until its epoch ends. Returns False when any
     call's model has no price row (those calls contribute $0 and the payload
     flags cost as partially unavailable).
-
-    ``timeline`` may be a :class:`PriceTimeline` (historical-aware) or a plain
-    ``dict[str, ModelPrice]`` (backward-compatible, treated as a single-period
-    flat table).
     """
     fully_priced = True
     thread.read_prices = []
     thread.write_prices = []
-    _is_timeline = isinstance(timeline, PriceTimeline)
     for call in thread.calls:
-        if _is_timeline:
-            price = timeline.price_for(call.model, call.ts, historical=historical)  # type: ignore[union-attr]
-        else:
-            price = match_price(timeline, call.model)  # type: ignore[arg-type]
+        price = timeline.price_for(call.model, call.ts, historical=historical)
         if price is None:
             fully_priced = False
             thread.read_prices.append(0.0)

--- a/backend/src/ccfr/analysis/context_economics.py
+++ b/backend/src/ccfr/analysis/context_economics.py
@@ -19,8 +19,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any
 
-from ccfr.analysis.pricing import load_price_table, match_price
-from ccfr.config import pricing_path
+from ccfr.analysis.pricing import PriceTimeline, load_price_timeline, match_price
+from ccfr.config import pricing_dir, pricing_path
 from ccfr.naming import project_display_name
 
 # --- Estimation and detection constants -------------------------------------
@@ -238,16 +238,30 @@ def calibrate_contributors(
     return contributors
 
 
-def accrue_tax(thread: ThreadRec, table: dict[str, Any]) -> bool:
+def accrue_tax(
+    thread: ThreadRec,
+    timeline: PriceTimeline | dict[str, Any],
+    *,
+    historical: bool = True,
+) -> bool:
     """Price each contributor's carry: one 5m cache write at entry, then one
     cache read per subsequent call until its epoch ends. Returns False when any
     call's model has no price row (those calls contribute $0 and the payload
-    flags cost as partially unavailable)."""
+    flags cost as partially unavailable).
+
+    ``timeline`` may be a :class:`PriceTimeline` (historical-aware) or a plain
+    ``dict[str, ModelPrice]`` (backward-compatible, treated as a single-period
+    flat table).
+    """
     fully_priced = True
     thread.read_prices = []
     thread.write_prices = []
+    _is_timeline = isinstance(timeline, PriceTimeline)
     for call in thread.calls:
-        price = match_price(table, call.model)
+        if _is_timeline:
+            price = timeline.price_for(call.model, call.ts, historical=historical)  # type: ignore[union-attr]
+        else:
+            price = match_price(timeline, call.model)  # type: ignore[arg-type]
         if price is None:
             fully_priced = False
             thread.read_prices.append(0.0)
@@ -807,26 +821,28 @@ def _thumbnail(thread: ThreadRec, finding: FindingRec) -> dict[str, Any]:
 
 
 def _corpus_total_usd(conn: sqlite3.Connection, project_id: int | None,
-                      table: dict[str, Any]) -> float:
+                      timeline: PriceTimeline, *, historical: bool = True) -> float:
     where, params = "", []
     if project_id is not None:
         where = "WHERE s.project_id = ?"
         params.append(project_id)
+    period_expr = timeline.sql_period_expr("e.timestamp", historical=historical)
     rows = conn.execute(
         f"""
-        SELECT m.model, SUM(m.base_input_tokens) AS base, SUM(m.cache_5m_tokens) AS c5,
+        SELECT m.model, ({period_expr}) AS price_period,
+               SUM(m.base_input_tokens) AS base, SUM(m.cache_5m_tokens) AS c5,
                SUM(m.cache_1h_tokens) AS c1, SUM(m.cache_read_tokens) AS cr,
                SUM(m.output_tokens) AS out
         FROM messages m
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
-        {where} GROUP BY m.model
+        {where} GROUP BY m.model, price_period
         """,
         params,
     ).fetchall()
     total = 0.0
     for row in rows:
-        price = match_price(table, row["model"])
+        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
         if price is None:
             continue
         total += (
@@ -854,7 +870,7 @@ def _week_start(ts: str | None) -> str | None:
 
 
 def _corpus_weekly_usd(conn: sqlite3.Connection, project_id: int | None,
-                       table: dict[str, Any]) -> dict[str, float]:
+                       timeline: PriceTimeline, *, historical: bool = True) -> dict[str, float]:
     """Total billed spend bucketed by ISO week (Monday start).
 
     Grouped by model+day in SQL to keep the row count small, then folded into
@@ -880,7 +896,7 @@ def _corpus_weekly_usd(conn: sqlite3.Connection, project_id: int | None,
     weekly: dict[str, float] = defaultdict(float)
     for row in rows:
         week = _week_start(row["day"])
-        price = match_price(table, row["model"])
+        price = timeline.price_for(row["model"], row["day"], historical=historical)
         if week is None or price is None:
             continue
         weekly[week] += (
@@ -931,14 +947,15 @@ def context_economics_analytics(
     *,
     project_id: int | None = None,
     min_support: int = 3,
+    historical: bool = True,
 ) -> dict[str, Any]:
     """Corpus-level Context Economics payload (Discover landing view)."""
     min_support = max(1, int(min_support or 1))
-    table = load_price_table(pricing_path())
-    cost_available = bool(table)
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    cost_available = timeline.has_prices
     threads, skipped = load_threads(conn, project_id=project_id)
     for thread in threads:
-        accrue_tax(thread, table)
+        accrue_tax(thread, timeline, historical=historical)
     results = run_detectors(threads)
     thread_by_session: dict[tuple[int, str | None], ThreadRec] = {
         (t.session_db_id, t.agent_id): t for t in threads
@@ -982,7 +999,7 @@ def context_economics_analytics(
             "findings": [_finding_payload(f) for f in findings[:FINDINGS_LIMIT]] if meets else [],
         })
 
-    total_usd = _corpus_total_usd(conn, project_id, table) if cost_available else 0.0
+    total_usd = _corpus_total_usd(conn, project_id, timeline, historical=historical) if cost_available else 0.0
     # avoidable is a subset of carry reads/writes that are themselves part of
     # total, so it should not exceed total. The clamp is defense-in-depth against
     # the estimate-vs-actual gap (savings use calibrated token estimates; total
@@ -993,7 +1010,7 @@ def context_economics_analytics(
     )
     trend: list[dict[str, Any]] = []
     if cost_available:
-        weekly_total = _corpus_weekly_usd(conn, project_id, table)
+        weekly_total = _corpus_weekly_usd(conn, project_id, timeline, historical=historical)
         weeks = sorted(set(weekly_total) | set(avoidable_weekly))[-TREND_WEEKS:]
         trend = [
             {
@@ -1023,7 +1040,8 @@ def context_economics_analytics(
     }
 
 
-def session_context_economics(conn: sqlite3.Connection, session_db_id: int) -> dict[str, Any]:
+def session_context_economics(conn: sqlite3.Connection, session_db_id: int, *,
+                              historical: bool = True) -> dict[str, Any]:
     """Drill-down payload for one session.
 
     Detection runs session-locally: corpus-relative thresholds are computed
@@ -1034,10 +1052,10 @@ def session_context_economics(conn: sqlite3.Connection, session_db_id: int) -> d
     Findings are routed to the thread that owns their event_id, so sidechain
     findings stay on the sidechain thread.
     """
-    table = load_price_table(pricing_path())
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
     threads, _skipped = load_threads(conn, session_db_id=session_db_id)
     for thread in threads:
-        accrue_tax(thread, table)
+        accrue_tax(thread, timeline, historical=historical)
     results = run_detectors(threads)
 
     payload_threads = []
@@ -1070,4 +1088,4 @@ def session_context_economics(conn: sqlite3.Connection, session_db_id: int) -> d
                 if f.session_id == thread.session_db_id and f.event_id in thread_event_ids
             ],
         })
-    return {"threads": payload_threads, "cost_available": bool(table)}
+    return {"threads": payload_threads, "cost_available": timeline.has_prices}

--- a/backend/src/ccfr/analysis/discovery.py
+++ b/backend/src/ccfr/analysis/discovery.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass
 from statistics import NormalDist
 from typing import Any
 
-from ccfr.analysis.pricing import TokenBreakdown, cost_usd, load_price_table, match_price
+from ccfr.analysis.pricing import TokenBreakdown, cost_usd, load_price_timeline, match_price
 from ccfr.analysis.risk_patterns import _command_family
 from ccfr.naming import project_display_name
-from ccfr.config import pricing_path
+from ccfr.config import pricing_dir, pricing_path
 
 
 SECTION_LIMIT = 8
@@ -59,10 +59,11 @@ def discovery_analytics(
     *,
     project_id: int | None = None,
     min_support: int = 5,
+    historical: bool = True,
 ) -> dict[str, Any]:
     """Return on-demand driver discovery results from the rebuildable SQLite cache."""
     min_support = max(1, int(min_support or 1))
-    sessions, cost_available = _session_subjects(conn, project_id=project_id)
+    sessions, cost_available = _session_subjects(conn, project_id=project_id, historical=historical)
     tool_calls = _tool_call_subjects(conn, project_id=project_id)
     rejection_slices = _rejection_slice_subjects(conn, project_id=project_id)
 
@@ -288,8 +289,8 @@ def _summary(labels: list[str], lift: float) -> str:
     return f"{' and '.join(labels)} is {lift:.1f}x more likely than baseline."
 
 
-def _session_subjects(conn: sqlite3.Connection, *, project_id: int | None) -> tuple[list[Subject], bool]:
-    costs, available = _scoped_session_costs(conn, project_id=project_id)
+def _session_subjects(conn: sqlite3.Connection, *, project_id: int | None, historical: bool = True) -> tuple[list[Subject], bool]:
+    costs, available = _scoped_session_costs(conn, project_id=project_id, historical=historical)
     rows = conn.execute(
         f"""
         SELECT
@@ -558,15 +559,18 @@ def _feature_label(symbol: str) -> str:
     return _title(symbol.replace(":", " "))
 
 
-def _scoped_session_costs(conn: sqlite3.Connection, *, project_id: int | None) -> tuple[dict[int, float], bool]:
-    table = load_price_table(pricing_path())
-    if not table:
+def _scoped_session_costs(conn: sqlite3.Connection, *, project_id: int | None,
+                          historical: bool = True) -> tuple[dict[int, float], bool]:
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    if not timeline.has_prices:
         return {}, False
+    period_expr = timeline.sql_period_expr("e.timestamp", historical=historical)
     rows = conn.execute(
         f"""
         SELECT
             e.session_id,
             m.model,
+            ({period_expr}) AS price_period,
             COALESCE(SUM(m.base_input_tokens), 0) AS base_input,
             COALESCE(SUM(m.cache_5m_tokens), 0) AS cache_write_5m,
             COALESCE(SUM(m.cache_1h_tokens), 0) AS cache_write_1h,
@@ -576,12 +580,13 @@ def _scoped_session_costs(conn: sqlite3.Connection, *, project_id: int | None) -
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
         {_project_where(project_id, "s")}
-        GROUP BY e.session_id, m.model
+        GROUP BY e.session_id, m.model, price_period
         """,
         _project_params(project_id),
     ).fetchall()
     costs: dict[int, float] = {}
     for row in rows:
+        table = timeline.table_for_period(row["price_period"], historical=historical)
         price = match_price(table, row["model"])
         if price is None:
             continue

--- a/backend/src/ccfr/analysis/pricing.py
+++ b/backend/src/ccfr/analysis/pricing.py
@@ -151,7 +151,7 @@ def _coerce_date(when: object) -> date | None:
 
 
 # A dated snapshot file: pricing-YYYY-MM-DD.csv (date parsed from the filename).
-_SHEET_RE = re.compile(r"^pricing-(\d{4})-(\d{2})-(\d{2})\.csv$", re.IGNORECASE)
+_SHEET_RE = re.compile(r"^pricing-(\d{4})-(\d{2})-(\d{2})\.csv$")
 
 
 @dataclass(frozen=True)
@@ -190,7 +190,7 @@ class PriceTimeline:
     def current_table(self) -> dict[str, ModelPrice]:
         if self._current is None:
             self._current = self._merge_through(len(self._snapshots))
-        return self._current
+        return dict(self._current)
 
     def table_for_period(self, period: int, *, historical: bool = True) -> dict[str, ModelPrice]:
         if not historical:
@@ -198,7 +198,7 @@ class PriceTimeline:
         period = max(0, min(int(period), len(self._snapshots)))
         if period not in self._period_cache:
             self._period_cache[period] = self._merge_through(period)
-        return self._period_cache[period]
+        return dict(self._period_cache[period])
 
     def period_index(self, when: object) -> int:
         day = _coerce_date(when)

--- a/backend/src/ccfr/analysis/pricing.py
+++ b/backend/src/ccfr/analysis/pricing.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import csv
 import re
+from bisect import bisect_right
 from dataclasses import dataclass
+from datetime import date, datetime
 from pathlib import Path
 
 
@@ -126,3 +128,118 @@ def cost_usd(price: ModelPrice, tokens: TokenBreakdown) -> float:
         + tokens.output * price.output
     )
     return total / 1_000_000
+
+
+def _coerce_date(when: object) -> date | None:
+    """Best-effort fold of a date / datetime / ISO string to a date; None when unknown."""
+    if when is None:
+        return None
+    if isinstance(when, datetime):
+        return when.date()
+    if isinstance(when, date):
+        return when
+    text = str(when).strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(text[:10])
+        except ValueError:
+            return None
+
+
+# A dated snapshot file: pricing-YYYY-MM-DD.csv (date parsed from the filename).
+_SHEET_RE = re.compile(r"^pricing-(\d{4})-(\d{2})-(\d{2})\.csv$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    date: date
+    table: dict[str, ModelPrice]
+
+
+class PriceTimeline:
+    """Baseline prices plus dated snapshots, resolvable to a table for any date.
+
+    The merged table for a date is the baseline overlaid with every snapshot whose
+    effective date is <= that date, applied oldest-first (later snapshots win per model).
+    """
+
+    def __init__(self, baseline: dict[str, ModelPrice], snapshots: list[_Snapshot]) -> None:
+        self._baseline = baseline
+        self._snapshots = sorted(snapshots, key=lambda s: s.date)
+        self._boundaries = [s.date for s in self._snapshots]
+        self._period_cache: dict[int, dict[str, ModelPrice]] = {}
+        self._current: dict[str, ModelPrice] | None = None
+
+    @property
+    def has_prices(self) -> bool:
+        return bool(self._baseline) or any(snap.table for snap in self._snapshots)
+
+    def boundaries(self) -> list[date]:
+        return list(self._boundaries)
+
+    def _merge_through(self, count: int) -> dict[str, ModelPrice]:
+        merged = dict(self._baseline)
+        for snap in self._snapshots[:count]:
+            merged.update(snap.table)
+        return merged
+
+    def current_table(self) -> dict[str, ModelPrice]:
+        if self._current is None:
+            self._current = self._merge_through(len(self._snapshots))
+        return self._current
+
+    def table_for_period(self, period: int, *, historical: bool = True) -> dict[str, ModelPrice]:
+        if not historical:
+            return self.current_table()
+        period = max(0, min(int(period), len(self._snapshots)))
+        if period not in self._period_cache:
+            self._period_cache[period] = self._merge_through(period)
+        return self._period_cache[period]
+
+    def period_index(self, when: object) -> int:
+        day = _coerce_date(when)
+        if day is None:
+            return 0
+        return bisect_right(self._boundaries, day)
+
+    def table_for(self, when: object, *, historical: bool = True) -> dict[str, ModelPrice]:
+        if not historical:
+            return self.current_table()
+        return self.table_for_period(self.period_index(when), historical=True)
+
+    def price_for(self, model: str | None, when: object, *, historical: bool = True) -> ModelPrice | None:
+        return match_price(self.table_for(when, historical=historical), model)
+
+    def sql_period_expr(self, column: str = "e.timestamp", *, historical: bool = True) -> str:
+        """SQL yielding the 0-based price-period index for a timestamp column.
+
+        Booleans are 0/1 in SQLite, so summing `(date(col) >= 'd')` over the sorted
+        boundaries gives exactly ``period_index``. Returns the constant ``0`` when
+        historical is off or there are no snapshots (groups collapse to one period)."""
+        if not historical or not self._boundaries:
+            return "0"
+        terms = " + ".join(f"(date({column}) >= '{d.isoformat()}')" for d in self._boundaries)
+        return f"({terms})"
+
+
+def load_price_timeline(baseline_path: Path, sheets_dir: Path) -> PriceTimeline:
+    """Load the baseline CSV plus every pricing-YYYY-MM-DD.csv in ``sheets_dir``."""
+    baseline = load_price_table(baseline_path)
+    snapshots: list[_Snapshot] = []
+    if sheets_dir.is_dir():
+        for child in sorted(sheets_dir.iterdir()):
+            if not child.is_file():
+                continue
+            match = _SHEET_RE.match(child.name)
+            if not match:
+                continue
+            try:
+                day = date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+            except ValueError:
+                continue
+            snapshots.append(_Snapshot(date=day, table=load_price_table(child)))
+    return PriceTimeline(baseline, snapshots)

--- a/backend/src/ccfr/analysis/pricing.py
+++ b/backend/src/ccfr/analysis/pricing.py
@@ -192,10 +192,10 @@ class PriceTimeline:
             self._current = self._merge_through(len(self._snapshots))
         return dict(self._current)
 
-    def table_for_period(self, period: int, *, historical: bool = True) -> dict[str, ModelPrice]:
+    def table_for_period(self, period: int | None, *, historical: bool = True) -> dict[str, ModelPrice]:
         if not historical:
             return self.current_table()
-        period = max(0, min(int(period), len(self._snapshots)))
+        period = max(0, min(int(period) if period is not None else 0, len(self._snapshots)))
         if period not in self._period_cache:
             self._period_cache[period] = self._merge_through(period)
         return dict(self._period_cache[period])

--- a/backend/src/ccfr/analysis/usage_characteristics.py
+++ b/backend/src/ccfr/analysis/usage_characteristics.py
@@ -17,9 +17,9 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Any
 
-from ccfr.analysis.pricing import load_price_table
+from ccfr.analysis.pricing import load_price_timeline
 from ccfr.analysis.usage_map import EventRec, load_events
-from ccfr.config import pricing_path
+from ccfr.config import pricing_dir, pricing_path
 
 # Thresholds pinned to /usage (tunable). Subagent-heavy ratio is our own choice
 # (/usage's exact definition is unknown) and documented as approximate.
@@ -195,14 +195,15 @@ def _agent_types(
 def usage_characteristics_analytics(
     conn: sqlite3.Connection,
     *,
+    historical: bool = True,
     project_id: int | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
 ) -> dict[str, Any]:
     """Overlapping-characteristics payload for the filtered corpus."""
-    table = load_price_table(pricing_path())
-    cost_available = bool(table)
-    events = load_events(conn, table, project_id=project_id,
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    cost_available = timeline.has_prices
+    events = load_events(conn, timeline, historical=historical, project_id=project_id,
                          date_from=date_from, date_to=date_to)
     total_usd = sum(e.cost for e in events)
     total_tokens = sum(e.tokens for e in events)

--- a/backend/src/ccfr/analysis/usage_map.py
+++ b/backend/src/ccfr/analysis/usage_map.py
@@ -22,13 +22,12 @@ from typing import Any, Callable
 
 from ccfr.analysis.context_economics import accrue_tax, load_threads, run_detectors
 from ccfr.analysis.pricing import (
-    ModelPrice,
+    PriceTimeline,
     TokenBreakdown,
     cost_usd,
-    load_price_table,
-    match_price,
+    load_price_timeline,
 )
-from ccfr.config import pricing_path
+from ccfr.config import pricing_dir, pricing_path
 from ccfr.naming import project_display_name
 
 logger = logging.getLogger(__name__)
@@ -178,8 +177,9 @@ def _parse_input(raw_json: str | None) -> dict[str, Any]:
 
 def load_events(
     conn: sqlite3.Connection,
-    table: dict[str, ModelPrice],
+    timeline: PriceTimeline,
     *,
+    historical: bool = True,
     project_id: int | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
@@ -276,7 +276,7 @@ def load_events(
 
     events: list[EventRec] = []
     for row in rows:
-        price = match_price(table, row["model"])
+        price = timeline.price_for(row["model"], row["ts"], historical=historical)
         # Total billed tokens (all four input categories + output) — same definition
         # as context_economics' context_tokens; used for the token-fallback shares.
         tokens = row["base"] + row["c5"] + row["c1"] + row["cr"] + row["out"]
@@ -521,8 +521,9 @@ def _in_window(ts: str | None, date_from: str | None, date_to: str | None) -> bo
 
 def detect_context_habits(
     conn: sqlite3.Connection,
-    table: dict[str, ModelPrice],
+    timeline: PriceTimeline,
     *,
+    historical: bool = True,
     project_id: int | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
@@ -535,7 +536,7 @@ def detect_context_habits(
     memoise at the call site if this ends up on a hot path."""
     threads, _skipped = load_threads(conn, project_id=project_id)
     for thread in threads:
-        accrue_tax(thread, table)
+        accrue_tax(thread, timeline, historical=historical)
     results = run_detectors(threads)
     findings: list[HabitFinding] = []
     for archetype, (recs, _thresholds) in results.items():
@@ -603,9 +604,10 @@ SESSION_DETECTORS: list[Callable[[list[EventRec]], list[HabitFinding]]] = [
 
 def run_habit_detectors(
     conn: sqlite3.Connection,
-    table: dict[str, ModelPrice],
+    timeline: PriceTimeline,
     events: list[EventRec],
     *,
+    historical: bool = True,
     project_id: int | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
@@ -625,7 +627,7 @@ def run_habit_detectors(
                                  getattr(detector, "__name__", repr(detector)))
     try:
         findings.extend(detect_context_habits(
-            conn, table, project_id=project_id,
+            conn, timeline, historical=historical, project_id=project_id,
             date_from=date_from, date_to=date_to,
         ))
     except Exception:
@@ -662,6 +664,7 @@ def aggregate_habits(findings: list[HabitFinding]) -> list[dict[str, Any]]:
 def usage_map_analytics(
     conn: sqlite3.Connection,
     *,
+    historical: bool = True,
     project_id: int | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
@@ -669,13 +672,13 @@ def usage_map_analytics(
     """The full usage-map tree for the filtered corpus. Shares are cost-based
     when pricing is available (and non-zero), token-based otherwise; either way
     the phases partition the corpus, so shares sum to 1."""
-    table = load_price_table(pricing_path())
-    cost_available = bool(table)
-    events = load_events(conn, table, project_id=project_id,
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    cost_available = timeline.has_prices
+    events = load_events(conn, timeline, historical=historical, project_id=project_id,
                          date_from=date_from, date_to=date_to)
     phase_acc = aggregate_phases(events)
     leaves = aggregate_habits(run_habit_detectors(
-        conn, table, events, project_id=project_id,
+        conn, timeline, events, historical=historical, project_id=project_id,
         date_from=date_from, date_to=date_to,
     )) if events else []
 
@@ -741,6 +744,7 @@ def usage_map_evidence(
     conn: sqlite3.Connection,
     *,
     node: str,
+    historical: bool = True,
     project_id: int | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
@@ -748,8 +752,8 @@ def usage_map_evidence(
     """Receipts for one map node: the rule that put it there, and the sessions
     that fed it (cost-descending). Raises KeyError for unknown nodes."""
     kind, _, key = node.partition(":")
-    table = load_price_table(pricing_path())
-    events = load_events(conn, table, project_id=project_id,
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    events = load_events(conn, timeline, historical=historical, project_id=project_id,
                          date_from=date_from, date_to=date_to)
 
     sessions: dict[int, dict[str, Any]] = {}
@@ -789,7 +793,7 @@ def usage_map_evidence(
         label, rule = spec["label"], spec["rule"]
         findings = [
             f for f in run_habit_detectors(
-                conn, table, events, project_id=project_id,
+                conn, timeline, events, historical=historical, project_id=project_id,
                 date_from=date_from, date_to=date_to,
             )
             if f.habit_key == habit_key

--- a/backend/src/ccfr/api/analytics.py
+++ b/backend/src/ccfr/api/analytics.py
@@ -14,15 +14,16 @@ from typing import Any
 
 from ccfr.analysis.pricing import (
     ModelPrice,
+    PriceTimeline,
     TokenBreakdown,
     cost_usd,
-    load_price_table,
+    load_price_timeline,
     match_price,
     normalize_model_key,
 )
 from ccfr.analysis.metrics import compute_loop_stats
 from ccfr.naming import project_display_name
-from ccfr.config import pricing_path
+from ccfr.config import pricing_dir, pricing_path
 
 # Payload category -> messages column. input_tokens == base+5m+1h+read, so we sum the four
 # breakdown columns plus output and never touch input_tokens (avoids double counting).
@@ -152,8 +153,8 @@ def _turn_cost_stat(values: list[float]) -> dict[str, Any]:
     }
 
 
-def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
-    table = load_price_table(pricing_path())
+def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int, *, historical: bool = True) -> dict[str, Any]:
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
     turn_start_rows = conn.execute(
         """
         SELECT
@@ -232,6 +233,7 @@ def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int) -> di
         f"""
         SELECT
             e.id AS event_id,
+            e.timestamp AS event_ts,
             e.is_sidechain,
             m.role,
             m.model,
@@ -263,7 +265,7 @@ def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int) -> di
         model = row["model"]
         if not model:
             continue
-        price = match_price(table, str(model))
+        price = timeline.price_for(str(model), row["event_ts"], historical=historical)
         if price is None:
             continue
 
@@ -302,14 +304,15 @@ def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int) -> di
 
 def _turn_cost_stats(
     conn: sqlite3.Connection,
-    table: dict[str, ModelPrice],
+    timeline: PriceTimeline,
     *,
     where: str,
     params: list[Any],
     project_id: int | None,
     matches: Any,
+    historical: bool = True,
 ) -> dict[int, dict[str, Any]]:
-    if not table:
+    if not timeline.has_prices:
         return {}
     project_clause = "AND s.project_id = ?" if project_id is not None else ""
     project_params: list[Any] = [project_id] if project_id is not None else []
@@ -334,7 +337,7 @@ def _turn_cost_stats(
     costs_by_turn: dict[int, dict[int, float]] = {}
     for row in conn.execute(
         f"""
-        SELECT e.session_id AS session_id, e.id AS event_id, m.model AS model, { _token_value_select() }
+        SELECT e.session_id AS session_id, e.id AS event_id, e.timestamp AS event_ts, m.model AS model, { _token_value_select() }
         FROM events e
         JOIN messages m ON m.event_id = e.id
         JOIN sessions s ON s.id = e.session_id
@@ -345,7 +348,7 @@ def _turn_cost_stats(
     ).fetchall():
         if not matches(row["model"]):
             continue
-        price = match_price(table, row["model"])
+        price = timeline.price_for(row["model"], row["event_ts"], historical=historical)
         if price is None:
             continue
         turn_starts = turn_starts_by_session.get(row["session_id"], [])
@@ -370,8 +373,11 @@ def cost_analytics(
     date_to: str | None = None,
     project_id: int | None = None,
     model: str | None = None,
+    historical: bool = True,
 ) -> dict[str, Any]:
-    table = load_price_table(pricing_path())
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    period_expr = timeline.sql_period_expr("e.timestamp", historical=historical)
+    price_available = timeline.has_prices
     model_key = normalize_model_key(model) if model else None
     where, params = _where(date_from, date_to, project_id)
     cols = _token_sum_select()
@@ -406,13 +412,13 @@ def cost_analytics(
     pm_rows = conn.execute(
         f"""
         SELECT s.project_id AS project_id, p.export_name AS project_name, p.inferred_cwd AS project_cwd,
-               m.model AS model, {cols}
+               m.model AS model, ({period_expr}) AS price_period, {cols}
         FROM messages m
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
         JOIN projects p ON p.id = s.project_id
         {where}
-        GROUP BY s.project_id, m.model
+        GROUP BY s.project_id, m.model, price_period
         """,
         params,
     ).fetchall()
@@ -421,7 +427,7 @@ def cost_analytics(
             continue
         breakdown = _breakdown(row)
         used = any(getattr(breakdown, c) for c in _CATEGORIES)
-        price = match_price(table, row["model"])
+        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
         usd = cost_usd(price, breakdown) if price else 0.0
         label = row["model"] or "unknown"
         if price is None and used and row["model"]:
@@ -490,18 +496,18 @@ def cost_analytics(
     over_time: dict[str, dict[str, Any]] = {}
     for row in conn.execute(
         f"""
-        SELECT {bucket_expr} AS bucket, m.model AS model, {cols}
+        SELECT {bucket_expr} AS bucket, m.model AS model, ({period_expr}) AS price_period, {cols}
         FROM messages m
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
         {where}
-        GROUP BY bucket, m.model
+        GROUP BY bucket, m.model, price_period
         """,
         params,
     ).fetchall():
         if row["bucket"] is None or not matches(row["model"]):
             continue
-        price = match_price(table, row["model"])
+        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
         if price is None:
             continue
         usd = cost_usd(price, _breakdown(row))
@@ -516,6 +522,7 @@ def cost_analytics(
         f"""
         SELECT s.id AS id, s.session_id AS session_id, s.title AS title,
                p.export_name AS project_name, p.inferred_cwd AS project_cwd, m.model AS model,
+               ({period_expr}) AS price_period,
                COALESCE(ss.turn_count, 0) AS turn_count,
                COALESCE(ss.tool_call_count, 0) AS tool_call_count,
                COALESCE(ss.subagent_count, 0) AS subagent_count,
@@ -536,13 +543,13 @@ def cost_analytics(
         JOIN projects p ON p.id = s.project_id
         LEFT JOIN session_stats ss ON ss.session_id = s.id
         {where}
-        GROUP BY s.id, m.model
+        GROUP BY s.id, m.model, price_period
         """,
         params,
     ).fetchall():
         if not matches(row["model"]):
             continue
-        price = match_price(table, row["model"])
+        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
         usd = cost_usd(price, _breakdown(row)) if price else 0.0
         s = sessions.setdefault(
             row["id"],
@@ -565,19 +572,20 @@ def cost_analytics(
     for row in conn.execute(
         f"""
         SELECT {bucket_expr} AS bucket, s.id AS id, s.session_id AS session_id, s.title AS title,
-               p.export_name AS project_name, p.inferred_cwd AS project_cwd, m.model AS model, {cols}
+               p.export_name AS project_name, p.inferred_cwd AS project_cwd, m.model AS model,
+               ({period_expr}) AS price_period, {cols}
         FROM messages m
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
         JOIN projects p ON p.id = s.project_id
         {where}
-        GROUP BY bucket, s.id, m.model
+        GROUP BY bucket, s.id, m.model, price_period
         """,
         params,
     ).fetchall():
         if row["bucket"] is None or not matches(row["model"]):
             continue
-        price = match_price(table, row["model"])
+        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
         usd = cost_usd(price, _breakdown(row)) if price else 0.0
         if usd == 0:
             continue
@@ -656,11 +664,12 @@ def cost_analytics(
     )
     turn_costs = _turn_cost_stats(
         conn,
-        table,
+        timeline,
         where=where,
         params=params,
         project_id=project_id,
         matches=matches,
+        historical=historical,
     )
     for session in sessions_out:
         session["turn_cost_stats"] = turn_costs.get(session["id"], _turn_cost_stat([]))
@@ -723,7 +732,7 @@ def cost_analytics(
 
     return {
         "meta": {
-            "available": bool(table),
+            "available": price_available,
             "unpriced_models": sorted(unpriced),
             "total_usd": round(total_usd, 6),
             "total_tokens": total_tokens,

--- a/backend/src/ccfr/api/analytics.py
+++ b/backend/src/ccfr/api/analytics.py
@@ -382,6 +382,9 @@ def cost_analytics(
     where, params = _where(date_from, date_to, project_id)
     cols = _token_sum_select()
 
+    def _price(period: int | None, model_id: str | None) -> ModelPrice | None:
+        return match_price(timeline.table_for_period(period, historical=historical), model_id)
+
     def matches(raw: str | None) -> bool:
         return model_key is None or normalize_model_key(raw or "") == model_key
 
@@ -427,7 +430,7 @@ def cost_analytics(
             continue
         breakdown = _breakdown(row)
         used = any(getattr(breakdown, c) for c in _CATEGORIES)
-        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
+        price = _price(row["price_period"], row["model"])
         usd = cost_usd(price, breakdown) if price else 0.0
         label = row["model"] or "unknown"
         if price is None and used and row["model"]:
@@ -507,7 +510,7 @@ def cost_analytics(
     ).fetchall():
         if row["bucket"] is None or not matches(row["model"]):
             continue
-        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
+        price = _price(row["price_period"], row["model"])
         if price is None:
             continue
         usd = cost_usd(price, _breakdown(row))
@@ -549,7 +552,7 @@ def cost_analytics(
     ).fetchall():
         if not matches(row["model"]):
             continue
-        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
+        price = _price(row["price_period"], row["model"])
         usd = cost_usd(price, _breakdown(row)) if price else 0.0
         s = sessions.setdefault(
             row["id"],
@@ -585,7 +588,7 @@ def cost_analytics(
     ).fetchall():
         if row["bucket"] is None or not matches(row["model"]):
             continue
-        price = match_price(timeline.table_for_period(row["price_period"], historical=historical), row["model"])
+        price = _price(row["price_period"], row["model"])
         usd = cost_usd(price, _breakdown(row)) if price else 0.0
         if usd == 0:
             continue

--- a/backend/src/ccfr/api/deps.py
+++ b/backend/src/ccfr/api/deps.py
@@ -19,5 +19,13 @@ def get_db() -> Iterator[Connection]:
         conn.close()
 
 
-def get_historical_pricing() -> bool:
+def get_historical_pricing(historical: bool | None = None) -> bool:
+    """Resolve the pricing mode for a request.
+
+    An explicit ``?historical=`` query param wins so the request URL encodes the
+    mode (two modes never share one cacheable URL); absent it, the persisted
+    server-side setting applies.
+    """
+    if historical is not None:
+        return historical
     return read_settings().historical_pricing

--- a/backend/src/ccfr/api/deps.py
+++ b/backend/src/ccfr/api/deps.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from sqlite3 import Connection
 
 from ccfr.config import database_path
+from ccfr.settings import read_settings
 from ccfr.storage import connect
 
 
@@ -16,9 +17,6 @@ def get_db() -> Iterator[Connection]:
         yield conn
     finally:
         conn.close()
-
-
-from ccfr.settings import read_settings
 
 
 def get_historical_pricing() -> bool:

--- a/backend/src/ccfr/api/deps.py
+++ b/backend/src/ccfr/api/deps.py
@@ -16,3 +16,10 @@ def get_db() -> Iterator[Connection]:
         yield conn
     finally:
         conn.close()
+
+
+from ccfr.settings import read_settings
+
+
+def get_historical_pricing() -> bool:
+    return read_settings().historical_pricing

--- a/backend/src/ccfr/api/repository.py
+++ b/backend/src/ccfr/api/repository.py
@@ -7,28 +7,30 @@ from typing import Any
 from ccfr.analysis.pricing import (
     TokenBreakdown,
     cost_usd,
-    load_price_table,
+    load_price_timeline,
     match_price,
 )
 from ccfr.analysis.trace import build_trace
 from ccfr.naming import project_display_name
-from ccfr.config import pricing_path
+from ccfr.config import pricing_dir, pricing_path
 
 _COST_CATEGORIES = ("base_input", "cache_write_5m", "cache_write_1h", "cache_read", "output")
 
 
-def session_cost(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
+def session_cost(conn: sqlite3.Connection, session_id: int, *, historical: bool = True) -> dict[str, Any]:
     """Estimate the session's dollar cost from per-model token breakdowns.
 
-    Tokens are grouped by model and priced via pricing.csv (per million). Models with
-    usage but no price row are reported in ``unpriced_models`` so the UI can flag that
-    the estimate is partial. When no price table is available, ``available`` is False.
+    Tokens are grouped by model and price-period and priced via the PriceTimeline
+    (per million). Models with usage but no price row are reported in
+    ``unpriced_models``. When no price table is available, ``available`` is False.
     """
-    table = load_price_table(pricing_path())
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    period_expr = timeline.sql_period_expr("e.timestamp", historical=historical)
     rows = conn.execute(
-        """
+        f"""
         SELECT
             m.model AS model,
+            ({period_expr}) AS price_period,
             COALESCE(SUM(m.base_input_tokens), 0) AS base_input,
             COALESCE(SUM(m.cache_5m_tokens), 0) AS cache_write_5m,
             COALESCE(SUM(m.cache_1h_tokens), 0) AS cache_write_1h,
@@ -37,7 +39,7 @@ def session_cost(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
         FROM messages m
         JOIN events e ON e.id = m.event_id
         WHERE e.session_id = ?
-        GROUP BY m.model
+        GROUP BY m.model, price_period
         """,
         (session_id,),
     ).fetchall()
@@ -50,6 +52,7 @@ def session_cost(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
         used = any(getattr(breakdown, category) for category in _COST_CATEGORIES)
         for category in _COST_CATEGORIES:
             tokens_total[category] += getattr(breakdown, category)
+        table = timeline.table_for_period(row["price_period"], historical=historical)
         price = match_price(table, row["model"])
         if price is None:
             if used and row["model"]:
@@ -59,25 +62,25 @@ def session_cost(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
 
     return {
         "usd": round(total_usd, 6),
-        "available": bool(table),
+        "available": timeline.has_prices,
         "unpriced_models": sorted(unpriced),
         "tokens": tokens_total,
     }
 
 
-def session_cost_map(conn: sqlite3.Connection) -> tuple[dict[int, float], bool]:
-    """Estimate every session's dollar cost in one pass.
+def session_cost_map(conn: sqlite3.Connection, *, historical: bool = True) -> tuple[dict[int, float], bool]:
+    """Estimate every session's dollar cost in one pass, priced by each session's date.
 
-    Returns ``({session_id: usd}, available)``. ``available`` is False when no price
-    table is loaded; sessions whose models are all unpriced are simply absent from the
-    map (treated as 0 by callers). Costs are rounded to match :func:`session_cost`.
+    Returns ``({session_id: usd}, available)``.
     """
-    table = load_price_table(pricing_path())
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    period_expr = timeline.sql_period_expr("e.timestamp", historical=historical)
     rows = conn.execute(
-        """
+        f"""
         SELECT
             e.session_id AS session_id,
             m.model AS model,
+            ({period_expr}) AS price_period,
             COALESCE(SUM(m.base_input_tokens), 0) AS base_input,
             COALESCE(SUM(m.cache_5m_tokens), 0) AS cache_write_5m,
             COALESCE(SUM(m.cache_1h_tokens), 0) AS cache_write_1h,
@@ -85,23 +88,24 @@ def session_cost_map(conn: sqlite3.Connection) -> tuple[dict[int, float], bool]:
             COALESCE(SUM(m.output_tokens), 0) AS output
         FROM messages m
         JOIN events e ON e.id = m.event_id
-        GROUP BY e.session_id, m.model
+        GROUP BY e.session_id, m.model, price_period
         """
     ).fetchall()
 
     costs: dict[int, float] = {}
     for row in rows:
+        table = timeline.table_for_period(row["price_period"], historical=historical)
         price = match_price(table, row["model"])
         if price is None:
             continue
         breakdown = TokenBreakdown(**{category: int(row[category]) for category in _COST_CATEGORIES})
         costs[row["session_id"]] = costs.get(row["session_id"], 0.0) + cost_usd(price, breakdown)
-    return {sid: round(usd, 6) for sid, usd in costs.items()}, bool(table)
+    return {sid: round(usd, 6) for sid, usd in costs.items()}, timeline.has_prices
 
 
-def project_cost_map(conn: sqlite3.Connection) -> tuple[dict[int, float], bool]:
+def project_cost_map(conn: sqlite3.Connection, *, historical: bool = True) -> tuple[dict[int, float], bool]:
     """Aggregate session costs to ``({project_id: usd}, available)``."""
-    session_costs, available = session_cost_map(conn)
+    session_costs, available = session_cost_map(conn, historical=historical)
     project_costs: dict[int, float] = {}
     if session_costs:
         for row in conn.execute("SELECT id, project_id FROM sessions").fetchall():
@@ -173,7 +177,7 @@ def import_summary_stats(conn: sqlite3.Connection, import_id: int) -> dict[str, 
     return {key: int(conn.execute(sql, (import_id,)).fetchone()[0]) for key, sql in counts.items()}
 
 
-def list_projects(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+def list_projects(conn: sqlite3.Connection, *, historical: bool = True) -> list[dict[str, Any]]:
     rows = conn.execute(
         """
         SELECT
@@ -191,7 +195,7 @@ def list_projects(conn: sqlite3.Connection) -> list[dict[str, Any]]:
         ORDER BY p.export_name
         """
     ).fetchall()
-    costs, available = project_cost_map(conn)
+    costs, available = project_cost_map(conn, historical=historical)
     projects = rows_to_dicts(rows)
     for project in projects:
         project["display_name"] = project_display_name(project["export_name"], project["inferred_cwd"])
@@ -211,6 +215,7 @@ def list_sessions(
     date_from: str | None = None,
     date_to: str | None = None,
     with_cost: bool = True,
+    historical: bool = True,
 ) -> list[dict[str, Any]]:
     clauses: list[str] = []
     params: list[Any] = []
@@ -311,7 +316,7 @@ def list_sessions(
         params,
     ).fetchall()
     sessions = rows_to_dicts(rows)
-    costs, available = session_cost_map(conn) if with_cost else ({}, False)
+    costs, available = session_cost_map(conn, historical=historical) if with_cost else ({}, False)
     for session in sessions:
         session["project_name"] = project_display_name(
             session["project_name"], session.pop("project_cwd", None) or session.get("cwd"),
@@ -386,7 +391,7 @@ def get_timeline(conn: sqlite3.Connection, session_id: int) -> list[dict[str, An
 
 
 
-def get_trace(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
+def get_trace(conn: sqlite3.Connection, session_id: int, *, historical: bool = True) -> dict[str, Any]:
     rows = conn.execute(
         """
         SELECT
@@ -466,7 +471,7 @@ def get_trace(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
             }
         )
     trace = build_trace(session_id=session_id, rows=normalized, result_ts_by_use_id=result_ts)
-    trace["cost"] = session_cost(conn, session_id)
+    trace["cost"] = session_cost(conn, session_id, historical=historical)
     return trace
 
 

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlite3 import Connection
 
 from ccfr.api import analytics, repository
-from ccfr.api.deps import get_db
+from ccfr.api.deps import get_db, get_historical_pricing
 from ccfr.api.import_progress import import_progress_store
 from ccfr.settings import Settings, read_settings, write_settings
 from ccfr.analysis.context_economics import (
@@ -160,8 +160,11 @@ def get_stats(conn: Connection = Depends(get_db)) -> CacheStatsResponse:
 
 
 @router.get("/projects", response_model=list[ProjectResponse])
-def list_projects(conn: Connection = Depends(get_db)) -> list[ProjectResponse]:
-    return [ProjectResponse(**row) for row in repository.list_projects(conn)]
+def list_projects(
+    conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
+) -> list[ProjectResponse]:
+    return [ProjectResponse(**row) for row in repository.list_projects(conn, historical=historical)]
 
 
 @router.get("/sessions", response_model=list[SessionCard])
@@ -173,6 +176,7 @@ def list_sessions(
     date_from: str | None = None,
     date_to: str | None = None,
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> list[SessionCard]:
     rows = repository.list_sessions(
         conn,
@@ -182,6 +186,7 @@ def list_sessions(
         has_errors=has_errors,
         date_from=date_from,
         date_to=date_to,
+        historical=historical,
     )
     return [SessionCard(**row) for row in rows]
 
@@ -203,17 +208,25 @@ def get_timeline(session_id: int, conn: Connection = Depends(get_db)) -> list[Ti
 
 
 @router.get("/sessions/{session_id}/trace", response_model=TraceResponse)
-def get_trace(session_id: int, conn: Connection = Depends(get_db)) -> TraceResponse:
+def get_trace(
+    session_id: int,
+    conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
+) -> TraceResponse:
     if repository.get_session(conn, session_id) is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    return TraceResponse(**repository.get_trace(conn, session_id))
+    return TraceResponse(**repository.get_trace(conn, session_id, historical=historical))
 
 
 @router.get("/sessions/{session_id}/turn-costs", response_model=TurnCostBreakdown)
-def get_turn_costs(session_id: int, conn: Connection = Depends(get_db)) -> TurnCostBreakdown:
+def get_turn_costs(
+    session_id: int,
+    conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
+) -> TurnCostBreakdown:
     if repository.get_session(conn, session_id) is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    return TurnCostBreakdown(**analytics.session_turn_cost_breakdown(conn, session_id))
+    return TurnCostBreakdown(**analytics.session_turn_cost_breakdown(conn, session_id, historical=historical))
 
 
 @router.get("/sessions/{session_id}/subagents", response_model=list[SubagentResponse])
@@ -259,10 +272,12 @@ def get_cost_analytics(
     project_id: int | None = None,
     model: str | None = None,
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> CostAnalyticsResponse:
     return CostAnalyticsResponse(
         **analytics.cost_analytics(
-            conn, date_from=date_from, date_to=date_to, project_id=project_id, model=model
+            conn, date_from=date_from, date_to=date_to, project_id=project_id, model=model,
+            historical=historical,
         )
     )
 

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from sqlite3 import Connection
 from ccfr.api import analytics, repository
 from ccfr.api.deps import get_db
 from ccfr.api.import_progress import import_progress_store
+from ccfr.settings import Settings, read_settings, write_settings
 from ccfr.analysis.context_economics import (
     context_economics_analytics,
     session_context_economics,
@@ -32,6 +34,7 @@ from ccfr.api.schemas import (
     SearchResult,
     SessionCard,
     SessionContextEconomicsResponse,
+    SettingsResponse,
     SubagentResponse,
     TimelineItem,
     TurnCostBreakdown,
@@ -83,6 +86,17 @@ def get_config() -> RuntimeConfigResponse:
         database_path=str(database_path()),
         is_docker=is_docker(),
     )
+
+
+@router.get("/settings", response_model=SettingsResponse)
+def get_settings() -> SettingsResponse:
+    return SettingsResponse(**asdict(read_settings()))
+
+
+@router.put("/settings", response_model=SettingsResponse)
+def update_settings(payload: SettingsResponse) -> SettingsResponse:
+    saved = write_settings(Settings(historical_pricing=payload.historical_pricing))
+    return SettingsResponse(**asdict(saved))
 
 
 @router.post("/imports", response_model=ImportSummaryResponse)

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -287,9 +287,10 @@ def get_discovery_analytics(
     project_id: int | None = None,
     min_support: int = Query(default=5, ge=1),
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> DiscoveryResponse:
     return DiscoveryResponse(
-        **discovery_analytics(conn, project_id=project_id, min_support=min_support)
+        **discovery_analytics(conn, project_id=project_id, min_support=min_support, historical=historical)
     )
 
 
@@ -298,9 +299,10 @@ def get_context_economics(
     project_id: int | None = None,
     min_support: int = Query(default=3, ge=1),
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> ContextEconomicsResponse:
     return ContextEconomicsResponse(
-        **context_economics_analytics(conn, project_id=project_id, min_support=min_support)
+        **context_economics_analytics(conn, project_id=project_id, min_support=min_support, historical=historical)
     )
 
 
@@ -309,8 +311,9 @@ def get_context_economics(
 def get_session_context_economics(
     session_id: int,
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> SessionContextEconomicsResponse:
-    return SessionContextEconomicsResponse(**session_context_economics(conn, session_id))
+    return SessionContextEconomicsResponse(**session_context_economics(conn, session_id, historical=historical))
 
 
 @router.get("/analytics/usage-map", response_model=UsageMapResponse)
@@ -319,10 +322,11 @@ def get_usage_map(
     date_from: str | None = None,
     date_to: str | None = None,
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> UsageMapResponse:
     return UsageMapResponse(
         **usage_map_analytics(conn, project_id=project_id,
-                              date_from=date_from, date_to=date_to)
+                              date_from=date_from, date_to=date_to, historical=historical)
     )
 
 
@@ -333,10 +337,11 @@ def get_usage_map_evidence(
     date_from: str | None = None,
     date_to: str | None = None,
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> UsageMapEvidenceResponse:
     try:
         payload = usage_map_evidence(conn, node=node, project_id=project_id,
-                                     date_from=date_from, date_to=date_to)
+                                     date_from=date_from, date_to=date_to, historical=historical)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=f"Unknown node: {node}") from exc
     return UsageMapEvidenceResponse(**payload)
@@ -348,8 +353,9 @@ def get_usage_characteristics(
     date_from: str | None = None,
     date_to: str | None = None,
     conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
 ) -> UsageCharacteristicsResponse:
     return UsageCharacteristicsResponse(
         **usage_characteristics_analytics(conn, project_id=project_id,
-                                          date_from=date_from, date_to=date_to)
+                                          date_from=date_from, date_to=date_to, historical=historical)
     )

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -16,6 +16,10 @@ class RuntimeConfigResponse(BaseModel):
     is_docker: bool = False
 
 
+class SettingsResponse(BaseModel):
+    historical_pricing: bool = True
+
+
 class CacheStatsResponse(BaseModel):
     project_count: int
     session_count: int

--- a/backend/src/ccfr/config.py
+++ b/backend/src/ccfr/config.py
@@ -50,6 +50,11 @@ def pricing_path() -> Path:
     return Path(os.getenv("CCFR_PRICING_PATH", str(repository_root() / "pricing.csv")))
 
 
+def pricing_dir() -> Path:
+    """Directory of dated price snapshots (pricing-YYYY-MM-DD.csv) layered over pricing.csv."""
+    return Path(os.getenv("CCFR_PRICING_DIR", str(repository_root() / "pricing")))
+
+
 def allowed_origins() -> list[str]:
     """CORS origins permitted to call the API.
 

--- a/backend/src/ccfr/settings.py
+++ b/backend/src/ccfr/settings.py
@@ -1,0 +1,41 @@
+"""Small persisted app settings (data_dir/settings.json).
+
+Lives outside the rebuildable SQLite DB so it survives `reset_db`. The only
+setting today is the historical-pricing toggle.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from ccfr.config import data_dir
+
+
+@dataclass
+class Settings:
+    historical_pricing: bool = True
+
+
+def _settings_path() -> Path:
+    return data_dir() / "settings.json"
+
+
+def read_settings() -> Settings:
+    path = _settings_path()
+    if not path.exists():
+        return Settings()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return Settings()
+    if not isinstance(raw, dict):
+        return Settings()
+    return Settings(historical_pricing=bool(raw.get("historical_pricing", True)))
+
+
+def write_settings(settings: Settings) -> Settings:
+    path = _settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(settings), indent=2), encoding="utf-8")
+    return settings

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+import ccfr.settings as settings_mod
+
+
+@pytest.fixture(autouse=True)
+def isolate_ambient_pricing_state(tmp_path, monkeypatch):
+    """Keep tests independent of real on-disk pricing/settings state.
+
+    Cost-bearing tests historically patched ``pricing_path`` but not
+    ``pricing_dir``, so a real ``pricing/`` snapshot directory (or a
+    ``.ccfr-data/settings.json`` written by the running app) silently changed
+    their results. Default both to throwaway locations; a test that needs dated
+    snapshots or a specific setting overrides these afterward (later monkeypatch
+    wins), so opt-in behavior is unaffected.
+    """
+    monkeypatch.setenv("CCFR_PRICING_DIR", str(tmp_path / "_ambient_no_pricing"))
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path / "_ambient_data")

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -366,6 +366,46 @@ def test_cost_analytics_prices_by_period(monkeypatch, tmp_path):
     assert round(off["meta"]["total_usd"], 2) == 10.0
 
 
+def test_cost_analytics_tolerates_null_event_timestamp(monkeypatch, tmp_path):
+    import math
+
+    from ccfr.api import analytics
+
+    conn = _conn_two_dated_opus(tmp_path)
+    # A third session/event whose events.timestamp is NULL: with historical pricing ON and a
+    # snapshot present, sql_period_expr yields a NULL price_period for this row. The request
+    # must not crash on int(None) — the unknown date falls back to the oldest (baseline) table.
+    conn.execute("INSERT INTO sessions(project_id, session_id, first_ts, last_ts) "
+                 "VALUES(1, 's3', NULL, NULL)")
+    conn.execute("INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json) "
+                 "VALUES(3, 'f', 3, 'assistant', NULL, '{}')")
+    conn.execute("INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens) "
+                 "VALUES(3, 'assistant', 'claude-opus-4-1', 1000000, 0)")
+    conn.commit()
+
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,75\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,25\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(analytics, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(analytics, "pricing_dir", lambda: sheets)
+
+    payload = analytics.cost_analytics(conn, historical=True)
+    total = payload["meta"]["total_usd"]
+    assert math.isfinite(total)
+    # $15 (Jan) + $5 (Aug) + $15 (NULL -> baseline fallback) = $35.
+    assert round(total, 2) == 35.0
+
+
 def test_cost_analytics_sums_multi_model_session(seeded: sqlite3.Connection) -> None:
     # Add a second model's usage to the FIRST session and re-query.
     s1_id = next(

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -320,6 +320,52 @@ def test_cost_analytics_uses_leaf_folder_name_when_cwd_known(seeded: sqlite3.Con
     assert "agent-dashboard" in {s["project_name"] for s in payload["sessions"]}
 
 
+def _conn_two_dated_opus(tmp_path):
+    """One project, two assistant messages (1M base-input each) on claude-opus-4-1,
+    dated Jan 2026 and Aug 2026 — straddling a 2026-07-01 price change."""
+    from ccfr.storage import connect, init_db
+    conn = connect(tmp_path / "ca.sqlite3")
+    init_db(conn)
+    conn.execute("INSERT INTO imports(source_path, imported_at, status) VALUES('x','x','done')")
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, ts in enumerate(["2026-01-15T10:00:00Z", "2026-08-15T10:00:00Z"], start=1):
+        conn.execute("INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+                     (f"s{sid}", ts, ts))
+        conn.execute("INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json) "
+                     "VALUES(?,?,?,?,?,'{}')", (sid, "f", sid, "assistant", ts))
+        conn.execute("INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens) "
+                     "VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)", (sid,))
+    conn.commit()
+    return conn
+
+
+def test_cost_analytics_prices_by_period(monkeypatch, tmp_path):
+    from ccfr.api import analytics
+
+    conn = _conn_two_dated_opus(tmp_path)
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,75\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,25\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(analytics, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(analytics, "pricing_dir", lambda: sheets)
+
+    on = analytics.cost_analytics(conn, historical=True)
+    off = analytics.cost_analytics(conn, historical=False)
+    # ON: $15 (Jan) + $5 (Aug) = $20. OFF: both at current $5 = $10.
+    assert round(on["meta"]["total_usd"], 2) == 20.0
+    assert round(off["meta"]["total_usd"], 2) == 10.0
+
+
 def test_cost_analytics_sums_multi_model_session(seeded: sqlite3.Connection) -> None:
     # Add a second model's usage to the FIRST session and re-query.
     s1_id = next(

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from ccfr.api import analytics
 from ccfr.api.deps import get_db
+from ccfr import settings as settings_mod
 from ccfr.main import create_app
 from ccfr.storage import init_db
 from tests.test_analytics import _seed  # reuse the deterministic seed
@@ -58,3 +59,70 @@ def test_session_turn_costs_endpoint_returns_breakdown(client: TestClient) -> No
     assert body["session_id"] == 1
     assert body["turn_count"] == 1
     assert body["turns"][0]["title"] == "Turn 1"
+
+
+@pytest.fixture()
+def toggle_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Client seeded with two claude-opus-4-1 messages straddling a 2026-07-01 price change."""
+    # --- pricing setup ---
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(analytics, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(analytics, "pricing_dir", lambda: sheets)
+
+    # --- settings isolation: write_settings → tmp_path/settings.json ---
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+
+    # --- DB setup: two sessions, 1M base-input each, Jan + Aug 2026, claude-opus-4-1 ---
+    monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+
+    conn.execute(
+        "INSERT INTO imports(source_path, imported_at, status) VALUES('x','2026-01-01T00:00:00Z','done')"
+    )
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, ts in enumerate(["2026-01-15T10:00:00Z", "2026-08-15T10:00:00Z"], start=1):
+        conn.execute(
+            "INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+            (f"s{sid}", ts, ts),
+        )
+        conn.execute(
+            "INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json)"
+            " VALUES(?,?,?,?,?,'{}') ",
+            (sid, "f", sid, "assistant", ts),
+        )
+        conn.execute(
+            "INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens)"
+            " VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)",
+            (sid,),
+        )
+    conn.commit()
+
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: conn
+    with TestClient(app) as c:
+        yield c
+    conn.close()
+
+
+def test_cost_analytics_toggle_honors_historical_setting(toggle_client: TestClient) -> None:
+    toggle_client.put("/api/settings", json={"historical_pricing": True})
+    on = toggle_client.get("/api/analytics/cost").json()
+    toggle_client.put("/api/settings", json={"historical_pricing": False})
+    off = toggle_client.get("/api/analytics/cost").json()
+    # historical ON: Jan @ $15 + Aug @ $5 = $20; OFF: both at current $5 = $10
+    assert round(on["meta"]["total_usd"], 2) == 20.0
+    assert round(off["meta"]["total_usd"], 2) == 10.0

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -129,6 +129,18 @@ def test_cost_analytics_toggle_honors_historical_setting(toggle_client: TestClie
     assert round(off["meta"]["total_usd"], 2) == 10.0
 
 
+def test_cost_analytics_query_param_overrides_persisted_setting(toggle_client: TestClient) -> None:
+    # An explicit ?historical= wins over the persisted setting so the request URL
+    # itself encodes the mode (no two modes share a cacheable URL).
+    toggle_client.put("/api/settings", json={"historical_pricing": True})
+    off = toggle_client.get("/api/analytics/cost", params={"historical": "false"}).json()
+    on = toggle_client.get("/api/analytics/cost", params={"historical": "true"}).json()
+    assert round(off["meta"]["total_usd"], 2) == 10.0  # current rate for both
+    assert round(on["meta"]["total_usd"], 2) == 20.0  # date-effective
+    # No param → falls back to the persisted setting (ON → 20).
+    assert round(toggle_client.get("/api/analytics/cost").json()["meta"]["total_usd"], 2) == 20.0
+
+
 @pytest.fixture()
 def usage_map_toggle_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Client seeded identically to toggle_client but with usage_map pricing monkeypatched."""

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from ccfr.api import analytics
+from ccfr.analysis import usage_map
 from ccfr.api.deps import get_db
 from ccfr import settings as settings_mod
 from ccfr.main import create_app
@@ -123,6 +124,81 @@ def test_cost_analytics_toggle_honors_historical_setting(toggle_client: TestClie
     on = toggle_client.get("/api/analytics/cost").json()
     toggle_client.put("/api/settings", json={"historical_pricing": False})
     off = toggle_client.get("/api/analytics/cost").json()
+    # historical ON: Jan @ $15 + Aug @ $5 = $20; OFF: both at current $5 = $10
+    assert round(on["meta"]["total_usd"], 2) == 20.0
+    assert round(off["meta"]["total_usd"], 2) == 10.0
+
+
+@pytest.fixture()
+def usage_map_toggle_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Client seeded identically to toggle_client but with usage_map pricing monkeypatched."""
+    # --- pricing setup: baseline $15/M, post-2026-07-01 sheet $5/M ---
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    # Monkeypatch the usage_map module's imported callables (it does
+    # `from ccfr.config import pricing_path, pricing_dir` so we must patch
+    # the names on the usage_map module, not on ccfr.config).
+    monkeypatch.setattr(usage_map, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(usage_map, "pricing_dir", lambda: sheets)
+    # Also patch analytics for routes that still call analytics.*
+    monkeypatch.setattr(analytics, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(analytics, "pricing_dir", lambda: sheets)
+
+    # --- settings isolation ---
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+
+    # --- DB: two sessions, 1M base-input each, Jan + Aug 2026, claude-opus-4-1 ---
+    monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+
+    conn.execute(
+        "INSERT INTO imports(source_path, imported_at, status) VALUES('x','2026-01-01T00:00:00Z','done')"
+    )
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, ts in enumerate(["2026-01-15T10:00:00Z", "2026-08-15T10:00:00Z"], start=1):
+        conn.execute(
+            "INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+            (f"s{sid}", ts, ts),
+        )
+        conn.execute(
+            "INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json)"
+            " VALUES(?,?,?,?,?,'{}') ",
+            (sid, "f", sid, "assistant", ts),
+        )
+        conn.execute(
+            "INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens)"
+            " VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)",
+            (sid,),
+        )
+    conn.commit()
+
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: conn
+    with TestClient(app) as c:
+        yield c
+    conn.close()
+
+
+def test_usage_map_endpoint_respects_historical_toggle(
+    usage_map_toggle_client: TestClient,
+) -> None:
+    usage_map_toggle_client.put("/api/settings", json={"historical_pricing": True})
+    on = usage_map_toggle_client.get("/api/analytics/usage-map").json()
+    usage_map_toggle_client.put("/api/settings", json={"historical_pricing": False})
+    off = usage_map_toggle_client.get("/api/analytics/usage-map").json()
     # historical ON: Jan @ $15 + Aug @ $5 = $20; OFF: both at current $5 = $10
     assert round(on["meta"]["total_usd"], 2) == 20.0
     assert round(off["meta"]["total_usd"], 2) == 10.0

--- a/backend/tests/test_api_repository.py
+++ b/backend/tests/test_api_repository.py
@@ -115,3 +115,71 @@ def test_get_session_returns_none_for_nonexistent_id(tmp_path: Path) -> None:
 
     result = repository.get_session(conn, 999_999)
     assert result is None
+
+
+from ccfr.storage import connect
+
+
+def _seed_two_dated_sessions(conn):
+    """Two sessions, identical 1M base-input tokens on Opus, on different dates."""
+    init_db(conn)
+    conn.execute("INSERT INTO imports(source_path, imported_at, status) VALUES('x','x','done')")
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, (session_key, ts) in enumerate(
+        {"old": "2026-01-15T10:00:00Z", "new": "2026-08-15T10:00:00Z"}.items(), start=1
+    ):
+        conn.execute(
+            "INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+            (session_key, ts, ts),
+        )
+        conn.execute(
+            "INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json) "
+            "VALUES(?,?,?,?,?,'{}')",
+            (sid, "f", sid, "assistant", ts),
+        )
+        conn.execute(
+            "INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens) "
+            "VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)",
+            (sid,),
+        )
+    conn.commit()
+
+
+def _pricing(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,75\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,25\n",
+        encoding="utf-8",
+    )
+    return baseline, sheets
+
+
+def test_session_cost_prices_by_session_date(monkeypatch, tmp_path):
+    conn = connect(tmp_path / "db.sqlite3")
+    _seed_two_dated_sessions(conn)
+    baseline, sheets = _pricing(tmp_path)
+    monkeypatch.setattr(repository, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(repository, "pricing_dir", lambda: sheets)
+
+    assert repository.session_cost(conn, 1, historical=True)["usd"] == 15.0
+    assert repository.session_cost(conn, 2, historical=True)["usd"] == 5.0
+    assert repository.session_cost(conn, 1, historical=False)["usd"] == 5.0
+
+
+def test_session_cost_map_prices_by_date(monkeypatch, tmp_path):
+    conn = connect(tmp_path / "db.sqlite3")
+    _seed_two_dated_sessions(conn)
+    baseline, sheets = _pricing(tmp_path)
+    monkeypatch.setattr(repository, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(repository, "pricing_dir", lambda: sheets)
+    costs, available = repository.session_cost_map(conn, historical=True)
+    assert available is True
+    assert costs == {1: 15.0, 2: 5.0}

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from ccfr import config
+
+
+def test_pricing_dir_defaults_beside_pricing_csv(monkeypatch):
+    monkeypatch.delenv("CCFR_PRICING_DIR", raising=False)
+    assert config.pricing_dir() == config.repository_root() / "pricing"
+
+
+def test_pricing_dir_env_override(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CCFR_PRICING_DIR", str(tmp_path / "sheets"))
+    assert config.pricing_dir() == tmp_path / "sheets"

--- a/backend/tests/test_context_economics.py
+++ b/backend/tests/test_context_economics.py
@@ -152,7 +152,7 @@ def test_calibrate_many_items_still_sum_to_delta() -> None:
 # ---------------------------------------------------------------------------
 
 from ccfr.analysis.context_economics import ThreadRec, _carry_usd, accrue_tax
-from ccfr.analysis.pricing import ModelPrice
+from ccfr.analysis.pricing import ModelPrice, PriceTimeline
 
 
 PRICE_TABLE = {
@@ -161,6 +161,9 @@ PRICE_TABLE = {
     "claude-sonnet-4-6": ModelPrice(base_input=1, cache_write_5m=1, cache_write_1h=1,
                                     cache_read=1, output=1),
 }
+
+# Wrap the flat table in a no-snapshot timeline for use with the updated API.
+PRICE_TIMELINE = PriceTimeline(PRICE_TABLE, [])
 
 
 def _thread(calls: list[CallRec], items: dict[int, list[RawItem]] | None = None) -> ThreadRec:
@@ -174,7 +177,7 @@ def test_accrue_tax_is_write_once_plus_read_per_carried_call() -> None:
     calls = [_call(1, 10_000), _call(2, 16_000), _call(3, 16_000), _call(4, 16_000)]
     items = {1: [RawItem(kind="tool_result", label="Read a.py", raw_chars=24_000)]}
     thread = _thread(calls, items)
-    priced = accrue_tax(thread, PRICE_TABLE)
+    priced = accrue_tax(thread, PRICE_TIMELINE)
 
     assert priced is True
     read = next(c for c in thread.contributors if c.label == "Read a.py")
@@ -190,7 +193,7 @@ def test_accrue_tax_unknown_model_reports_unpriced() -> None:
     calls = [CallRec(event_id=1, ts=None, model="mystery-model", context_tokens=5_000,
                      output_tokens=0)]
     thread = _thread(calls)
-    assert accrue_tax(thread, PRICE_TABLE) is False
+    assert accrue_tax(thread, PRICE_TIMELINE) is False
     assert thread.contributors[0].accrued_usd == 0.0
 
 
@@ -204,7 +207,7 @@ def test_accrue_tax_mixed_pricing_keeps_known_costs() -> None:
                 context_tokens=14_000, output_tokens=0),
     ]
     thread = _thread(calls)
-    assert accrue_tax(thread, PRICE_TABLE) is False
+    assert accrue_tax(thread, PRICE_TIMELINE) is False
     assert thread.read_prices == [1 / 1e6, 1 / 1e6, 0.0]
     baseline = next(c for c in thread.contributors if c.kind == "baseline")
     # 10k tokens: write at 0 + read at 1 + $0 read at the unpriced call 2.
@@ -214,7 +217,7 @@ def test_accrue_tax_mixed_pricing_keeps_known_costs() -> None:
 def test_carry_usd_is_reads_only_over_the_span() -> None:
     calls = [_call(1, 10_000), _call(2, 12_000), _call(3, 13_000), _call(4, 14_000)]
     thread = _thread(calls)
-    accrue_tax(thread, PRICE_TABLE)
+    accrue_tax(thread, PRICE_TIMELINE)
     # 1000 tokens carried from after call 0 through call 2 = reads at calls 1,2
     # only (no entry write): 1000 * (1 + 1) / 1e6.
     assert _carry_usd(thread, 1_000, 0, 2) == pytest.approx(2_000 / 1e6)
@@ -417,7 +420,7 @@ from ccfr.analysis.context_economics import Claims, detect_rereads
 
 def _priced_thread(calls, items=None) -> ThreadRec:
     thread = _thread(calls, items)
-    accrue_tax(thread, PRICE_TABLE)
+    accrue_tax(thread, PRICE_TIMELINE)
     return thread
 
 
@@ -654,7 +657,7 @@ def _gapped_thread() -> ThreadRec:
         calls.append(CallRec(event_id=9 + j, ts=_ts(minute), model="claude-sonnet-4-6",
                              context_tokens=161_000 + j * 1_000, output_tokens=0))
     thread = _thread(calls)
-    accrue_tax(thread, PRICE_TABLE)
+    accrue_tax(thread, PRICE_TIMELINE)
     return thread
 
 
@@ -696,7 +699,7 @@ def test_detect_stale_continuation_skips_small_resumed_context() -> None:
         CallRec(event_id=2, ts=_ts(200), model="claude-sonnet-4-6",
                 context_tokens=6_000, output_tokens=0),
     ])
-    accrue_tax(small, PRICE_TABLE)
+    accrue_tax(small, PRICE_TIMELINE)
     threads = [small]
     for n in range(9):  # pad so corpus p75 context is large
         threads.append(_priced_thread([_call(1, 200_000), _call(2, 200_000)]))
@@ -721,6 +724,7 @@ def economics_conn(conn: sqlite3.Connection, tmp_path: Path,
         encoding="utf-8",
     )
     monkeypatch.setattr(context_economics, "pricing_path", lambda: csv)
+    monkeypatch.setattr(context_economics, "pricing_dir", lambda: tmp_path / "pricing")
     # Three sessions that each re-read the same file once (clears min_support=3).
     for n in range(3):
         add_session(conn, uuid=f"re-{n}", title=f"Re-reader {n}", calls=[
@@ -784,6 +788,7 @@ def test_corpus_payload_without_pricing_is_token_only(
     conn: sqlite3.Connection, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(context_economics, "pricing_path", lambda: tmp_path / "missing.csv")
+    monkeypatch.setattr(context_economics, "pricing_dir", lambda: tmp_path / "pricing")
     add_session(conn, uuid="np", calls=[{"context": 10_000, "minute": 1}])
     payload = context_economics_analytics(conn)
     assert payload["meta"]["cost_available"] is False
@@ -794,6 +799,7 @@ def test_corpus_payload_without_pricing_is_token_only(
 def test_corpus_payload_empty_db_is_stable(conn: sqlite3.Connection, tmp_path: Path,
                                            monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(context_economics, "pricing_path", lambda: tmp_path / "missing.csv")
+    monkeypatch.setattr(context_economics, "pricing_dir", lambda: tmp_path / "pricing")
     payload = context_economics_analytics(conn)
     assert payload["meta"]["sessions_analyzed"] == 0
     assert [a["findings"] for a in payload["archetypes"]] == [[], [], [], []]
@@ -860,6 +866,7 @@ def test_session_payload_without_pricing_is_token_only(
     conn: sqlite3.Connection, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(context_economics, "pricing_path", lambda: tmp_path / "missing.csv")
+    monkeypatch.setattr(context_economics, "pricing_dir", lambda: tmp_path / "pricing")
     sid = add_session(conn, uuid="nz", calls=[
         {"context": 10_000, "minute": 1}, {"context": 20_000, "minute": 2},
     ])
@@ -920,3 +927,51 @@ def test_context_economics_endpoints(economics_conn: sqlite3.Connection, tmp_pat
     ]
     assert session.status_code == 200
     assert session.json()["threads"][0]["calls"]
+
+
+# ---------------------------------------------------------------------------
+# Historical pricing: period-aware cost totals
+# ---------------------------------------------------------------------------
+
+def _conn_two_dated_opus(tmp_path):
+    """One project, two assistant messages (1M base-input each) on claude-opus-4-1,
+    dated Jan 2026 and Aug 2026 — straddling a 2026-07-01 price change."""
+    from ccfr.storage import connect, init_db
+    conn = connect(tmp_path / "ce.sqlite3")
+    init_db(conn)
+    conn.execute("INSERT INTO imports(source_path, imported_at, status) VALUES('x','x','done')")
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, ts in enumerate(["2026-01-15T10:00:00Z", "2026-08-15T10:00:00Z"], start=1):
+        conn.execute("INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+                     (f"s{sid}", ts, ts))
+        conn.execute("INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json) "
+                     "VALUES(?,?,?,?,?,'{}')", (sid, "f", sid, "assistant", ts))
+        conn.execute("INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens) "
+                     "VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)", (sid,))
+    conn.commit()
+    return conn
+
+
+def test_corpus_total_prices_by_period(monkeypatch, tmp_path):
+    from ccfr.analysis import context_economics as ce
+
+    conn = _conn_two_dated_opus(tmp_path)
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,75\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,25\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ce, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(ce, "pricing_dir", lambda: sheets)
+
+    timeline = ce.load_price_timeline(baseline, sheets)
+    assert round(ce._corpus_total_usd(conn, None, timeline, historical=True), 2) == 20.0
+    assert round(ce._corpus_total_usd(conn, None, timeline, historical=False), 2) == 10.0

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -358,6 +358,50 @@ def test_discovery_empty_db_is_stable(tmp_path: Path, monkeypatch: pytest.Monkey
     assert payload["sections"]["rejections"]["baseline_count"] == 0
 
 
+def _conn_two_dated_opus(tmp_path):
+    """One project, two assistant messages (1M base-input each) on claude-opus-4-1,
+    dated Jan 2026 and Aug 2026 — straddling a 2026-07-01 price change."""
+    from ccfr.storage import connect, init_db
+    conn = connect(tmp_path / "disc.sqlite3")
+    init_db(conn)
+    conn.execute("INSERT INTO imports(source_path, imported_at, status) VALUES('x','x','done')")
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, ts in enumerate(["2026-01-15T10:00:00Z", "2026-08-15T10:00:00Z"], start=1):
+        conn.execute("INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+                     (f"s{sid}", ts, ts))
+        conn.execute("INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json) "
+                     "VALUES(?,?,?,?,?,'{}')", (sid, "f", sid, "assistant", ts))
+        conn.execute("INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens) "
+                     "VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)", (sid,))
+    conn.commit()
+    return conn
+
+
+def test_scoped_session_costs_prices_by_period(monkeypatch, tmp_path):
+    from ccfr.analysis import discovery
+
+    conn = _conn_two_dated_opus(tmp_path)
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,75\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,25\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(discovery, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(discovery, "pricing_dir", lambda: sheets)
+
+    costs, available = discovery._scoped_session_costs(conn, project_id=None, historical=True)
+    assert available is True
+    assert costs == {1: 15.0, 2: 5.0}
+
+
 def test_discovery_endpoint_returns_payload(seeded: tuple[sqlite3.Connection, int, int], tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     conn, alpha, _beta = seeded
     monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from ccfr.analysis.pricing import (
     ModelPrice,
-    PriceTimeline,
     TokenBreakdown,
     cost_usd,
     load_price_table,

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -161,6 +161,19 @@ def test_sql_period_expr(tmp_path):
     assert match_price(timeline.table_for_period(1), "claude-opus-4-1").base_input == 5
 
 
+def test_table_for_period_none_falls_back_to_baseline(tmp_path):
+    # A NULL event timestamp yields a NULL price_period from sql_period_expr; table_for_period
+    # must treat None as period 0 (the oldest/baseline table) rather than crashing on int(None).
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    _write_sheet(sheets / "pricing-2026-07-01.csv", {"Claude-Opus-4.1": 5})
+    timeline = load_price_timeline(baseline, sheets)
+    price = match_price(timeline.table_for_period(None), "claude-opus-4-1")
+    assert price is not None and price.base_input == 15
+
+
 def test_timeline_resolves_across_multiple_snapshots(tmp_path):
     baseline = tmp_path / "pricing.csv"
     _write_sheet(baseline, {"Claude-Opus-4.1": 15})

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 
 from ccfr.analysis.pricing import (
     ModelPrice,
+    PriceTimeline,
     TokenBreakdown,
     cost_usd,
     load_price_table,
+    load_price_timeline,
     match_price,
     normalize_model_key,
 )
@@ -83,14 +86,6 @@ def test_missing_pricing_file_yields_empty_table(tmp_path: Path) -> None:
     assert match_price(table, "claude-opus-4-8") is None
 
 
-from datetime import date
-
-from ccfr.analysis.pricing import (
-    PriceTimeline,
-    load_price_timeline,
-)
-
-
 def _write_sheet(path, model_to_input):
     lines = ["model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens"]
     for model, base in model_to_input.items():
@@ -165,3 +160,27 @@ def test_sql_period_expr(tmp_path):
     assert timeline.sql_period_expr("e.timestamp", historical=False) == "0"
     assert match_price(timeline.table_for_period(0), "claude-opus-4-1").base_input == 15
     assert match_price(timeline.table_for_period(1), "claude-opus-4-1").base_input == 5
+
+
+def test_timeline_resolves_across_multiple_snapshots(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    _write_sheet(sheets / "pricing-2026-07-01.csv", {"Claude-Opus-4.1": 5})
+    _write_sheet(sheets / "pricing-2026-09-01.csv", {"Claude-Opus-4.1": 2})
+    timeline = load_price_timeline(baseline, sheets)
+
+    # (a) boundaries in chronological order
+    assert timeline.boundaries() == [date(2026, 7, 1), date(2026, 9, 1)]
+
+    # (b) before / between / after the two boundaries
+    assert match_price(timeline.table_for("2026-06-01"), "claude-opus-4-1").base_input == 15
+    assert match_price(timeline.table_for("2026-08-01"), "claude-opus-4-1").base_input == 5
+    assert match_price(timeline.table_for("2026-10-01"), "claude-opus-4-1").base_input == 2
+
+    # (c) SQL expr sums both boundary terms
+    expr = timeline.sql_period_expr("e.timestamp")
+    assert "(date(e.timestamp) >= '2026-07-01')" in expr
+    assert "(date(e.timestamp) >= '2026-09-01')" in expr
+    assert " + " in expr

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -81,3 +81,87 @@ def test_missing_pricing_file_yields_empty_table(tmp_path: Path) -> None:
     table = load_price_table(tmp_path / "does-not-exist.csv")
     assert table == {}
     assert match_price(table, "claude-opus-4-8") is None
+
+
+from datetime import date
+
+from ccfr.analysis.pricing import (
+    PriceTimeline,
+    load_price_timeline,
+)
+
+
+def _write_sheet(path, model_to_input):
+    lines = ["model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens"]
+    for model, base in model_to_input.items():
+        lines.append(f"{model},{base},0,0,0,{base * 5}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_timeline_with_no_dir_is_just_baseline(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    timeline = load_price_timeline(baseline, tmp_path / "missing")
+    assert timeline.boundaries() == []
+    assert match_price(timeline.table_for("2026-01-01"), "claude-opus-4-1").base_input == 15
+    assert match_price(timeline.current_table(), "claude-opus-4-1").base_input == 15
+
+
+def test_timeline_resolves_by_date(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    _write_sheet(sheets / "pricing-2026-07-01.csv", {"Claude-Opus-4.1": 5})
+    timeline = load_price_timeline(baseline, sheets)
+
+    assert timeline.boundaries() == [date(2026, 7, 1)]
+    assert match_price(timeline.table_for("2026-06-30T23:00:00Z"), "claude-opus-4-1").base_input == 15
+    assert match_price(timeline.table_for("2026-07-01T00:00:00Z"), "claude-opus-4-1").base_input == 5
+    assert match_price(timeline.current_table(), "claude-opus-4-1").base_input == 5
+
+
+def test_timeline_partial_snapshot_inherits_baseline(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15, "Claude-Sonnet-4.5": 3})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    _write_sheet(sheets / "pricing-2026-07-01.csv", {"Claude-Opus-4.1": 5})
+    timeline = load_price_timeline(baseline, sheets)
+    table = timeline.table_for("2026-08-01")
+    assert match_price(table, "claude-opus-4-1").base_input == 5
+    assert match_price(table, "claude-sonnet-4-5").base_input == 3
+
+
+def test_timeline_historical_false_uses_current(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    _write_sheet(sheets / "pricing-2026-07-01.csv", {"Claude-Opus-4.1": 5})
+    timeline = load_price_timeline(baseline, sheets)
+    assert match_price(timeline.table_for("2026-01-01", historical=False), "claude-opus-4-1").base_input == 5
+
+
+def test_timeline_skips_malformed_filenames(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "notes.txt").write_text("ignore me", encoding="utf-8")
+    _write_sheet(sheets / "pricing-bad.csv", {"Claude-Opus-4.1": 1})
+    timeline = load_price_timeline(baseline, sheets)
+    assert timeline.boundaries() == []
+
+
+def test_sql_period_expr(tmp_path):
+    baseline = tmp_path / "pricing.csv"
+    _write_sheet(baseline, {"Claude-Opus-4.1": 15})
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    _write_sheet(sheets / "pricing-2026-07-01.csv", {"Claude-Opus-4.1": 5})
+    timeline = load_price_timeline(baseline, sheets)
+    assert timeline.sql_period_expr("e.timestamp") == "((date(e.timestamp) >= '2026-07-01'))"
+    assert timeline.sql_period_expr("e.timestamp", historical=False) == "0"
+    assert match_price(timeline.table_for_period(0), "claude-opus-4-1").base_input == 15
+    assert match_price(timeline.table_for_period(1), "claude-opus-4-1").base_input == 5

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,20 @@
+from ccfr import settings as settings_mod
+from ccfr.settings import Settings, read_settings, write_settings
+
+
+def test_defaults_when_file_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    assert read_settings() == Settings(historical_pricing=True)
+
+
+def test_round_trip(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    write_settings(Settings(historical_pricing=False))
+    assert read_settings().historical_pricing is False
+    assert (tmp_path / "settings.json").exists()
+
+
+def test_corrupt_file_falls_back_to_defaults(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    (tmp_path / "settings.json").write_text("{not json", encoding="utf-8")
+    assert read_settings() == Settings(historical_pricing=True)

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from ccfr import settings as settings_mod
+from ccfr.main import app
+
+
+def test_settings_get_default_and_put_round_trip(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    client = TestClient(app)
+
+    got = client.get("/api/settings")
+    assert got.status_code == 200
+    assert got.json() == {"historical_pricing": True}
+
+    put = client.put("/api/settings", json={"historical_pricing": False})
+    assert put.status_code == 200
+    assert put.json() == {"historical_pricing": False}
+
+    assert client.get("/api/settings").json() == {"historical_pricing": False}

--- a/backend/tests/test_usage_characteristics.py
+++ b/backend/tests/test_usage_characteristics.py
@@ -158,52 +158,73 @@ def _add(conn, event_id, session_id, *, agent_id=None, base=200_000, out=40_000,
     conn.commit()
 
 
-PRICE = {"claude-opus-4-8": um.ModelPrice(base_input=5, cache_write_5m=6.25,
-                                          cache_write_1h=10, cache_read=0.5, output=25)}
+def _pricing_csv(tmp_path):
+    """Baseline price sheet matching the opus row used across these tests."""
+    csv = tmp_path / "pricing.csv"
+    csv.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,"
+        "cache-hits-&-refreshes,output-tokens\n"
+        "claude-opus-4-8,5,6.25,10,0.50,25\n",
+        encoding="utf-8",
+    )
+    return csv
 
 
-def test_analytics_total_matches_usage_map(monkeypatch) -> None:
+def _use_pricing(monkeypatch, tmp_path):
+    """Point both modules' pricing_path at a real CSV and pricing_dir at an
+    empty (nonexistent) sheets dir, so load_price_timeline yields a single
+    baseline period."""
+    csv = _pricing_csv(tmp_path)
+    sheets = tmp_path / "pricing"
+    for mod in ("ccfr.analysis.usage_characteristics", "ccfr.analysis.usage_map"):
+        monkeypatch.setattr(f"{mod}.pricing_path", lambda csv=csv: csv)
+        monkeypatch.setattr(f"{mod}.pricing_dir", lambda sheets=sheets: sheets)
+
+
+def test_analytics_total_matches_usage_map(monkeypatch, tmp_path) -> None:
     conn = _conn()
     _seed(conn)
     _add(conn, 1, 1)
     _add(conn, 2, 1, agent_id="a1")
-    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
-    monkeypatch.setattr("ccfr.analysis.usage_map.load_price_table", lambda _p: PRICE)
+    _use_pricing(monkeypatch, tmp_path)
 
     chars_total = usage_characteristics_analytics(conn)["meta"]["total_usd"]
     map_total = um.usage_map_analytics(conn)["meta"]["total_usd"]
     assert chars_total == map_total
 
 
-def test_analytics_token_basis_when_no_pricing(monkeypatch) -> None:
+def test_analytics_token_basis_when_no_pricing(monkeypatch, tmp_path) -> None:
     conn = _conn()
     _seed(conn)
     _add(conn, 1, 1)
-    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: {})
+    monkeypatch.setattr("ccfr.analysis.usage_characteristics.pricing_path",
+                        lambda: tmp_path / "missing.csv")
+    monkeypatch.setattr("ccfr.analysis.usage_characteristics.pricing_dir",
+                        lambda: tmp_path / "pricing")
     payload = usage_characteristics_analytics(conn)
     assert payload["meta"]["share_basis"] == "tokens"
     assert payload["meta"]["cost_available"] is False
     assert "token" in payload["meta"]["basis_note"].lower()
 
 
-def test_analytics_reads_agent_type_from_subagents(monkeypatch) -> None:
+def test_analytics_reads_agent_type_from_subagents(monkeypatch, tmp_path) -> None:
     conn = _conn()
     _seed(conn)
     _add(conn, 1, 1, agent_id="a1")
     conn.execute("INSERT INTO subagents (parent_session_id, agent_id, agent_type) "
                  "VALUES (1, 'a1', 'general-purpose')")
     conn.commit()
-    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
+    _use_pricing(monkeypatch, tmp_path)
     keys = [c["key"] for c in usage_characteristics_analytics(conn)["characteristics"]]
     assert "agent_type:general-purpose" in keys
 
 
-def test_endpoint_returns_characteristics(monkeypatch) -> None:
+def test_endpoint_returns_characteristics(monkeypatch, tmp_path) -> None:
     conn = _conn()
     _seed(conn)
     _add(conn, 1, 1)
     _add(conn, 2, 1, agent_id="a1")
-    monkeypatch.setattr("ccfr.analysis.usage_characteristics.load_price_table", lambda _p: PRICE)
+    _use_pricing(monkeypatch, tmp_path)
     app = create_app()
     app.dependency_overrides[get_db] = lambda: conn
     client = TestClient(app)

--- a/backend/tests/test_usage_map.py
+++ b/backend/tests/test_usage_map.py
@@ -7,7 +7,7 @@ import sqlite3
 import pytest
 from fastapi.testclient import TestClient
 
-from ccfr.analysis.pricing import ModelPrice
+from ccfr.analysis.pricing import ModelPrice, PriceTimeline
 from ccfr.analysis import usage_map
 from ccfr.analysis.usage_map import (
     HABIT_BY_KEY,
@@ -180,10 +180,15 @@ def test_aggregate_phases_null_tool_name_gets_no_tool_entry() -> None:
     assert acc["converse"]["tool_count"] == 1
 
 
-PRICE_TABLE = {
-    "claude-opus-4-8": ModelPrice(base_input=5, cache_write_5m=6.25,
-                                  cache_write_1h=10, cache_read=0.5, output=25),
-}
+# A flat (single-period) timeline so the direct-unit tests below can pass it
+# wherever load_events / detectors now expect a PriceTimeline.
+PRICE_TABLE = PriceTimeline(
+    {
+        "claude-opus-4-8": ModelPrice(base_input=5, cache_write_5m=6.25,
+                                      cache_write_1h=10, cache_read=0.5, output=25),
+    },
+    [],
+)
 
 
 def _conn() -> sqlite3.Connection:
@@ -1107,3 +1112,52 @@ def test_usage_map_tool_evidence_bad_phase_is_404(api_client: TestClient) -> Non
     resp = api_client.get("/api/analytics/usage-map/evidence",
                           params={"node": "tool:Read@nonsense"})
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Historical pricing (date-aware PriceTimeline)
+# ---------------------------------------------------------------------------
+
+def _conn_two_dated_opus(tmp_path):
+    """One project, two assistant messages (1M base-input each) on claude-opus-4-1,
+    dated Jan 2026 and Aug 2026 — straddling a 2026-07-01 price change."""
+    from ccfr.storage import connect, init_db
+    conn = connect(tmp_path / "um.sqlite3")
+    init_db(conn)
+    conn.execute("INSERT INTO imports(source_path, imported_at, status) VALUES('x','x','done')")
+    conn.execute("INSERT INTO projects(import_id, export_name) VALUES(1,'proj')")
+    for sid, ts in enumerate(["2026-01-15T10:00:00Z", "2026-08-15T10:00:00Z"], start=1):
+        conn.execute("INSERT INTO sessions(project_id, session_id, first_ts, last_ts) VALUES(1,?,?,?)",
+                     (f"s{sid}", ts, ts))
+        conn.execute("INSERT INTO events(session_id, source_path, line_no, type, timestamp, raw_json) "
+                     "VALUES(?,?,?,?,?,'{}')", (sid, "f", sid, "assistant", ts))
+        conn.execute("INSERT INTO messages(event_id, role, model, base_input_tokens, output_tokens) "
+                     "VALUES(?, 'assistant', 'claude-opus-4-1', 1000000, 0)", (sid,))
+    conn.commit()
+    return conn
+
+
+def test_usage_map_total_prices_by_period(monkeypatch, tmp_path):
+    from ccfr.analysis import usage_map
+
+    conn = _conn_two_dated_opus(tmp_path)
+    baseline = tmp_path / "pricing.csv"
+    baseline.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,15,0,0,0,75\n",
+        encoding="utf-8",
+    )
+    sheets = tmp_path / "pricing"
+    sheets.mkdir()
+    (sheets / "pricing-2026-07-01.csv").write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "Claude-Opus-4.1,5,0,0,0,25\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(usage_map, "pricing_path", lambda: baseline)
+    monkeypatch.setattr(usage_map, "pricing_dir", lambda: sheets)
+
+    on = usage_map.usage_map_analytics(conn, historical=True)["meta"]["total_usd"]
+    off = usage_map.usage_map_analytics(conn, historical=False)["meta"]["total_usd"]
+    assert round(on, 2) == 20.0
+    assert round(off, 2) == 10.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - ccfr-data:/app/data
       # Mount pricing.csv read-only so edits take effect on the next request (no rebuild).
       - ./pricing.csv:/app/pricing.csv:ro
+      # Mount the dated price-snapshot dir too, so historical pricing works in
+      # Docker and new snapshots are picked up on the next request (no rebuild).
+      - ./pricing:/app/pricing:ro
 
   frontend:
     build:

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -9,6 +9,8 @@ vi.mock("./api/client", () => ({
   listProjects: vi.fn(async () => []),
   listSessions: vi.fn(async () => []),
   discoverSourceProjects: vi.fn(async () => []),
+  getSettings: vi.fn(async () => ({ historical_pricing: true })),
+  updateSettings: vi.fn(async (s: { historical_pricing: boolean }) => s),
   getRuntimeConfig: vi.fn(async () => ({ import_root: "/srv/Data", database_path: "/srv/ccfr.sqlite3", is_docker: false })),
   getCacheStats: vi.fn(async () => ({
     project_count: 0, session_count: 0, event_count: 0,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import type { View } from "./shell/navConfig";
 import { DEFAULT_TECHNIQUE } from "./discover/techniques";
 import { useCollapsed } from "./shell/useCollapsed";
 import { useGlossaryHint } from "./shell/useGlossaryHint";
+import { useSettings } from "./shell/useSettings";
 import { useTheme } from "./theme/useTheme";
 
 function App() {
@@ -26,6 +27,7 @@ function App() {
   const [focusEventId, setFocusEventId] = React.useState<number | null>(null);
   const { theme, toggle } = useTheme();
   const { collapsed, toggle: toggleCollapsed } = useCollapsed();
+  const { historicalPricing, setHistoricalPricing } = useSettings();
   const { seen: glossaryHintSeen, dismiss: dismissGlossaryHint } = useGlossaryHint();
   const [glossaryOpen, setGlossaryOpen] = React.useState(false);
   const autoRouted = React.useRef(false);
@@ -78,6 +80,8 @@ function App() {
         onToggleCollapsed={toggleCollapsed}
         onToggleTheme={toggle}
         onOpenGlossary={openGlossary}
+        historicalPricing={historicalPricing}
+        onToggleHistoricalPricing={() => setHistoricalPricing(!historicalPricing)}
         glossaryHint={!glossaryHintSeen}
         onDismissGlossaryHint={dismissGlossaryHint}
       />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,7 +98,9 @@ function App() {
             onOpenSession={openSession}
           />
         )}
-        {view === "cost" && <CostAnalyticsPage onOpenSession={openSessionById} />}
+        {view === "cost" && (
+          <CostAnalyticsPage onOpenSession={openSessionById} historical={historicalPricing} />
+        )}
         {view === "discover" && (
           <DiscoverPage
             projects={projects.data ?? []}

--- a/frontend/src/analytics/CostAnalyticsPage.test.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.test.tsx
@@ -179,6 +179,27 @@ describe("CostAnalyticsPage", () => {
     expect(screen.queryByRole("button", { name: "Review" })).not.toBeInTheDocument();
   });
 
+  it("passes the pricing mode to the request and refetches when it flips", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const view = render(
+      <QueryClientProvider client={qc}>
+        <CostAnalyticsPage onOpenSession={() => {}} historical={true} />
+      </QueryClientProvider>,
+    );
+    await screen.findAllByText("alpha");
+    expect(getCostAnalytics.mock.calls[0][1]).toBe(true);
+
+    view.rerender(
+      <QueryClientProvider client={qc}>
+        <CostAnalyticsPage onOpenSession={() => {}} historical={false} />
+      </QueryClientProvider>,
+    );
+    // Flipping the mode must drive a fresh request carrying the new mode.
+    await vi.waitFor(() =>
+      expect(getCostAnalytics.mock.calls.some((c) => c[1] === false)).toBe(true),
+    );
+  });
+
   it("shows the unavailable message on $-tiles when pricing is missing", async () => {
     getCostAnalytics.mockResolvedValueOnce({ ...payload, meta: { ...payload.meta, available: false } });
     renderPage();

--- a/frontend/src/analytics/CostAnalyticsPage.test.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.test.tsx
@@ -158,11 +158,11 @@ beforeEach(() => {
   getSessionTurnCosts.mockResolvedValue(turnBreakdown);
 });
 
-function renderPage(onOpenSession = () => {}) {
+function renderPage(onOpenSession = () => {}, historical?: boolean) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <CostAnalyticsPage onOpenSession={onOpenSession} />
+      <CostAnalyticsPage onOpenSession={onOpenSession} historical={historical} />
     </QueryClientProvider>,
   );
 }
@@ -214,6 +214,20 @@ describe("CostAnalyticsPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open session page" }));
 
     expect(onOpenSession).toHaveBeenCalledWith(7);
+  });
+
+  it("describes historical pricing mode in the cost note", async () => {
+    renderPage();
+    expect(
+      await screen.findByText(/priced at the rates in effect on each session/i),
+    ).toBeInTheDocument();
+  });
+
+  it("switches the cost note to current-rate wording when historical pricing is off", async () => {
+    renderPage(() => {}, false);
+    expect(
+      await screen.findByText(/priced at current rates for every session/i),
+    ).toBeInTheDocument();
   });
 
   it("shows an error instead of loading forever when analytics fails", async () => {

--- a/frontend/src/analytics/CostAnalyticsPage.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.tsx
@@ -13,6 +13,8 @@ import SessionInsights, { TurnDistributionSection } from "./SessionInsights";
 
 interface Props {
   onOpenSession: (sessionId: number) => void;
+  /** Whether historical (date-effective) pricing is active; drives the pricing-mode note. */
+  historical?: boolean;
 }
 
 function defaultFrom(): string {
@@ -21,7 +23,7 @@ function defaultFrom(): string {
   return d.toISOString();
 }
 
-export default function CostAnalyticsPage({ onOpenSession }: Props) {
+export default function CostAnalyticsPage({ onOpenSession, historical = true }: Props) {
   const [filters, setFilters] = React.useState<CostAnalyticsFilters>({ dateFrom: defaultFrom() });
   const query = useQuery({
     queryKey: ["cost-analytics", filters],
@@ -40,8 +42,9 @@ export default function CostAnalyticsPage({ onOpenSession }: Props) {
       <div className="cost-page-inner">
         <FilterBar filters={filters} meta={payload?.meta} onChange={setFilters} />
         <p className="cost-pricing-note">
-          Spend is priced at the rates in effect on each session&apos;s date. Toggle historical pricing in the sidebar to
-          value everything at current rates.
+          {historical
+            ? "Spend is priced at the rates in effect on each session's date. Toggle historical pricing in the sidebar to value everything at current rates."
+            : "Spend is priced at current rates for every session. Toggle historical pricing in the sidebar to value each session at the rates in effect on its date."}
         </p>
         {query.isError ? (
           <div className="empty-state panel-error">

--- a/frontend/src/analytics/CostAnalyticsPage.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.tsx
@@ -39,6 +39,10 @@ export default function CostAnalyticsPage({ onOpenSession }: Props) {
     <main className="cost-page">
       <div className="cost-page-inner">
         <FilterBar filters={filters} meta={payload?.meta} onChange={setFilters} />
+        <p className="cost-pricing-note">
+          Spend is priced at the rates in effect on each session&apos;s date. Toggle historical pricing in the sidebar to
+          value everything at current rates.
+        </p>
         {query.isError ? (
           <div className="empty-state panel-error">
             <strong>Cost analytics failed.</strong>

--- a/frontend/src/analytics/CostAnalyticsPage.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.tsx
@@ -26,8 +26,11 @@ function defaultFrom(): string {
 export default function CostAnalyticsPage({ onOpenSession, historical = true }: Props) {
   const [filters, setFilters] = React.useState<CostAnalyticsFilters>({ dateFrom: defaultFrom() });
   const query = useQuery({
-    queryKey: ["cost-analytics", filters],
-    queryFn: () => getCostAnalytics(filters),
+    // `historical` is part of the key so flipping the price mode is a distinct
+    // query (and a distinct request URL), not a same-URL refetch that could be
+    // served stale from cache.
+    queryKey: ["cost-analytics", filters, historical],
+    queryFn: () => getCostAnalytics(filters, historical),
   });
 
   const payload = query.data;

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCostAnalytics } from "./client";
+
+function okJson(body: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+}
+
+describe("api client", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => okJson({}));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("requests are sent with cache disabled so toggled state can't serve stale data", async () => {
+    await getCostAnalytics({});
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.cache).toBe("no-store");
+  });
+
+  it("getCostAnalytics encodes the historical pricing mode in the URL when given", async () => {
+    await getCostAnalytics({ dateFrom: "2026-05-18" }, false);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("historical=false");
+
+    fetchMock.mockClear();
+    await getCostAnalytics({ dateFrom: "2026-05-18" }, true);
+    expect(fetchMock.mock.calls[0][0] as string).toContain("historical=true");
+  });
+
+  it("omits the historical param when the mode is not provided", async () => {
+    await getCostAnalytics({ dateFrom: "2026-05-18" });
+    expect(fetchMock.mock.calls[0][0] as string).not.toContain("historical=");
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -32,6 +32,10 @@ const API_BASE = (import.meta.env.VITE_API_BASE ?? "/api").replace(/\/$/, "");
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
+    // Always hit the backend: analytics responses carry no cache headers and some
+    // (e.g. the price-mode toggle) change server-side state without changing the
+    // URL, so a cached body would otherwise be served stale.
+    cache: "no-store",
     headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
     ...init,
   });
@@ -138,12 +142,15 @@ export function search(q: string, sessionId?: number) {
   return request<SearchResult[]>(`/search?${params.toString()}`);
 }
 
-export function getCostAnalytics(filters: CostAnalyticsFilters = {}) {
+export function getCostAnalytics(filters: CostAnalyticsFilters = {}, historical?: boolean) {
   const params = new URLSearchParams();
   if (filters.dateFrom) params.set("date_from", filters.dateFrom);
   if (filters.dateTo) params.set("date_to", filters.dateTo);
   if (filters.projectId) params.set("project_id", String(filters.projectId));
   if (filters.model) params.set("model", filters.model);
+  // Encode the pricing mode in the URL so the two modes never share one cacheable
+  // request (the backend falls back to the persisted setting when it's absent).
+  if (historical !== undefined) params.set("historical", String(historical));
   const query = params.toString();
   return request<CostAnalyticsResponse>(`/analytics/cost${query ? `?${query}` : ""}`);
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   SearchResult,
   SessionCard,
   SessionContextEconomicsResponse,
+  Settings,
   Subagent,
   TimelineItem,
   TurnCostBreakdown,
@@ -197,4 +198,15 @@ export function getUsageCharacteristics(filters: UsageMapFilters = {}) {
   return request<UsageCharacteristicsResponse>(
     `/analytics/usage-characteristics${query ? `?${query}` : ""}`,
   );
+}
+
+export function getSettings() {
+  return request<Settings>("/settings");
+}
+
+export function updateSettings(settings: Settings) {
+  return request<Settings>("/settings", {
+    method: "PUT",
+    body: JSON.stringify(settings),
+  });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -643,3 +643,7 @@ export interface UsageCharacteristicsResponse {
   meta: UsageCharacteristicsMeta;
   characteristics: UsageCharacteristic[];
 }
+
+export interface Settings {
+  historical_pricing: boolean;
+}

--- a/frontend/src/shell/Sidebar.test.tsx
+++ b/frontend/src/shell/Sidebar.test.tsx
@@ -95,3 +95,29 @@ describe("Sidebar", () => {
     expect(props.onDismissGlossaryHint).toHaveBeenCalled();
   });
 });
+
+describe("Sidebar historical-pricing toggle", () => {
+  it("renders and toggles", () => {
+    const onToggle = vi.fn();
+    render(
+      <Sidebar
+        view="map"
+        discoverTechnique="subgroup"
+        collapsed={false}
+        sessionEnabled={false}
+        theme="dark"
+        onSelectView={vi.fn()}
+        onSelectTechnique={vi.fn()}
+        onToggleCollapsed={vi.fn()}
+        onToggleTheme={vi.fn()}
+        onOpenGlossary={vi.fn()}
+        historicalPricing={true}
+        onToggleHistoricalPricing={onToggle}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /historical pricing/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/shell/Sidebar.test.tsx
+++ b/frontend/src/shell/Sidebar.test.tsx
@@ -120,4 +120,29 @@ describe("Sidebar historical-pricing toggle", () => {
     fireEvent.click(btn);
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
+
+  it("reflects on/off state on the toggle button", () => {
+    const base = {
+      view: "map" as const,
+      discoverTechnique: "subgroup",
+      collapsed: false,
+      sessionEnabled: false,
+      theme: "dark" as const,
+      onSelectView: vi.fn(),
+      onSelectTechnique: vi.fn(),
+      onToggleCollapsed: vi.fn(),
+      onToggleTheme: vi.fn(),
+      onOpenGlossary: vi.fn(),
+      onToggleHistoricalPricing: vi.fn(),
+    };
+    const { rerender } = render(<Sidebar {...base} historicalPricing={true} />);
+    let btn = screen.getByRole("button", { name: /historical pricing/i });
+    expect(btn).toHaveClass("is-active");
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+
+    rerender(<Sidebar {...base} historicalPricing={false} />);
+    btn = screen.getByRole("button", { name: /historical pricing/i });
+    expect(btn).not.toHaveClass("is-active");
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+  });
 });

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -1,5 +1,5 @@
 // frontend/src/shell/Sidebar.tsx
-import { Activity, HelpCircle, Moon, PanelLeft, PanelLeftClose, Sun } from "lucide-react";
+import { Activity, History, HelpCircle, Moon, PanelLeft, PanelLeftClose, Sun } from "lucide-react";
 import { NAV_ITEMS, type View } from "./navConfig";
 import { TECHNIQUES } from "../discover/techniques";
 
@@ -14,6 +14,8 @@ interface Props {
   onToggleCollapsed: () => void;
   onToggleTheme: () => void;
   onOpenGlossary: () => void;
+  historicalPricing: boolean;
+  onToggleHistoricalPricing: () => void;
   // First-run hint that surfaces the glossary. When true, the help button
   // pulses and a dismissable coachmark is shown.
   glossaryHint?: boolean;
@@ -33,6 +35,8 @@ export default function Sidebar({
   onOpenGlossary,
   glossaryHint = false,
   onDismissGlossaryHint,
+  historicalPricing,
+  onToggleHistoricalPricing,
 }: Props) {
   return (
     <aside className={`app-sidebar ${collapsed ? "is-collapsed" : ""}`} aria-label="Primary">
@@ -84,6 +88,19 @@ export default function Sidebar({
       </nav>
 
       <div className="sb-foot">
+        <button
+          className={`sb-action ${historicalPricing ? "is-active" : ""}`}
+          onClick={onToggleHistoricalPricing}
+          aria-pressed={historicalPricing}
+          aria-label="Historical pricing"
+          title={
+            historicalPricing
+              ? "Historical pricing on — spend uses rates effective on each session's date"
+              : "Historical pricing off — spend uses current rates for all sessions"
+          }
+        >
+          <History size={16} />
+        </button>
         <div className="sb-glossary">
           <button
             className={`sb-action ${glossaryHint ? "is-hinted" : ""}`}

--- a/frontend/src/shell/useSettings.test.tsx
+++ b/frontend/src/shell/useSettings.test.tsx
@@ -1,0 +1,30 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettings } from "./useSettings";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+describe("useSettings", () => {
+  beforeEach(() => {
+    vi.spyOn(global, "fetch").mockImplementation((url, init) => {
+      if (init?.method === "PUT") {
+        return Promise.resolve(new Response(init.body as string, { status: 200 }));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ historical_pricing: true }), { status: 200 }),
+      );
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("loads the setting and toggles it", async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await waitFor(() => expect(result.current.historicalPricing).toBe(true));
+    await act(async () => result.current.setHistoricalPricing(false));
+    await waitFor(() => expect(result.current.historicalPricing).toBe(false));
+  });
+});

--- a/frontend/src/shell/useSettings.ts
+++ b/frontend/src/shell/useSettings.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getSettings, updateSettings } from "../api/client";
+
+export function useSettings() {
+  const queryClient = useQueryClient();
+  const query = useQuery({ queryKey: ["settings"], queryFn: getSettings });
+
+  const mutation = useMutation({
+    mutationFn: (historical: boolean) => updateSettings({ historical_pricing: historical }),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(["settings"], saved);
+      // Pricing affects nearly every cost-bearing query; refetch them all except
+      // the settings query itself (it was just set above via setQueryData).
+      void queryClient.invalidateQueries({
+        predicate: (q) => q.queryKey[0] !== "settings",
+      });
+    },
+  });
+
+  return {
+    historicalPricing: query.data?.historical_pricing ?? true,
+    setHistoricalPricing: (value: boolean) => mutation.mutate(value),
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -111,6 +111,13 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
   border: 1px solid var(--border); background: var(--bg); color: var(--muted); border-radius: 9px;
 }
 .sb-action:hover { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 40%, var(--border-2)); }
+/* Toggled-on footer action (e.g. historical pricing): clearly "lit", mirroring .sb-item.active. */
+.sb-action.is-active {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-2));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+}
 .sb-collapse { margin-left: auto; }
 
 /* Collapsed: hide text, center icons */
@@ -907,6 +914,7 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
 /* ---- Cost analytics page ---- */
 .cost-page { flex: 1; min-height: 0; overflow-y: auto; width: 100%; }
 .cost-page-inner { max-width: var(--page-max-width); margin: 0 auto; padding: 18px var(--page-gutter); display: flex; flex-direction: column; gap: 14px; }
+.cost-pricing-note { margin: -6px 0 0; color: var(--faint); font-size: 11.5px; }
 .cost-page-header { display: flex; align-items: center; gap: 18px; }
 .cost-page-header .cost-filterbar { flex: 1; min-width: 0; }
 

--- a/frontend/src/trace/TraceView.tsx
+++ b/frontend/src/trace/TraceView.tsx
@@ -845,8 +845,8 @@ function TraceView({ trace, selectedEventId, playheadTimestamp, onSelect }: Prop
                 className="trace-cost"
                 title={
                   trace.cost.unpriced_models.length > 0
-                    ? `Estimated from pricing.csv · excludes unpriced model(s): ${trace.cost.unpriced_models.join(", ")}`
-                    : "Estimated session cost from pricing.csv"
+                    ? `Priced at rates effective on the session date · excludes unpriced model(s): ${trace.cost.unpriced_models.join(", ")}`
+                    : "Priced at rates effective on the session date"
                 }
               >
                 {formatUsd(trace.cost.usd)}


### PR DESCRIPTION
## Historical (time-aware) pricing

Price each session at the model rates in effect on its date, with a sidebar
toggle to value everything at current rates instead (default: historical on).

- `pricing.csv` is the baseline; dated `pricing/pricing-YYYY-MM-DD.csv` snapshots
  layer on top by date (`PriceTimeline`). Applied across cost analytics, usage
  map, discovery, and context economics.
- Mode is persisted via `GET/PUT /api/settings` and sent on the request, so the
  two modes are distinct, cache-safe queries.
- docker-compose now mounts the `pricing/` dir (was missing, so the toggle had
  no effect in Docker).

Tests: full suite green (275 backend, 223 frontend).