### PR TITLE
Feature/team bundle sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ frontend/vite.config.d.ts
 .superpowers/
 *.log
 /Data
+/TeamBundles
 .claude/*
 AGENT.md
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ frontend/vite.config.d.ts
 *.log
 /Data
 /TeamBundles
+/.ccfr-data/
 .claude/*
 AGENT.md
 CLAUDE.md

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,9 +22,10 @@ By default, local runs use:
 ```text
 CCFR_IMPORT_ROOT=../Data
 CCFR_DB_PATH=../.ccfr-data/ccfr.sqlite3
+CCFR_TEAM_BUNDLE_ROOT=../.ccfr-data/team-bundles
 ```
 
-The app reads raw exports from the import root and stores rebuildable index data in SQLite. Deleting the SQLite file removes the cache, but it does not delete the original export.
+The app reads raw exports from the import root and stores rebuildable index data in SQLite. Team bundle exports are written under the configured team bundle root. Deleting the SQLite file removes the cache, but it does not delete the original export or exported team bundles.
 
 ## Network Behavior
 
@@ -38,6 +39,7 @@ Never commit sensitive or generated local data:
 
 ```text
 Data/
+TeamBundles/
 .ccfr-data/
 *.sqlite3
 *.sqlite3-*

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Frontend: http://localhost:5173
 Backend API docs: http://localhost:8000/docs
 ```
 
-By default `docker-compose.yml` mounts the local `Data/` folder as `/imports` for the backend service. Both containers bind to host loopback only; the backend serves API routes and the frontend is served by a separate container.
+By default `docker-compose.yml` mounts the local `Data/` folder as `/imports` for the backend service and `TeamBundles/` as `/team-bundles` for team bundle exports and optional server-path imports. Team managers can also import a team bundle by choosing the JSON file in the browser, which does not require the file path to exist inside the container. Both containers bind to host loopback only; the backend serves API routes and the frontend is served by a separate container.
 
 ## Local Backend
 
@@ -87,6 +87,7 @@ When run outside Docker, the backend defaults to:
 ```text
 CCFR_IMPORT_ROOT=../Data
 CCFR_DB_PATH=../.ccfr-data/ccfr.sqlite3
+CCFR_TEAM_BUNDLE_ROOT=../.ccfr-data/team-bundles
 ```
 
 Set those environment variables before starting `uvicorn` if you want to index a different export root or store the rebuildable SQLite cache elsewhere.

--- a/backend/src/ccfr/analysis/context_economics.py
+++ b/backend/src/ccfr/analysis/context_economics.py
@@ -601,6 +601,9 @@ def detect_late_compaction(
     later growth. Savings = dropped tokens (minus any already claimed by
     contributor-level findings) read-priced over the tail, minus the one-off
     re-write of the retained content.
+
+    `savings_tokens` is the one-time avoidable footprint; `savings_usd`
+    accumulates the per-call carry.
     """
     pressure = CONTEXT_WINDOW_TOKENS * COMPACTION_PRESSURE_RATIO
     thresholds = [
@@ -631,7 +634,10 @@ def detect_late_compaction(
                 residual = dropped - claimed[k]
                 if residual > 0:
                     savings_usd += residual * thread.read_prices[k]
-                    savings_tokens += int(residual)
+                    # Footprint, not token-turns: the same ballast is re-paid each
+                    # call; the frontend subtracts savings_tokens from EVERY tail
+                    # turn (streamGeometry counterfactual), so report it once.
+                    savings_tokens = max(savings_tokens, int(residual))
                     covered.append(k)
             if savings_usd < MIN_FINDING_USD:
                 continue
@@ -647,7 +653,7 @@ def detect_late_compaction(
                 label=(f"Context above {int(pressure / 1000)}k tokens for "
                        f"{epoch.end - eligible} more turns without compaction"),
                 carried_turns=epoch.end - eligible,
-                carried_tokens=savings_tokens,
+                carried_tokens=int(dropped),
                 savings_tokens=savings_tokens,
                 savings_usd=savings_usd,
                 counterfactual={
@@ -687,6 +693,9 @@ def detect_stale_continuation(
 
     Must run AFTER detect_late_compaction so compaction-claimed calls (in
     claims.calls) are excluded here.
+
+    `savings_tokens` is the one-time avoidable footprint; `savings_usd`
+    accumulates the per-call carry.
     """
     all_gaps = [
         _gap_seconds(thread.calls[i - 1].ts, thread.calls[i].ts)
@@ -732,7 +741,7 @@ def detect_stale_continuation(
                 residual = avoidable_ctx - claimed_tokens[k]
                 if residual > 0:
                     savings_usd += residual * thread.read_prices[k]
-                    savings_tokens += int(residual)
+                    savings_tokens = max(savings_tokens, int(residual))
             if savings_usd < MIN_FINDING_USD:
                 continue
             claims.calls[thread_index].update(tail_calls)
@@ -747,7 +756,7 @@ def detect_stale_continuation(
                 label=(f"Resumed a {thread.calls[i - 1].context_tokens // 1000}k-token "
                        f"context after {gap_minutes} min for {tail} short turns"),
                 carried_turns=tail,
-                carried_tokens=savings_tokens,
+                carried_tokens=int(avoidable_ctx),
                 savings_tokens=savings_tokens,
                 savings_usd=savings_usd,
                 counterfactual={

--- a/backend/src/ccfr/analysis/context_economics.py
+++ b/backend/src/ccfr/analysis/context_economics.py
@@ -344,6 +344,7 @@ def load_threads(
             """
             SELECT e.id AS event_id, e.agent_id, e.timestamp, e.type,
                    length(e.raw_json) AS raw_len,
+                   length(tr.raw_json) AS result_raw_len,
                    tr.id AS tool_result_id, po.size_bytes,
                    tc.tool_name, tc.raw_json AS call_json
             FROM events e
@@ -403,8 +404,9 @@ def _raw_item(row: sqlite3.Row) -> RawItem:
                 detail = None
         label = f"{tool_name} result" + (f": {detail}" if detail else "")
         # `is not None`, not truthiness: a genuinely empty (0-byte) persisted output
-        # must not fall back to the raw_json wrapper length.
-        chars = row["size_bytes"] if row["size_bytes"] is not None else row["raw_len"]
+        # must not fall back to the result length. Size by THIS result's own JSON,
+        # not the whole event's — parallel sibling results must not share one size.
+        chars = row["size_bytes"] if row["size_bytes"] is not None else row["result_raw_len"]
         return RawItem(kind="tool_result", label=label, raw_chars=chars or 0,
                        event_id=row["event_id"], tool_name=tool_name, detail=detail)
     kind = "attachment" if row["type"] == "attachment" else "user"

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -634,7 +634,7 @@ def import_team_bundle(
         team_bundle_id = int(cur.lastrowid)
         session_rows = []
         for session in bundle["sessions"]:
-            if bundle["profile"] == LEVEL_TEAM:
+            if bundle["privacy_level"] == LEVEL_TEAM:
                 project_key = normalize_project_key(session["project_name"])
                 project_name = session["project_name"]
             else:

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -108,6 +108,7 @@ class TeamImportResult:
     member_id: str
     session_count: int
     imported: bool
+    status: str  # "imported" | "replaced" | "duplicate" | "stale"
 
 
 def _hash_id(salt: str, namespace: str, *parts: object) -> str:
@@ -308,10 +309,32 @@ def import_team_bundle(
             member_id=str(existing["member_id"]),
             session_count=int(existing["session_count"]),
             imported=False,
+            status="duplicate",
+        )
+
+    newest = conn.execute(
+        "SELECT MAX(generated_at) FROM team_bundles WHERE member_id = ?",
+        (bundle["member_id"],),
+    ).fetchone()[0]
+    if newest is not None and str(bundle["generated_at"]) < str(newest):
+        return TeamImportResult(
+            bundle_id=bundle["bundle_id"],
+            member_id=bundle["member_id"],
+            session_count=0,
+            imported=False,
+            status="stale",
         )
 
     imported_at = datetime.now(timezone.utc).isoformat()
     with conn:
+        # A bundle is a full snapshot of one member's sessions, so a newer
+        # bundle supersedes everything previously imported for that member.
+        replaced = int(conn.execute(
+            "SELECT COUNT(*) FROM team_bundles WHERE member_id = ?",
+            (bundle["member_id"],),
+        ).fetchone()[0])
+        conn.execute("DELETE FROM team_bundle_sessions WHERE member_id = ?", (bundle["member_id"],))
+        conn.execute("DELETE FROM team_bundles WHERE member_id = ?", (bundle["member_id"],))
         cur = conn.execute(
             """
             INSERT INTO team_bundles(
@@ -371,6 +394,7 @@ def import_team_bundle(
         member_id=bundle["member_id"],
         session_count=len(bundle["sessions"]),
         imported=True,
+        status="replaced" if replaced else "imported",
     )
 
 

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -489,11 +489,14 @@ def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
             stop_reason_counts[str(reason)] += _nonnegative_int(count)
         for category in risks:
             risk_counts[str(category)] += 1
+        seen_types: set[str] = set()
         for subagent in subagents:
             if not isinstance(subagent, dict):
                 continue
             agent_type = str(subagent.get("agent_type") or "custom")
             subagent_events[agent_type] += _nonnegative_int(subagent.get("event_count"))
+            seen_types.add(agent_type)
+        for agent_type in seen_types:
             subagent_sessions[agent_type] += 1
         for step in sequence:
             if isinstance(step, dict) and step.get("sym"):

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -410,6 +410,17 @@ def list_team_imports(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     return [dict(row) for row in rows]
 
 
+def delete_team_member(conn: sqlite3.Connection, member_id: str) -> int:
+    """Remove every imported bundle (and its sessions) for one member."""
+    with conn:
+        removed = int(conn.execute(
+            "SELECT COUNT(*) FROM team_bundles WHERE member_id = ?", (member_id,)
+        ).fetchone()[0])
+        conn.execute("DELETE FROM team_bundle_sessions WHERE member_id = ?", (member_id,))
+        conn.execute("DELETE FROM team_bundles WHERE member_id = ?", (member_id,))
+    return removed
+
+
 def reset_team_bundles(conn: sqlite3.Connection) -> None:
     with conn:
         conn.execute("DELETE FROM team_bundle_sessions")

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import sqlite3
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -23,10 +24,28 @@ from ccfr.analysis.contribution import (
     sanitize_symbol,
 )
 from ccfr.analysis import contribution as contribution_helpers
+from ccfr.naming import project_display_name
 
-SCHEMA_VERSION = 1
-PROFILE = "team_strict"
+SCHEMA_VERSION = 2
+LEGACY_SCHEMA_VERSION = 1
+PROFILE = "team_strict"  # legacy v1 wire profile == the structural level
 DEFAULT_PROVIDER = "claude"
+
+LEVEL_STRUCTURAL = "structural"
+LEVEL_TEAM = "team"
+BUILD_LEVELS = (LEVEL_STRUCTURAL, LEVEL_TEAM)
+# Ladder rungs reserved for raw-session sharing (separate sub-project).
+RESERVED_LEVELS = ("sessions", "raw")
+
+_EXT_RE = re.compile(r"^[a-z0-9_+-]{1,12}$")
+_MAX_TOOLS_PER_SESSION = 300
+_MAX_FILE_TYPES_PER_SESSION = 100
+
+
+def privacy_level_of(profile: str | None) -> str:
+    """Level for a stored profile string ("team_strict" is legacy structural)."""
+    return LEVEL_TEAM if profile == LEVEL_TEAM else LEVEL_STRUCTURAL
+
 
 TOKEN_KEYS = ("input", "output", "base", "cache_5m", "cache_1h", "cache_read")
 STAT_KEYS = (
@@ -65,6 +84,18 @@ TOP_LEVEL_KEYS = {
     "app_version",
     "sessions",
 }
+SESSION_KEYS_TEAM = (SESSION_KEYS - {"pid"}) | {"project_name", "tools", "file_types"}
+TOP_LEVEL_KEYS_V2 = {
+    "schema_version",
+    "privacy_level",
+    "bundle_id",
+    "member_id",
+    "member_name",
+    "generated_at",
+    "generated_seq",
+    "app_version",
+    "sessions",
+}
 RISK_CATEGORIES = frozenset(
     {
         "cost_context_blowup",
@@ -85,26 +116,31 @@ class TeamBundle:
     generated_at: str
     app_version: str
     sessions: list[dict[str, Any]] = field(default_factory=list)
-    # Per-member monotonic export counter (defaults to 0 for legacy v1 bundles).
+    # Per-member monotonic export counter (defaults to 0 for legacy bundles).
     # Not part of bundle_content_id's key tuple: two identical-content same-day
     # bundles legitimately share a content id (the duplicate check handles them).
     generated_seq: int = 0
+    privacy_level: str = LEVEL_STRUCTURAL
+    member_name: str | None = None
     bundle_id: str | None = None
 
     def base_dict(self) -> dict[str, Any]:
-        return {
+        data: dict[str, Any] = {
             "schema_version": SCHEMA_VERSION,
-            "profile": PROFILE,
+            "privacy_level": self.privacy_level,
             "member_id": self.member_id,
             "generated_at": self.generated_at,
             "generated_seq": self.generated_seq,
             "app_version": self.app_version,
             "sessions": self.sessions,
         }
+        if self.privacy_level == LEVEL_TEAM:
+            data["member_name"] = self.member_name
+        return data
 
     def to_dict(self) -> dict[str, Any]:
         data = self.base_dict()
-        data["bundle_id"] = self.bundle_id or bundle_content_id(data)
+        data["bundle_id"] = self.bundle_id or bundle_content_id_v2(data)
         return data
 
 
@@ -128,6 +164,25 @@ def bundle_content_id(bundle: dict[str, Any]) -> str:
     )}
     encoded = json.dumps(base, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def bundle_content_id_v2(bundle: dict[str, Any]) -> str:
+    base = {key: bundle[key] for key in (
+        "schema_version", "privacy_level", "member_id", "generated_at", "app_version", "sessions",
+    )}
+    if bundle.get("privacy_level") == LEVEL_TEAM:
+        base["member_name"] = bundle.get("member_name")
+    encoded = json.dumps(base, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def normalize_project_key(name: str) -> str:
+    """Cross-member grouping key: casefold, collapse non-alphanumeric runs to '-'."""
+    folded = "".join(ch if ch.isalnum() else "-" for ch in name.casefold())
+    key = re.sub("-+", "-", folded).strip("-")
+    if not key:
+        raise ValueError(f"project name has no usable characters: {name!r}")
+    return key
 
 
 def _fold_tokens_by_model(pairs: Any) -> dict[str, dict[str, int]]:
@@ -161,6 +216,48 @@ def _session_tokens_by_model(conn: sqlite3.Connection, session_pk: int) -> dict[
     )
 
 
+def _session_tools(conn: sqlite3.Connection, session_pk: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT tool_name, COUNT(*) AS calls
+        FROM tool_calls
+        WHERE session_id = ? AND tool_name IS NOT NULL AND TRIM(tool_name) != ''
+        GROUP BY tool_name
+        ORDER BY tool_name
+        """,
+        (session_pk,),
+    ).fetchall()
+    return [{"name": str(row["tool_name"])[:120], "calls": int(row["calls"])} for row in rows]
+
+
+def _session_file_types(conn: sqlite3.Connection, session_pk: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT file_ext, COUNT(*) AS count
+        FROM tool_calls
+        WHERE session_id = ? AND file_ext IS NOT NULL
+        GROUP BY file_ext
+        ORDER BY file_ext
+        """,
+        (session_pk,),
+    ).fetchall()
+    return [{"ext": str(row["file_ext"]), "count": int(row["count"])} for row in rows]
+
+
+def _session_subagents_raw(conn: sqlite3.Connection, session_pk: int) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT agent_type, event_count FROM subagents WHERE parent_session_id = ? ORDER BY id",
+        (session_pk,),
+    ).fetchall()
+    return [
+        {
+            "agent_type": (str(row["agent_type"]).strip()[:80] or "custom") if row["agent_type"] else "custom",
+            "event_count": int(row["event_count"]),
+        }
+        for row in rows
+    ]
+
+
 def build_team_bundle(
     conn: sqlite3.Connection,
     *,
@@ -169,38 +266,79 @@ def build_team_bundle(
     app_version: str,
     generated_on: date,
     generated_seq: int = 0,
+    privacy_level: str = LEVEL_STRUCTURAL,
+    member_name: str | None = None,
+    projects: list[dict[str, Any]] | None = None,
 ) -> TeamBundle:
-    sessions: list[dict[str, Any]] = []
+    if privacy_level not in BUILD_LEVELS:
+        raise ValueError(f"unsupported privacy_level: {privacy_level}")
+    if privacy_level == LEVEL_TEAM and not (member_name or "").strip():
+        raise ValueError("member_name is required at the team level")
+    if privacy_level == LEVEL_STRUCTURAL and member_name:
+        raise ValueError("member_name is not allowed at the structural level")
+
+    label_overrides: dict[str, str] = {}
+    selected: list[str] | None = None
+    if projects is not None:
+        selected = []
+        for item in projects:
+            export_name = str(item["export_name"])
+            selected.append(export_name)
+            label = str(item.get("label") or "").strip()
+            if label:
+                label_overrides[export_name] = label
+        if not selected:
+            raise ValueError("projects selection must not be empty")
+        known = {str(row["export_name"]) for row in conn.execute("SELECT export_name FROM projects")}
+        unknown_projects = sorted(name for name in selected if name not in known)
+        if unknown_projects:
+            raise ValueError(f"unknown project: {unknown_projects[0]}")
+
+    where = ""
+    params: list[Any] = []
+    if selected is not None:
+        placeholders = ",".join("?" * len(selected))
+        where = f"WHERE p.export_name IN ({placeholders})"
+        params = selected
     session_rows = conn.execute(
-        """
-        SELECT s.id, s.session_id, s.first_ts, s.last_ts, p.export_name
+        f"""
+        SELECT s.id, s.session_id, s.first_ts, s.last_ts, p.export_name, p.inferred_cwd
         FROM sessions s
         JOIN projects p ON p.id = s.project_id
+        {where}
         ORDER BY p.id, s.id
-        """
+        """,
+        params,
     ).fetchall()
 
+    sessions: list[dict[str, Any]] = []
     for row in session_rows:
         session_pk = int(row["id"])
         export_name = str(row["export_name"])
-        sessions.append(
-            {
-                "pid": _hash_id(salt, "project", export_name),
-                "sid": _hash_id(salt, "session", export_name, row["session_id"]),
-                "provider": DEFAULT_PROVIDER,
-                "models": contribution_helpers._session_models(conn, session_pk),
-                "first_date": contribution_helpers._date_only(row["first_ts"]),
-                "last_date": contribution_helpers._date_only(row["last_ts"]),
-                "duration_s": contribution_helpers._duration_s(row["first_ts"], row["last_ts"]),
-                "tokens": contribution_helpers._session_tokens(conn, session_pk),
-                "tokens_by_model": _session_tokens_by_model(conn, session_pk),
-                "stats": contribution_helpers._session_stats(conn, session_pk),
-                "stop_reasons": contribution_helpers._session_stop_reasons(conn, session_pk),
-                "risk_categories": contribution_helpers._session_risk_categories(conn, session_pk),
-                "subagents": contribution_helpers._session_subagents(conn, session_pk),
-                "sequence": contribution_helpers._session_sequence(conn, session_pk),
-            }
-        )
+        session: dict[str, Any] = {
+            "sid": _hash_id(salt, "session", export_name, row["session_id"]),
+            "provider": DEFAULT_PROVIDER,
+            "models": contribution_helpers._session_models(conn, session_pk),
+            "first_date": contribution_helpers._date_only(row["first_ts"]),
+            "last_date": contribution_helpers._date_only(row["last_ts"]),
+            "duration_s": contribution_helpers._duration_s(row["first_ts"], row["last_ts"]),
+            "tokens": contribution_helpers._session_tokens(conn, session_pk),
+            "tokens_by_model": _session_tokens_by_model(conn, session_pk),
+            "stats": contribution_helpers._session_stats(conn, session_pk),
+            "stop_reasons": contribution_helpers._session_stop_reasons(conn, session_pk),
+            "risk_categories": contribution_helpers._session_risk_categories(conn, session_pk),
+            "sequence": contribution_helpers._session_sequence(conn, session_pk),
+        }
+        if privacy_level == LEVEL_TEAM:
+            default_label = project_display_name(export_name, row["inferred_cwd"])
+            session["project_name"] = label_overrides.get(export_name, default_label)
+            session["subagents"] = _session_subagents_raw(conn, session_pk)
+            session["tools"] = _session_tools(conn, session_pk)
+            session["file_types"] = _session_file_types(conn, session_pk)
+        else:
+            session["pid"] = _hash_id(salt, "project", export_name)
+            session["subagents"] = contribution_helpers._session_subagents(conn, session_pk)
+        sessions.append(session)
 
     raw_bundle = TeamBundle(
         member_id=member_id,
@@ -208,6 +346,8 @@ def build_team_bundle(
         app_version=app_version,
         sessions=sessions,
         generated_seq=generated_seq,
+        privacy_level=privacy_level,
+        member_name=(member_name or "").strip() or None,
     )
     canonical = validate_team_bundle(raw_bundle.base_dict())
     return TeamBundle(
@@ -216,46 +356,78 @@ def build_team_bundle(
         app_version=canonical["app_version"],
         sessions=canonical["sessions"],
         generated_seq=canonical["generated_seq"],
+        privacy_level=canonical["privacy_level"],
+        member_name=canonical["member_name"],
         bundle_id=canonical["bundle_id"],
     )
 
 
 def team_bundle_manifest(bundle: TeamBundle) -> dict[str, Any]:
     sessions = bundle.sessions
-    return {
-        "profile": PROFILE,
+    manifest: dict[str, Any] = {
+        "privacy_level": bundle.privacy_level,
         "session_count": len(sessions),
         "sequence_step_count": sum(len(session["sequence"]) for session in sessions),
-        "included_fields": [
+    }
+    if bundle.privacy_level == LEVEL_TEAM:
+        manifest["included_fields"] = [
+            "Your member name and the selected projects' names (editable labels)",
+            "Real tool, MCP server, and subagent names with call counts",
+            "File-type mix (extensions only — never paths or file names)",
+            "Provider and bucketed model families",
+            "Date-only session timing and structural per-step deltas",
+            "Token counts with cache breakdowns, split per model family",
+            "Session stats, stop reasons, risk categories",
+        ]
+        manifest["excluded"] = [
+            "Prompts, assistant text, reasoning, titles, and free text",
+            "Paths, cwd, branches, file names, shell commands, and tool IO",
+            "Raw JSON and previews",
+        ]
+        manifest["fingerprint_caveat"] = (
+            "Team level: your name, project names, tool names, and file types are visible "
+            "to everyone who imports this bundle. Conversation content never leaves this machine."
+        )
+    else:
+        manifest["included_fields"] = [
             "Pseudonymous member, project, and session IDs",
             "Provider and bucketed model families",
             "Date-only session timing and structural per-step deltas",
             "Token counts with cache breakdowns, split per model family",
             "Session stats, stop reasons, risk categories",
             "Bucketed subagent types and structural event sequence",
-        ],
-        "excluded": [
+        ]
+        manifest["excluded"] = [
             "Raw JSON and previews",
             "Prompts, assistant text, reasoning, titles, and free text",
             "Paths, cwd, branches, file names, shell commands, and tool IO",
             "Raw model aliases, MCP server names, and custom subagent names",
-        ],
-        "fingerprint_caveat": (
+        ]
+        manifest["fingerprint_caveat"] = (
             "This bundle contains no content, but token counts and structural sequences "
             "can still be distinctive."
-        ),
-    }
+        )
+    return manifest
 
 
 def validate_team_bundle(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("team bundle must be a JSON object")
+    version = payload.get("schema_version")
+    if version == LEGACY_SCHEMA_VERSION:
+        return _validate_v1(payload)
+    if version == SCHEMA_VERSION:
+        return _validate_v2(payload)
+    raise ValueError("unsupported team bundle schema_version")
+
+
+def _validate_v1(payload: dict[str, Any]) -> dict[str, Any]:
     unknown = set(payload) - TOP_LEVEL_KEYS
     if unknown:
         raise ValueError(f"unexpected team bundle field: {sorted(unknown)[0]}")
     if payload.get("profile") != PROFILE:
         raise ValueError("unsupported team bundle profile")
-    if payload.get("schema_version") != SCHEMA_VERSION:
+    if payload.get("schema_version") != LEGACY_SCHEMA_VERSION:
         raise ValueError("unsupported team bundle schema_version")
 
     member_id = _required_str(payload.get("member_id"), "member_id")
@@ -267,7 +439,7 @@ def validate_team_bundle(payload: Any) -> dict[str, Any]:
         raise ValueError("sessions must be a list")
 
     raw_base = {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": LEGACY_SCHEMA_VERSION,
         "profile": PROFILE,
         "member_id": member_id,
         "generated_at": generated_at,
@@ -279,17 +451,19 @@ def validate_team_bundle(payload: Any) -> dict[str, Any]:
     sessions: list[dict[str, Any]] = []
     seen_sids: set[str] = set()
     for index, raw_session in enumerate(raw_sessions):
-        session = _validate_session(raw_session, index)
+        session = _validate_session(raw_session, index, LEVEL_STRUCTURAL)
         sid = session["sid"]
         if sid in seen_sids:
             raise ValueError("duplicate session id in team bundle")
         seen_sids.add(sid)
         sessions.append(session)
 
-    canonical = {
-        "schema_version": SCHEMA_VERSION,
+    canonical: dict[str, Any] = {
+        "schema_version": LEGACY_SCHEMA_VERSION,
         "profile": PROFILE,
+        "privacy_level": LEVEL_STRUCTURAL,
         "member_id": member_id,
+        "member_name": None,
         "generated_at": generated_at,
         "generated_seq": generated_seq,
         "app_version": app_version,
@@ -301,6 +475,84 @@ def validate_team_bundle(payload: Any) -> dict[str, Any]:
         raise ValueError("bundle_id does not match bundle content")
     canonical["bundle_id"] = computed_id
     return canonical
+
+
+def _validate_v2(payload: dict[str, Any]) -> dict[str, Any]:
+    unknown = set(payload) - TOP_LEVEL_KEYS_V2
+    if unknown:
+        raise ValueError(f"unexpected team bundle field: {sorted(unknown)[0]}")
+    level = payload.get("privacy_level")
+    if level in RESERVED_LEVELS:
+        raise ValueError(f"privacy_level not yet supported: {level}")
+    if level not in BUILD_LEVELS:
+        raise ValueError("unsupported team bundle privacy_level")
+
+    member_id = _required_str(payload.get("member_id"), "member_id")
+    if level == LEVEL_TEAM:
+        member_name = _member_name(payload.get("member_name"))
+    else:
+        if payload.get("member_name") is not None:
+            raise ValueError("member_name is not allowed at the structural level")
+        member_name = None
+    generated_at = _date_or_string(payload.get("generated_at"), "generated_at")
+    generated_seq = _generated_seq(payload.get("generated_seq"))
+    app_version = _required_str(payload.get("app_version"), "app_version")
+    raw_sessions = payload.get("sessions")
+    if not isinstance(raw_sessions, list):
+        raise ValueError("sessions must be a list")
+
+    sessions: list[dict[str, Any]] = []
+    seen_sids: set[str] = set()
+    for index, raw_session in enumerate(raw_sessions):
+        session = _validate_session(raw_session, index, level)
+        sid = session["sid"]
+        if sid in seen_sids:
+            raise ValueError("duplicate session id in team bundle")
+        seen_sids.add(sid)
+        sessions.append(session)
+
+    canonical: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "privacy_level": level,
+        "profile": level,  # stored in the team_bundles.profile column
+        "member_id": member_id,
+        "member_name": member_name,
+        "generated_at": generated_at,
+        "generated_seq": generated_seq,
+        "app_version": app_version,
+        "sessions": sessions,
+    }
+    if level == LEVEL_TEAM:
+        canonical_for_id = dict(canonical)
+    else:
+        canonical_for_id = {k: v for k, v in canonical.items() if k != "member_name"}
+    computed_id = bundle_content_id_v2(canonical_for_id)
+    supplied_id = payload.get("bundle_id")
+    if supplied_id is not None and str(supplied_id) != computed_id:
+        raise ValueError("bundle_id does not match bundle content")
+    canonical["bundle_id"] = computed_id
+    return canonical
+
+
+def _member_name(value: Any) -> str:
+    name = _required_str(value, "member_name").strip()
+    if not name:
+        raise ValueError("member_name must be a non-empty string")
+    if len(name) > 80:
+        raise ValueError("member_name is too long (max 80 characters)")
+    return name
+
+
+def _project_label(value: Any, name: str) -> str:
+    label = _required_str(value, name).strip()
+    if not label:
+        raise ValueError(f"{name} must be a non-empty string")
+    if len(label) > 120:
+        raise ValueError(f"{name} is too long (max 120 characters)")
+    if "/" in label or "\\" in label:
+        raise ValueError(f"{name} must not contain path separators")
+    normalize_project_key(label)  # reject labels that normalize to nothing
+    return label
 
 
 def import_team_bundle(
@@ -393,7 +645,7 @@ def import_team_bundle(
                 (
                     team_bundle_id,
                     bundle["member_id"],
-                    session["pid"],
+                    session.get("pid") or normalize_project_key(session["project_name"]),
                     session["sid"],
                     session["provider"],
                     session["first_date"],
@@ -584,17 +836,15 @@ def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
     }
 
 
-def _validate_session(raw_session: Any, index: int) -> dict[str, Any]:
+def _validate_session(raw_session: Any, index: int, level: str) -> dict[str, Any]:
     if not isinstance(raw_session, dict):
         raise ValueError(f"sessions[{index}] must be an object")
-    unknown = set(raw_session) - SESSION_KEYS
+    allowed = SESSION_KEYS_TEAM if level == LEVEL_TEAM else SESSION_KEYS
+    unknown = set(raw_session) - allowed
     if unknown:
         raise ValueError(f"unexpected session field: {sorted(unknown)[0]}")
-    pid = _hex_id(raw_session.get("pid"), f"sessions[{index}].pid")
-    sid = _hex_id(raw_session.get("sid"), f"sessions[{index}].sid")
-    return {
-        "pid": pid,
-        "sid": sid,
+    session: dict[str, Any] = {
+        "sid": _hex_id(raw_session.get("sid"), f"sessions[{index}].sid"),
         "provider": _provider(raw_session.get("provider")),
         "models": _models(raw_session.get("models")),
         "first_date": _optional_date(raw_session.get("first_date"), f"sessions[{index}].first_date"),
@@ -605,9 +855,18 @@ def _validate_session(raw_session: Any, index: int) -> dict[str, Any]:
         "stats": _number_map(raw_session.get("stats"), STAT_KEYS),
         "stop_reasons": _stop_reasons(raw_session.get("stop_reasons")),
         "risk_categories": _risk_categories(raw_session.get("risk_categories")),
-        "subagents": _subagents(raw_session.get("subagents")),
+        "subagents": _subagents(raw_session.get("subagents"), raw=(level == LEVEL_TEAM)),
         "sequence": _sequence(raw_session.get("sequence")),
     }
+    if level == LEVEL_TEAM:
+        session["project_name"] = _project_label(
+            raw_session.get("project_name"), f"sessions[{index}].project_name"
+        )
+        session["tools"] = _tools(raw_session.get("tools"))
+        session["file_types"] = _file_types(raw_session.get("file_types"))
+    else:
+        session["pid"] = _hex_id(raw_session.get("pid"), f"sessions[{index}].pid")
+    return session
 
 
 def _required_str(value: Any, name: str) -> str:
@@ -698,7 +957,49 @@ def _risk_categories(value: Any) -> list[str]:
     return sorted({str(item) if str(item) in RISK_CATEGORIES else "other" for item in value})
 
 
-def _subagents(value: Any) -> list[dict[str, int | str]]:
+def _tools(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("tools must be a list")
+    if len(value) > _MAX_TOOLS_PER_SESSION:
+        raise ValueError("tools list is too long")
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("tools entries must be objects")
+        unknown = set(item) - {"name", "calls"}
+        if unknown:
+            raise ValueError(f"unexpected tool field: {sorted(unknown)[0]}")
+        name = _required_str(item.get("name"), "tools[].name").strip()
+        if len(name) > 120:
+            raise ValueError("tool name is too long (max 120 characters)")
+        result.append({"name": name, "calls": _nonnegative_int(item.get("calls"))})
+    return sorted(result, key=lambda entry: entry["name"])
+
+
+def _file_types(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("file_types must be a list")
+    if len(value) > _MAX_FILE_TYPES_PER_SESSION:
+        raise ValueError("file_types list is too long")
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("file_types entries must be objects")
+        unknown = set(item) - {"ext", "count"}
+        if unknown:
+            raise ValueError(f"unexpected file_types field: {sorted(unknown)[0]}")
+        ext = _required_str(item.get("ext"), "file_types[].ext")
+        if not _EXT_RE.match(ext):
+            raise ValueError(f"invalid file extension: {ext!r}")
+        result.append({"ext": ext, "count": _nonnegative_int(item.get("count"))})
+    return sorted(result, key=lambda entry: entry["ext"])
+
+
+def _subagents(value: Any, *, raw: bool = False) -> list[dict[str, int | str]]:
     if not isinstance(value, list):
         return []
     result: list[dict[str, int | str]] = []
@@ -708,12 +1009,13 @@ def _subagents(value: Any) -> list[dict[str, int | str]]:
         unknown = set(item) - {"agent_type", "event_count"}
         if unknown:
             raise ValueError(f"unexpected subagent field: {sorted(unknown)[0]}")
-        result.append(
-            {
-                "agent_type": bucket_agent_type(item.get("agent_type")),
-                "event_count": _nonnegative_int(item.get("event_count")),
-            }
-        )
+        if raw:
+            agent_type = str(item.get("agent_type") or "").strip() or "custom"
+            if len(agent_type) > 80:
+                raise ValueError("subagent agent_type is too long (max 80 characters)")
+        else:
+            agent_type = bucket_agent_type(item.get("agent_type"))
+        result.append({"agent_type": agent_type, "event_count": _nonnegative_int(item.get("event_count"))})
     return result
 
 

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -37,7 +37,7 @@ BUILD_LEVELS = (LEVEL_STRUCTURAL, LEVEL_TEAM)
 # Ladder rungs reserved for raw-session sharing (separate sub-project).
 RESERVED_LEVELS = ("sessions", "raw")
 
-_EXT_RE = re.compile(r"^[a-z0-9_+-]{1,12}$")
+_EXT_RE = re.compile(r"^[a-z0-9_+-]{1,12}\Z")
 _MAX_TOOLS_PER_SESSION = 300
 _MAX_FILE_TYPES_PER_SESSION = 100
 

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -612,16 +612,17 @@ def import_team_bundle(
         cur = conn.execute(
             """
             INSERT INTO team_bundles(
-                bundle_id, profile, schema_version, member_id, generated_at, generated_seq,
-                app_version, imported_at, source_path, session_count
+                bundle_id, profile, schema_version, member_id, member_name, generated_at,
+                generated_seq, app_version, imported_at, source_path, session_count
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 bundle["bundle_id"],
                 bundle["profile"],
                 bundle["schema_version"],
                 bundle["member_id"],
+                bundle["member_name"],
                 bundle["generated_at"],
                 bundle["generated_seq"],
                 bundle["app_version"],
@@ -631,21 +632,20 @@ def import_team_bundle(
             ),
         )
         team_bundle_id = int(cur.lastrowid)
-        conn.executemany(
-            """
-            INSERT INTO team_bundle_sessions(
-                team_bundle_id, member_id, project_id, session_id, provider,
-                first_date, last_date, duration_s, models_json, tokens_json,
-                tokens_by_model_json, stats_json, stop_reasons_json,
-                risk_categories_json, subagents_json, sequence_json
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            [
+        session_rows = []
+        for session in bundle["sessions"]:
+            if bundle["profile"] == LEVEL_TEAM:
+                project_key = normalize_project_key(session["project_name"])
+                project_name = session["project_name"]
+            else:
+                project_key = session["pid"]
+                project_name = None
+            session_rows.append(
                 (
                     team_bundle_id,
                     bundle["member_id"],
-                    session.get("pid") or normalize_project_key(session["project_name"]),
+                    project_key,
+                    project_name,
                     session["sid"],
                     session["provider"],
                     session["first_date"],
@@ -658,10 +658,22 @@ def import_team_bundle(
                     _json(session["stop_reasons"]),
                     _json(session["risk_categories"]),
                     _json(session["subagents"]),
+                    _json(session.get("tools", [])),
+                    _json(session.get("file_types", [])),
                     _json(session["sequence"]),
                 )
-                for session in bundle["sessions"]
-            ],
+            )
+        conn.executemany(
+            """
+            INSERT INTO team_bundle_sessions(
+                team_bundle_id, member_id, project_id, project_name, session_id, provider,
+                first_date, last_date, duration_s, models_json, tokens_json,
+                tokens_by_model_json, stats_json, stop_reasons_json,
+                risk_categories_json, subagents_json, tools_json, file_types_json, sequence_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            session_rows,
         )
 
     return TeamImportResult(
@@ -676,13 +688,13 @@ def import_team_bundle(
 def list_team_imports(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     rows = conn.execute(
         """
-        SELECT id, bundle_id, profile, schema_version, member_id, generated_at,
+        SELECT id, bundle_id, profile, schema_version, member_id, member_name, generated_at,
                app_version, imported_at, source_path, session_count
         FROM team_bundles
         ORDER BY imported_at DESC, id DESC
         """
     ).fetchall()
-    return [dict(row) for row in rows]
+    return [dict(row) | {"privacy_level": privacy_level_of(row["profile"])} for row in rows]
 
 
 def delete_team_member(conn: sqlite3.Connection, member_id: str) -> int:
@@ -704,14 +716,15 @@ def reset_team_bundles(conn: sqlite3.Connection) -> None:
 
 def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
     bundles = conn.execute(
-        "SELECT bundle_id, member_id, session_count FROM team_bundles ORDER BY imported_at, id"
+        "SELECT bundle_id, member_id, member_name, session_count FROM team_bundles ORDER BY imported_at, id"
     ).fetchall()
     sessions = conn.execute(
         """
-        SELECT tb.bundle_id, tbs.member_id, tbs.project_id, tbs.provider,
+        SELECT tb.bundle_id, tbs.member_id, tbs.project_id, tbs.project_name, tbs.provider,
                tbs.first_date, tbs.last_date, tbs.duration_s, tbs.models_json,
                tbs.tokens_json, tbs.stats_json, tbs.stop_reasons_json,
-               tbs.risk_categories_json, tbs.subagents_json, tbs.sequence_json
+               tbs.risk_categories_json, tbs.subagents_json, tbs.tools_json,
+               tbs.file_types_json, tbs.sequence_json
         FROM team_bundle_sessions tbs
         JOIN team_bundles tb ON tb.id = tbs.team_bundle_id
         ORDER BY tbs.first_date, tbs.id
@@ -728,15 +741,36 @@ def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
     subagent_events: Counter[str] = Counter()
     subagent_sessions: Counter[str] = Counter()
     over_time: dict[str, dict[str, int]] = defaultdict(lambda: {"session_count": 0, "tokens": 0})
+
+    name_by_member: dict[str, str | None] = {
+        str(bundle["member_id"]): bundle["member_name"] for bundle in bundles
+    }
+
+    def _member_key(member_id: str) -> str:
+        return name_by_member.get(member_id) or f"id:{member_id}"
+
+    def _member_label(member_id: str) -> str:
+        return name_by_member.get(member_id) or f"member-{member_id[:8]}"
+
     member_summary: dict[str, dict[str, Any]] = defaultdict(
-        lambda: {"bundle_ids": set(), "project_ids": set(), "session_count": 0, "tokens": 0}
+        lambda: {"label": "", "member_ids": set(), "bundle_ids": set(), "project_ids": set(),
+                 "session_count": 0, "tokens": 0}
     )
+    project_summary: dict[str, dict[str, Any]] = {}
+    tool_calls_total: Counter[str] = Counter()
+    tool_sessions: Counter[str] = Counter()
+    file_type_counts: Counter[str] = Counter()
+    file_type_sessions: Counter[str] = Counter()
     project_ids: set[str] = set()
     first_dates: list[str] = []
     last_dates: list[str] = []
 
     for bundle in bundles:
-        member_summary[str(bundle["member_id"])]["bundle_ids"].add(str(bundle["bundle_id"]))
+        member_id = str(bundle["member_id"])
+        summary = member_summary[_member_key(member_id)]
+        summary["label"] = _member_label(member_id)
+        summary["member_ids"].add(member_id)
+        summary["bundle_ids"].add(str(bundle["bundle_id"]))
 
     for row in sessions:
         member_id = str(row["member_id"])
@@ -777,13 +811,46 @@ def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
             if isinstance(step, dict) and step.get("sym"):
                 sequence_counts[str(step["sym"])] += 1
 
-        project_id = str(row["project_id"])
-        project_ids.add(project_id)
-
         session_tokens = _nonnegative_int(tokens.get("input")) + _nonnegative_int(tokens.get("output"))
-        member_summary[member_id]["project_ids"].add(project_id)
-        member_summary[member_id]["session_count"] += 1
-        member_summary[member_id]["tokens"] += session_tokens
+
+        project_key = str(row["project_id"])
+        project_ids.add(project_key)
+        project = project_summary.setdefault(
+            project_key,
+            {"project_key": project_key, "project_name": row["project_name"] or project_key[:8],
+             "members": set(), "session_count": 0, "tokens": 0},
+        )
+        if row["project_name"] and project["project_name"] == project_key[:8]:
+            project["project_name"] = str(row["project_name"])
+        project["members"].add(_member_key(member_id))
+        project["session_count"] += 1
+        project["tokens"] += session_tokens
+
+        tools = _loads_list(row["tools_json"])
+        seen_tools: set[str] = set()
+        for tool in tools:
+            if not isinstance(tool, dict) or not tool.get("name"):
+                continue
+            name = str(tool["name"])
+            tool_calls_total[name] += _nonnegative_int(tool.get("calls"))
+            seen_tools.add(name)
+        for name in seen_tools:
+            tool_sessions[name] += 1
+
+        file_types = _loads_list(row["file_types_json"])
+        seen_exts: set[str] = set()
+        for entry in file_types:
+            if not isinstance(entry, dict) or not entry.get("ext"):
+                continue
+            ext = str(entry["ext"])
+            file_type_counts[ext] += _nonnegative_int(entry.get("count"))
+            seen_exts.add(ext)
+        for ext in seen_exts:
+            file_type_sessions[ext] += 1
+
+        member_summary[_member_key(member_id)]["project_ids"].add(project_key)
+        member_summary[_member_key(member_id)]["session_count"] += 1
+        member_summary[_member_key(member_id)]["tokens"] += session_tokens
         if row["first_date"]:
             bucket = str(row["first_date"])
             first_dates.append(bucket)
@@ -821,13 +888,34 @@ def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
         ],
         "members": [
             {
-                "member_id": member_id,
+                "member_name": summary["label"],
+                "member_ids": sorted(summary["member_ids"]),
                 "bundle_count": len(summary["bundle_ids"]),
                 "project_count": len(summary["project_ids"]),
                 "session_count": int(summary["session_count"]),
                 "tokens": int(summary["tokens"]),
             }
-            for member_id, summary in sorted(member_summary.items())
+            for _key, summary in sorted(member_summary.items(), key=lambda item: item[1]["label"])
+        ],
+        "projects": [
+            {
+                "project_key": project["project_key"],
+                "project_name": project["project_name"],
+                "member_count": len(project["members"]),
+                "session_count": int(project["session_count"]),
+                "tokens": int(project["tokens"]),
+            }
+            for project in sorted(
+                project_summary.values(), key=lambda item: (-item["tokens"], item["project_name"])
+            )
+        ],
+        "tools": [
+            {"name": name, "call_count": tool_calls_total[name], "session_count": tool_sessions[name]}
+            for name, _count in sorted(tool_calls_total.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "file_types": [
+            {"ext": ext, "count": file_type_counts[ext], "session_count": file_type_sessions[ext]}
+            for ext, _count in sorted(file_type_counts.items(), key=lambda item: (-item[1], item[0]))
         ],
         "over_time": [
             {"date": bucket, **values}

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -61,6 +61,7 @@ TOP_LEVEL_KEYS = {
     "bundle_id",
     "member_id",
     "generated_at",
+    "generated_seq",
     "app_version",
     "sessions",
 }
@@ -84,6 +85,10 @@ class TeamBundle:
     generated_at: str
     app_version: str
     sessions: list[dict[str, Any]] = field(default_factory=list)
+    # Per-member monotonic export counter (defaults to 0 for legacy v1 bundles).
+    # Not part of bundle_content_id's key tuple: two identical-content same-day
+    # bundles legitimately share a content id (the duplicate check handles them).
+    generated_seq: int = 0
     bundle_id: str | None = None
 
     def base_dict(self) -> dict[str, Any]:
@@ -92,6 +97,7 @@ class TeamBundle:
             "profile": PROFILE,
             "member_id": self.member_id,
             "generated_at": self.generated_at,
+            "generated_seq": self.generated_seq,
             "app_version": self.app_version,
             "sessions": self.sessions,
         }
@@ -162,6 +168,7 @@ def build_team_bundle(
     member_id: str,
     app_version: str,
     generated_on: date,
+    generated_seq: int = 0,
 ) -> TeamBundle:
     sessions: list[dict[str, Any]] = []
     session_rows = conn.execute(
@@ -200,6 +207,7 @@ def build_team_bundle(
         generated_at=generated_on.isoformat(),
         app_version=app_version,
         sessions=sessions,
+        generated_seq=generated_seq,
     )
     canonical = validate_team_bundle(raw_bundle.base_dict())
     return TeamBundle(
@@ -207,6 +215,7 @@ def build_team_bundle(
         generated_at=canonical["generated_at"],
         app_version=canonical["app_version"],
         sessions=canonical["sessions"],
+        generated_seq=canonical["generated_seq"],
         bundle_id=canonical["bundle_id"],
     )
 
@@ -251,6 +260,7 @@ def validate_team_bundle(payload: Any) -> dict[str, Any]:
 
     member_id = _required_str(payload.get("member_id"), "member_id")
     generated_at = _date_or_string(payload.get("generated_at"), "generated_at")
+    generated_seq = _generated_seq(payload.get("generated_seq"))
     app_version = _required_str(payload.get("app_version"), "app_version")
     raw_sessions = payload.get("sessions")
     if not isinstance(raw_sessions, list):
@@ -281,6 +291,7 @@ def validate_team_bundle(payload: Any) -> dict[str, Any]:
         "profile": PROFILE,
         "member_id": member_id,
         "generated_at": generated_at,
+        "generated_seq": generated_seq,
         "app_version": app_version,
         "sessions": sessions,
     }
@@ -312,18 +323,29 @@ def import_team_bundle(
             status="duplicate",
         )
 
-    newest = conn.execute(
-        "SELECT MAX(generated_at) FROM team_bundles WHERE member_id = ?",
+    # Ordered by (generated_at, generated_seq) so two different bundles from the
+    # same member on the same day are ordered by export sequence rather than
+    # silently replacing each other based on import order.
+    newest_row = conn.execute(
+        """
+        SELECT generated_at, generated_seq FROM team_bundles
+        WHERE member_id = ?
+        ORDER BY generated_at DESC, generated_seq DESC
+        LIMIT 1
+        """,
         (bundle["member_id"],),
-    ).fetchone()[0]
-    if newest is not None and str(bundle["generated_at"]) < str(newest):
-        return TeamImportResult(
-            bundle_id=bundle["bundle_id"],
-            member_id=bundle["member_id"],
-            session_count=0,
-            imported=False,
-            status="stale",
-        )
+    ).fetchone()
+    if newest_row is not None:
+        newest_tuple = (str(newest_row["generated_at"]), int(newest_row["generated_seq"] or 0))
+        incoming_tuple = (str(bundle["generated_at"]), int(bundle["generated_seq"]))
+        if incoming_tuple < newest_tuple:
+            return TeamImportResult(
+                bundle_id=bundle["bundle_id"],
+                member_id=bundle["member_id"],
+                session_count=0,
+                imported=False,
+                status="stale",
+            )
 
     imported_at = datetime.now(timezone.utc).isoformat()
     with conn:
@@ -338,10 +360,10 @@ def import_team_bundle(
         cur = conn.execute(
             """
             INSERT INTO team_bundles(
-                bundle_id, profile, schema_version, member_id, generated_at,
+                bundle_id, profile, schema_version, member_id, generated_at, generated_seq,
                 app_version, imported_at, source_path, session_count
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 bundle["bundle_id"],
@@ -349,6 +371,7 @@ def import_team_bundle(
                 bundle["schema_version"],
                 bundle["member_id"],
                 bundle["generated_at"],
+                bundle["generated_seq"],
                 bundle["app_version"],
                 imported_at,
                 str(source_path),
@@ -604,6 +627,17 @@ def _optional_date(value: Any, name: str) -> str | None:
     if value is None:
         return None
     return _date_or_string(value, name)
+
+
+def _generated_seq(value: Any) -> int:
+    # Missing generated_seq means a legacy (pre-sequence) bundle: treat as 0.
+    if value is None:
+        return 0
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("generated_seq must be a non-negative integer")
+    if value < 0:
+        raise ValueError("generated_seq must be a non-negative integer")
+    return value
 
 
 def _hex_id(value: Any, name: str) -> str:

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -1,0 +1,707 @@
+"""Team-strict privacy bundle export/import and dashboard aggregation.
+
+The bundle is built from an explicit structural allowlist and reuses the
+contribution sanitizers for model/tool/subagent buckets. Imports are
+canonicalized before persistence so the team tables never need raw Claude
+export content, previews, paths, commands, prompts, model aliases, or MCP names.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ccfr.analysis.contribution import (
+    KNOWN_STOP_REASONS,
+    bucket_agent_type,
+    bucket_model,
+    sanitize_symbol,
+)
+from ccfr.analysis import contribution as contribution_helpers
+
+SCHEMA_VERSION = 1
+PROFILE = "team_strict"
+DEFAULT_PROVIDER = "claude"
+
+TOKEN_KEYS = ("input", "output", "base", "cache_5m", "cache_1h", "cache_read")
+STAT_KEYS = (
+    "turns",
+    "tool_calls",
+    "subagents",
+    "errors",
+    "system",
+    "loops",
+    "max_repeat",
+    "persisted_outputs",
+)
+SESSION_KEYS = {
+    "pid",
+    "sid",
+    "provider",
+    "models",
+    "first_date",
+    "last_date",
+    "duration_s",
+    "tokens",
+    "tokens_by_model",
+    "stats",
+    "stop_reasons",
+    "risk_categories",
+    "subagents",
+    "sequence",
+}
+TOP_LEVEL_KEYS = {
+    "schema_version",
+    "profile",
+    "bundle_id",
+    "member_id",
+    "generated_at",
+    "app_version",
+    "sessions",
+}
+RISK_CATEGORIES = frozenset(
+    {
+        "cost_context_blowup",
+        "environment_mismatch",
+        "failed_verification_repair_loop",
+        "fanout_overload",
+        "permission_friction",
+        "rare_workflow_deviation",
+        "subagent_failure_propagation",
+        "unsafe_write_attempt",
+    }
+)
+
+
+@dataclass
+class TeamBundle:
+    member_id: str
+    generated_at: str
+    app_version: str
+    sessions: list[dict[str, Any]] = field(default_factory=list)
+    bundle_id: str | None = None
+
+    def base_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "profile": PROFILE,
+            "member_id": self.member_id,
+            "generated_at": self.generated_at,
+            "app_version": self.app_version,
+            "sessions": self.sessions,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        data = self.base_dict()
+        data["bundle_id"] = self.bundle_id or bundle_content_id(data)
+        return data
+
+
+@dataclass(frozen=True)
+class TeamImportResult:
+    bundle_id: str
+    member_id: str
+    session_count: int
+    imported: bool
+
+
+def _hash_id(salt: str, namespace: str, *parts: object) -> str:
+    body = "\0".join([PROFILE, namespace, *[str(part) for part in parts]])
+    return hashlib.sha256(f"{salt}\0{body}".encode()).hexdigest()
+
+
+def bundle_content_id(bundle: dict[str, Any]) -> str:
+    base = {key: bundle[key] for key in (
+        "schema_version", "profile", "member_id", "generated_at", "app_version", "sessions",
+    )}
+    encoded = json.dumps(base, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _fold_tokens_by_model(pairs: Any) -> dict[str, dict[str, int]]:
+    """Merge (family, token-map) pairs into per-family totals, dropping empties."""
+    out: dict[str, dict[str, int]] = {}
+    for family, tokens in pairs:
+        bucket = out.setdefault(family, {key: 0 for key in TOKEN_KEYS})
+        for key in TOKEN_KEYS:
+            bucket[key] += tokens[key]
+    return {family: vals for family, vals in out.items() if any(vals.values())}
+
+
+def _session_tokens_by_model(conn: sqlite3.Connection, session_pk: int) -> dict[str, dict[str, int]]:
+    rows = conn.execute(
+        """
+        SELECT m.model AS model,
+               COALESCE(SUM(m.input_tokens), 0)      AS input,
+               COALESCE(SUM(m.output_tokens), 0)     AS output,
+               COALESCE(SUM(m.base_input_tokens), 0) AS base,
+               COALESCE(SUM(m.cache_5m_tokens), 0)   AS cache_5m,
+               COALESCE(SUM(m.cache_1h_tokens), 0)   AS cache_1h,
+               COALESCE(SUM(m.cache_read_tokens), 0) AS cache_read
+        FROM messages m JOIN events e ON e.id = m.event_id
+        WHERE e.session_id = ?
+        GROUP BY m.model
+        """,
+        (session_pk,),
+    ).fetchall()
+    return _fold_tokens_by_model(
+        (bucket_model(row["model"]), {key: int(row[key]) for key in TOKEN_KEYS}) for row in rows
+    )
+
+
+def build_team_bundle(
+    conn: sqlite3.Connection,
+    *,
+    salt: str,
+    member_id: str,
+    app_version: str,
+    generated_on: date,
+) -> TeamBundle:
+    sessions: list[dict[str, Any]] = []
+    session_rows = conn.execute(
+        """
+        SELECT s.id, s.session_id, s.first_ts, s.last_ts, p.export_name
+        FROM sessions s
+        JOIN projects p ON p.id = s.project_id
+        ORDER BY p.id, s.id
+        """
+    ).fetchall()
+
+    for row in session_rows:
+        session_pk = int(row["id"])
+        export_name = str(row["export_name"])
+        sessions.append(
+            {
+                "pid": _hash_id(salt, "project", export_name),
+                "sid": _hash_id(salt, "session", export_name, row["session_id"]),
+                "provider": DEFAULT_PROVIDER,
+                "models": contribution_helpers._session_models(conn, session_pk),
+                "first_date": contribution_helpers._date_only(row["first_ts"]),
+                "last_date": contribution_helpers._date_only(row["last_ts"]),
+                "duration_s": contribution_helpers._duration_s(row["first_ts"], row["last_ts"]),
+                "tokens": contribution_helpers._session_tokens(conn, session_pk),
+                "tokens_by_model": _session_tokens_by_model(conn, session_pk),
+                "stats": contribution_helpers._session_stats(conn, session_pk),
+                "stop_reasons": contribution_helpers._session_stop_reasons(conn, session_pk),
+                "risk_categories": contribution_helpers._session_risk_categories(conn, session_pk),
+                "subagents": contribution_helpers._session_subagents(conn, session_pk),
+                "sequence": contribution_helpers._session_sequence(conn, session_pk),
+            }
+        )
+
+    raw_bundle = TeamBundle(
+        member_id=member_id,
+        generated_at=generated_on.isoformat(),
+        app_version=app_version,
+        sessions=sessions,
+    )
+    canonical = validate_team_bundle(raw_bundle.base_dict())
+    return TeamBundle(
+        member_id=canonical["member_id"],
+        generated_at=canonical["generated_at"],
+        app_version=canonical["app_version"],
+        sessions=canonical["sessions"],
+        bundle_id=canonical["bundle_id"],
+    )
+
+
+def team_bundle_manifest(bundle: TeamBundle) -> dict[str, Any]:
+    sessions = bundle.sessions
+    return {
+        "profile": PROFILE,
+        "session_count": len(sessions),
+        "sequence_step_count": sum(len(session["sequence"]) for session in sessions),
+        "included_fields": [
+            "Pseudonymous member, project, and session IDs",
+            "Provider and bucketed model families",
+            "Date-only session timing and structural per-step deltas",
+            "Token counts with cache breakdowns, split per model family",
+            "Session stats, stop reasons, risk categories",
+            "Bucketed subagent types and structural event sequence",
+        ],
+        "excluded": [
+            "Raw JSON and previews",
+            "Prompts, assistant text, reasoning, titles, and free text",
+            "Paths, cwd, branches, file names, shell commands, and tool IO",
+            "Raw model aliases, MCP server names, and custom subagent names",
+        ],
+        "fingerprint_caveat": (
+            "This bundle contains no content, but token counts and structural sequences "
+            "can still be distinctive."
+        ),
+    }
+
+
+def validate_team_bundle(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("team bundle must be a JSON object")
+    unknown = set(payload) - TOP_LEVEL_KEYS
+    if unknown:
+        raise ValueError(f"unexpected team bundle field: {sorted(unknown)[0]}")
+    if payload.get("profile") != PROFILE:
+        raise ValueError("unsupported team bundle profile")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported team bundle schema_version")
+
+    member_id = _required_str(payload.get("member_id"), "member_id")
+    generated_at = _date_or_string(payload.get("generated_at"), "generated_at")
+    app_version = _required_str(payload.get("app_version"), "app_version")
+    raw_sessions = payload.get("sessions")
+    if not isinstance(raw_sessions, list):
+        raise ValueError("sessions must be a list")
+
+    raw_base = {
+        "schema_version": SCHEMA_VERSION,
+        "profile": PROFILE,
+        "member_id": member_id,
+        "generated_at": generated_at,
+        "app_version": app_version,
+        "sessions": raw_sessions,
+    }
+    legacy_export_id = bundle_content_id(raw_base)
+
+    sessions: list[dict[str, Any]] = []
+    seen_sids: set[str] = set()
+    for index, raw_session in enumerate(raw_sessions):
+        session = _validate_session(raw_session, index)
+        sid = session["sid"]
+        if sid in seen_sids:
+            raise ValueError("duplicate session id in team bundle")
+        seen_sids.add(sid)
+        sessions.append(session)
+
+    canonical = {
+        "schema_version": SCHEMA_VERSION,
+        "profile": PROFILE,
+        "member_id": member_id,
+        "generated_at": generated_at,
+        "app_version": app_version,
+        "sessions": sessions,
+    }
+    computed_id = bundle_content_id(canonical)
+    supplied_id = payload.get("bundle_id")
+    if supplied_id is not None and str(supplied_id) not in {computed_id, legacy_export_id}:
+        raise ValueError("bundle_id does not match bundle content")
+    canonical["bundle_id"] = computed_id
+    return canonical
+
+
+def import_team_bundle(
+    conn: sqlite3.Connection,
+    payload: Any,
+    *,
+    source_path: Path,
+) -> TeamImportResult:
+    bundle = validate_team_bundle(payload)
+    existing = conn.execute(
+        "SELECT session_count, member_id FROM team_bundles WHERE bundle_id = ?",
+        (bundle["bundle_id"],),
+    ).fetchone()
+    if existing is not None:
+        return TeamImportResult(
+            bundle_id=bundle["bundle_id"],
+            member_id=str(existing["member_id"]),
+            session_count=int(existing["session_count"]),
+            imported=False,
+        )
+
+    imported_at = datetime.now(timezone.utc).isoformat()
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO team_bundles(
+                bundle_id, profile, schema_version, member_id, generated_at,
+                app_version, imported_at, source_path, session_count
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                bundle["bundle_id"],
+                bundle["profile"],
+                bundle["schema_version"],
+                bundle["member_id"],
+                bundle["generated_at"],
+                bundle["app_version"],
+                imported_at,
+                str(source_path),
+                len(bundle["sessions"]),
+            ),
+        )
+        team_bundle_id = int(cur.lastrowid)
+        conn.executemany(
+            """
+            INSERT INTO team_bundle_sessions(
+                team_bundle_id, member_id, project_id, session_id, provider,
+                first_date, last_date, duration_s, models_json, tokens_json,
+                tokens_by_model_json, stats_json, stop_reasons_json,
+                risk_categories_json, subagents_json, sequence_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    team_bundle_id,
+                    bundle["member_id"],
+                    session["pid"],
+                    session["sid"],
+                    session["provider"],
+                    session["first_date"],
+                    session["last_date"],
+                    session["duration_s"],
+                    _json(session["models"]),
+                    _json(session["tokens"]),
+                    _json(session["tokens_by_model"]),
+                    _json(session["stats"]),
+                    _json(session["stop_reasons"]),
+                    _json(session["risk_categories"]),
+                    _json(session["subagents"]),
+                    _json(session["sequence"]),
+                )
+                for session in bundle["sessions"]
+            ],
+        )
+
+    return TeamImportResult(
+        bundle_id=bundle["bundle_id"],
+        member_id=bundle["member_id"],
+        session_count=len(bundle["sessions"]),
+        imported=True,
+    )
+
+
+def list_team_imports(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT id, bundle_id, profile, schema_version, member_id, generated_at,
+               app_version, imported_at, source_path, session_count
+        FROM team_bundles
+        ORDER BY imported_at DESC, id DESC
+        """
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def reset_team_bundles(conn: sqlite3.Connection) -> None:
+    with conn:
+        conn.execute("DELETE FROM team_bundle_sessions")
+        conn.execute("DELETE FROM team_bundles")
+
+
+def team_dashboard(conn: sqlite3.Connection) -> dict[str, Any]:
+    bundles = conn.execute(
+        "SELECT bundle_id, member_id, session_count FROM team_bundles ORDER BY imported_at, id"
+    ).fetchall()
+    sessions = conn.execute(
+        """
+        SELECT tb.bundle_id, tbs.member_id, tbs.project_id, tbs.provider,
+               tbs.first_date, tbs.last_date, tbs.duration_s, tbs.models_json,
+               tbs.tokens_json, tbs.stats_json, tbs.stop_reasons_json,
+               tbs.risk_categories_json, tbs.subagents_json, tbs.sequence_json
+        FROM team_bundle_sessions tbs
+        JOIN team_bundles tb ON tb.id = tbs.team_bundle_id
+        ORDER BY tbs.first_date, tbs.id
+        """
+    ).fetchall()
+
+    token_totals = {key: 0 for key in TOKEN_KEYS}
+    stat_totals = {key: 0 for key in STAT_KEYS}
+    provider_counts: Counter[str] = Counter()
+    model_counts: Counter[str] = Counter()
+    stop_reason_counts: Counter[str] = Counter()
+    risk_counts: Counter[str] = Counter()
+    sequence_counts: Counter[str] = Counter()
+    subagent_events: Counter[str] = Counter()
+    subagent_sessions: Counter[str] = Counter()
+    over_time: dict[str, dict[str, int]] = defaultdict(lambda: {"session_count": 0, "tokens": 0})
+    member_summary: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"bundle_ids": set(), "project_ids": set(), "session_count": 0, "tokens": 0}
+    )
+    project_ids: set[str] = set()
+    first_dates: list[str] = []
+    last_dates: list[str] = []
+
+    for bundle in bundles:
+        member_summary[str(bundle["member_id"])]["bundle_ids"].add(str(bundle["bundle_id"]))
+
+    for row in sessions:
+        member_id = str(row["member_id"])
+        tokens = _loads_dict(row["tokens_json"])
+        stats = _loads_dict(row["stats_json"])
+        models = _loads_list(row["models_json"])
+        stop_reasons = _loads_dict(row["stop_reasons_json"])
+        risks = _loads_list(row["risk_categories_json"])
+        subagents = _loads_list(row["subagents_json"])
+        sequence = _loads_list(row["sequence_json"])
+
+        for key in TOKEN_KEYS:
+            token_totals[key] += _nonnegative_int(tokens.get(key))
+        for key in STAT_KEYS:
+            value = _nonnegative_int(stats.get(key))
+            if key == "max_repeat":
+                stat_totals[key] = max(stat_totals[key], value)
+            else:
+                stat_totals[key] += value
+
+        provider_counts[str(row["provider"] or DEFAULT_PROVIDER)] += 1
+        for model in models:
+            model_counts[str(model)] += 1
+        for reason, count in stop_reasons.items():
+            stop_reason_counts[str(reason)] += _nonnegative_int(count)
+        for category in risks:
+            risk_counts[str(category)] += 1
+        for subagent in subagents:
+            if not isinstance(subagent, dict):
+                continue
+            agent_type = str(subagent.get("agent_type") or "custom")
+            subagent_events[agent_type] += _nonnegative_int(subagent.get("event_count"))
+            subagent_sessions[agent_type] += 1
+        for step in sequence:
+            if isinstance(step, dict) and step.get("sym"):
+                sequence_counts[str(step["sym"])] += 1
+
+        project_id = str(row["project_id"])
+        project_ids.add(project_id)
+
+        session_tokens = _nonnegative_int(tokens.get("input")) + _nonnegative_int(tokens.get("output"))
+        member_summary[member_id]["project_ids"].add(project_id)
+        member_summary[member_id]["session_count"] += 1
+        member_summary[member_id]["tokens"] += session_tokens
+        if row["first_date"]:
+            bucket = str(row["first_date"])
+            first_dates.append(bucket)
+            over_time[bucket]["session_count"] += 1
+            over_time[bucket]["tokens"] += session_tokens
+        if row["last_date"]:
+            last_dates.append(str(row["last_date"]))
+
+    return {
+        "meta": {
+            "bundle_count": len(bundles),
+            "member_count": len(member_summary),
+            "project_count": len(project_ids),
+            "session_count": len(sessions),
+            "date_from": min(first_dates) if first_dates else None,
+            "date_to": max([*last_dates, *first_dates]) if (last_dates or first_dates) else None,
+        },
+        "tokens": {**token_totals, "total": token_totals["input"] + token_totals["output"]},
+        "stats": stat_totals,
+        "providers": _count_entries(provider_counts, "provider"),
+        "models": _count_entries(model_counts, "model"),
+        "stop_reasons": _count_entries(stop_reason_counts, "reason", count_key="count"),
+        "risk_categories": _count_entries(risk_counts, "category", count_key="session_count"),
+        "subagents": [
+            {
+                "agent_type": agent_type,
+                "event_count": subagent_events[agent_type],
+                "session_count": subagent_sessions[agent_type],
+            }
+            for agent_type in sorted(subagent_events)
+        ],
+        "sequence": [
+            {"sym": sym, "count": count}
+            for sym, count in sequence_counts.most_common(20)
+        ],
+        "members": [
+            {
+                "member_id": member_id,
+                "bundle_count": len(summary["bundle_ids"]),
+                "project_count": len(summary["project_ids"]),
+                "session_count": int(summary["session_count"]),
+                "tokens": int(summary["tokens"]),
+            }
+            for member_id, summary in sorted(member_summary.items())
+        ],
+        "over_time": [
+            {"date": bucket, **values}
+            for bucket, values in sorted(over_time.items())
+        ],
+    }
+
+
+def _validate_session(raw_session: Any, index: int) -> dict[str, Any]:
+    if not isinstance(raw_session, dict):
+        raise ValueError(f"sessions[{index}] must be an object")
+    unknown = set(raw_session) - SESSION_KEYS
+    if unknown:
+        raise ValueError(f"unexpected session field: {sorted(unknown)[0]}")
+    pid = _hex_id(raw_session.get("pid"), f"sessions[{index}].pid")
+    sid = _hex_id(raw_session.get("sid"), f"sessions[{index}].sid")
+    return {
+        "pid": pid,
+        "sid": sid,
+        "provider": _provider(raw_session.get("provider")),
+        "models": _models(raw_session.get("models")),
+        "first_date": _optional_date(raw_session.get("first_date"), f"sessions[{index}].first_date"),
+        "last_date": _optional_date(raw_session.get("last_date"), f"sessions[{index}].last_date"),
+        "duration_s": _nonnegative_int(raw_session.get("duration_s")),
+        "tokens": _number_map(raw_session.get("tokens"), TOKEN_KEYS),
+        "tokens_by_model": _tokens_by_model(raw_session.get("tokens_by_model")),
+        "stats": _number_map(raw_session.get("stats"), STAT_KEYS),
+        "stop_reasons": _stop_reasons(raw_session.get("stop_reasons")),
+        "risk_categories": _risk_categories(raw_session.get("risk_categories")),
+        "subagents": _subagents(raw_session.get("subagents")),
+        "sequence": _sequence(raw_session.get("sequence")),
+    }
+
+
+def _required_str(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _date_or_string(value: Any, name: str) -> str:
+    text = _required_str(value, name)
+    if "T" in text:
+        raise ValueError(f"{name} must be date-only")
+    return text
+
+
+def _optional_date(value: Any, name: str) -> str | None:
+    if value is None:
+        return None
+    return _date_or_string(value, name)
+
+
+def _hex_id(value: Any, name: str) -> str:
+    text = _required_str(value, name)
+    if len(text) != 64:
+        raise ValueError(f"{name} must be a 64-character pseudonymous id")
+    try:
+        int(text, 16)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be hex") from exc
+    return text
+
+
+def _provider(value: Any) -> str:
+    if value in (None, ""):
+        return DEFAULT_PROVIDER
+    provider = str(value)
+    return provider if provider == DEFAULT_PROVIDER else "other"
+
+
+def _models(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("models must be a list")
+    return sorted({bucket_model(str(item)) for item in value})
+
+
+def _number_map(value: Any, keys: tuple[str, ...]) -> dict[str, int]:
+    if not isinstance(value, dict):
+        value = {}
+    return {key: _nonnegative_int(value.get(key)) for key in keys}
+
+
+def _tokens_by_model(value: Any) -> dict[str, dict[str, int]]:
+    if not isinstance(value, dict):
+        return {}
+    return _fold_tokens_by_model(
+        (bucket_model(str(model)), _number_map(tokens, TOKEN_KEYS)) for model, tokens in value.items()
+    )
+
+
+def _stop_reasons(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    counts: dict[str, int] = {}
+    for raw_key, raw_count in value.items():
+        key = str(raw_key) if str(raw_key) in KNOWN_STOP_REASONS else "other"
+        count = _nonnegative_int(raw_count)
+        if count:
+            counts[key] = counts.get(key, 0) + count
+    return counts
+
+
+def _risk_categories(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted({str(item) if str(item) in RISK_CATEGORIES else "other" for item in value})
+
+
+def _subagents(value: Any) -> list[dict[str, int | str]]:
+    if not isinstance(value, list):
+        return []
+    result: list[dict[str, int | str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        unknown = set(item) - {"agent_type", "event_count"}
+        if unknown:
+            raise ValueError(f"unexpected subagent field: {sorted(unknown)[0]}")
+        result.append(
+            {
+                "agent_type": bucket_agent_type(item.get("agent_type")),
+                "event_count": _nonnegative_int(item.get("event_count")),
+            }
+        )
+    return result
+
+
+def _sequence(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        unknown = set(item) - {"sym", "fam", "dt_s", "out_tok"}
+        if unknown:
+            raise ValueError(f"unexpected sequence field: {sorted(unknown)[0]}")
+        family = str(item.get("fam") or "")
+        if family not in {"tool_call", "tool_result"}:
+            raise ValueError("sequence family must be tool_call or tool_result")
+        step: dict[str, Any] = {
+            "sym": sanitize_symbol(str(item.get("sym") or ""), family),
+            "fam": family,
+            "dt_s": _nonnegative_int(item.get("dt_s")),
+        }
+        if family == "tool_call":
+            step["out_tok"] = _nonnegative_int(item.get("out_tok"))
+        result.append(step)
+    return result
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        parsed = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _loads_dict(value: Any) -> dict[str, Any]:
+    loaded = _loads(value)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _loads_list(value: Any) -> list[Any]:
+    loaded = _loads(value)
+    return loaded if isinstance(loaded, list) else []
+
+
+def _loads(value: Any) -> Any:
+    if not value:
+        return None
+    try:
+        return json.loads(str(value))
+    except json.JSONDecodeError:
+        return None
+
+
+def _count_entries(counter: Counter[str], key_name: str, *, count_key: str = "session_count") -> list[dict[str, Any]]:
+    return [
+        {key_name: key, count_key: count}
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))
+    ]

--- a/backend/src/ccfr/analysis/team_cost.py
+++ b/backend/src/ccfr/analysis/team_cost.py
@@ -95,10 +95,19 @@ def team_cost_analytics(
     date_from: str | None = None,
     date_to: str | None = None,
     model: str | None = None,
+    project_id: int | None = None,
     historical: bool = True,
 ) -> dict[str, Any]:
     timeline = load_price_timeline(pricing_path(), pricing_dir())
     price_available = timeline.has_prices
+
+    # Stable across filter changes: ids depend only on the imported bundle
+    # set, not on the date/project filters applied below.
+    all_pids = [
+        str(r["project_id"])
+        for r in conn.execute("SELECT DISTINCT project_id FROM team_bundle_sessions ORDER BY project_id")
+    ]
+    pid_id = {pid: index for index, pid in enumerate(all_pids, start=1)}
 
     where: list[str] = []
     params: list[Any] = []
@@ -108,6 +117,10 @@ def team_cost_analytics(
     if date_to:
         where.append("first_date <= ?")
         params.append(date_to[:10])
+    if project_id is not None:
+        id_pid = {index: pid for pid, index in pid_id.items()}
+        where.append("project_id = ?")
+        params.append(id_pid.get(project_id, ""))  # unknown/stale id matches nothing
     clause = (" WHERE " + " AND ".join(where)) if where else ""
     rows = conn.execute(
         f"SELECT project_id, first_date, tokens_by_model_json FROM team_bundle_sessions{clause} ORDER BY first_date, id",
@@ -119,8 +132,6 @@ def team_cost_analytics(
     def matches(family: str) -> bool:
         return target is None or normalize_model_key(family) == target
 
-    distinct_pids = sorted({str(row["project_id"]) for row in rows})
-    pid_id = {pid: index for index, pid in enumerate(distinct_pids, start=1)}
     first_dates = [row["first_date"] for row in rows if row["first_date"]]
     bucket = _bucket_for_range(date_from or (min(first_dates) if first_dates else None), date_to or (max(first_dates) if first_dates else None))
 
@@ -292,7 +303,7 @@ def team_cost_analytics(
     spikes_out = sorted(spikes, key=lambda item: item["delta_usd"], reverse=True)[:5]
 
     available_projects = sorted(
-        ({"id": pid_id[pid], "name": pid[:8]} for pid in distinct_pids), key=lambda item: item["name"]
+        ({"id": pid_id[pid], "name": pid[:8]} for pid in all_pids), key=lambda item: item["name"]
     )
 
     return {

--- a/backend/src/ccfr/analysis/team_cost.py
+++ b/backend/src/ccfr/analysis/team_cost.py
@@ -1,0 +1,315 @@
+"""Cost analytics over imported team bundles.
+
+Mirrors the per-model cost math in ``api/analytics`` but reads per-model token
+attribution from ``team_bundle_sessions`` (there is no raw message data for
+team bundles). Produces the same ``CostAnalyticsResponse`` shape the local Cost
+view renders, so the existing frontend components render team data unchanged.
+Team bundles carry no per-session detail, so ``sessions`` is always empty.
+
+The small input/cache token-math helpers mirror ``api.analytics`` deliberately
+(kept here to avoid an analysis -> api import); the core ``cost_usd`` formula is
+reused from ``analysis.pricing``.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date
+from typing import Any
+
+from ccfr.analysis.pricing import (
+    ModelPrice,
+    TokenBreakdown,
+    cost_usd,
+    load_price_timeline,
+    normalize_model_key,
+)
+from ccfr.config import pricing_dir, pricing_path
+
+# Priced categories (order matches api.analytics._CATEGORIES). The map turns a
+# team bundle's token keys into pricing TokenBreakdown fields.
+_CATEGORIES = ("base_input", "cache_write_5m", "cache_write_1h", "cache_read", "output")
+_BUNDLE_TO_BREAKDOWN = {
+    "base": "base_input",
+    "cache_5m": "cache_write_5m",
+    "cache_1h": "cache_write_1h",
+    "cache_read": "cache_read",
+    "output": "output",
+}
+_WEEKLY_THRESHOLD_DAYS = 92
+
+
+def _breakdown_from_tokens(tokens: dict[str, Any]) -> TokenBreakdown:
+    return TokenBreakdown(
+        **{field: max(0, int(tokens.get(bundle_key, 0) or 0)) for bundle_key, field in _BUNDLE_TO_BREAKDOWN.items()}
+    )
+
+
+def _input_tokens_total(b: TokenBreakdown) -> int:
+    return b.base_input + b.cache_write_5m + b.cache_write_1h + b.cache_read
+
+
+def _cache_write_tokens_total(b: TokenBreakdown) -> int:
+    return b.cache_write_5m + b.cache_write_1h
+
+
+def _observed_input_usd(price: ModelPrice, b: TokenBreakdown) -> float:
+    return (
+        b.base_input * price.base_input
+        + b.cache_write_5m * price.cache_write_5m
+        + b.cache_write_1h * price.cache_write_1h
+        + b.cache_read * price.cache_read
+    ) / 1_000_000
+
+
+def _no_cache_input_usd(price: ModelPrice, b: TokenBreakdown) -> float:
+    return _input_tokens_total(b) * price.base_input / 1_000_000
+
+
+def _coerce_day(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _bucket_for_range(lo: str | None, hi: str | None) -> str:
+    a, b = _coerce_day(lo), _coerce_day(hi)
+    if a is None or b is None:
+        return "day"
+    return "week" if abs((b - a).days) > _WEEKLY_THRESHOLD_DAYS else "day"
+
+
+def _bucket_key(first_date: str | None, bucket: str) -> str | None:
+    day = _coerce_day(first_date)
+    if day is None:
+        return None
+    return day.isoformat() if bucket == "day" else day.strftime("%Y-%W")
+
+
+def team_cost_analytics(
+    conn: sqlite3.Connection,
+    *,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    model: str | None = None,
+    historical: bool = True,
+) -> dict[str, Any]:
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    price_available = timeline.has_prices
+
+    where: list[str] = []
+    params: list[Any] = []
+    if date_from:
+        where.append("first_date >= ?")
+        params.append(date_from[:10])
+    if date_to:
+        where.append("first_date <= ?")
+        params.append(date_to[:10])
+    clause = (" WHERE " + " AND ".join(where)) if where else ""
+    rows = conn.execute(
+        f"SELECT project_id, first_date, tokens_by_model_json FROM team_bundle_sessions{clause} ORDER BY first_date, id",
+        params,
+    ).fetchall()
+
+    target = normalize_model_key(model) if model else None
+
+    def matches(family: str) -> bool:
+        return target is None or normalize_model_key(family) == target
+
+    distinct_pids = sorted({str(row["project_id"]) for row in rows})
+    pid_id = {pid: index for index, pid in enumerate(distinct_pids, start=1)}
+    first_dates = [row["first_date"] for row in rows if row["first_date"]]
+    bucket = _bucket_for_range(date_from or (min(first_dates) if first_dates else None), date_to or (max(first_dates) if first_dates else None))
+
+    treemap: dict[int, dict[str, Any]] = {}
+    by_model: dict[str, dict[str, Any]] = {}
+    categories = {cat: {"tokens": 0, "usd": 0.0} for cat in _CATEGORIES}
+    cache_economics: dict[str, Any] = {
+        "observed_input_usd": 0.0,
+        "no_cache_input_usd": 0.0,
+        "net_savings_usd": 0.0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "by_model": {},
+    }
+    over_time: dict[str, dict[str, Any]] = {}
+    available_models: set[str] = set()
+    unpriced: set[str] = set()
+    total_usd = 0.0
+    total_tokens = 0
+
+    for row in rows:
+        pid = str(row["project_id"])
+        first_date = row["first_date"]
+        try:
+            tokens_by_model = json.loads(row["tokens_by_model_json"]) if row["tokens_by_model_json"] else {}
+        except json.JSONDecodeError:
+            tokens_by_model = {}
+        if not isinstance(tokens_by_model, dict):
+            continue
+        for raw_family, tokens in tokens_by_model.items():
+            if not isinstance(tokens, dict):
+                continue
+            family = str(raw_family)
+            available_models.add(family)
+            if not matches(family):
+                continue
+            breakdown = _breakdown_from_tokens(tokens)
+            used = any(getattr(breakdown, cat) for cat in _CATEGORIES)
+            price = timeline.price_for(family, first_date, historical=historical)
+            usd = cost_usd(price, breakdown) if price else 0.0
+            if price is None and used:
+                unpriced.add(family)
+
+            for cat in _CATEGORIES:
+                tok = getattr(breakdown, cat)
+                categories[cat]["tokens"] += tok
+                total_tokens += tok
+                if price is not None:
+                    categories[cat]["usd"] += tok * getattr(price, cat) / 1_000_000
+
+            if price is not None:
+                observed = _observed_input_usd(price, breakdown)
+                no_cache = _no_cache_input_usd(price, breakdown)
+                cache_economics["observed_input_usd"] += observed
+                cache_economics["no_cache_input_usd"] += no_cache
+                model_cache = cache_economics["by_model"].setdefault(
+                    family,
+                    {
+                        "model": family,
+                        "observed_input_usd": 0.0,
+                        "no_cache_input_usd": 0.0,
+                        "net_savings_usd": 0.0,
+                        "input_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "cache_write_tokens": 0,
+                    },
+                )
+                model_cache["observed_input_usd"] += observed
+                model_cache["no_cache_input_usd"] += no_cache
+                model_cache["input_tokens"] += _input_tokens_total(breakdown)
+                model_cache["cache_read_tokens"] += breakdown.cache_read
+                model_cache["cache_write_tokens"] += _cache_write_tokens_total(breakdown)
+            cache_economics["cache_read_tokens"] += breakdown.cache_read
+            cache_economics["cache_write_tokens"] += _cache_write_tokens_total(breakdown)
+            total_usd += usd
+
+            proj = treemap.setdefault(
+                pid_id[pid],
+                {"project_id": pid_id[pid], "project_name": pid[:8], "usd": 0.0, "children": {}},
+            )
+            proj["usd"] += usd
+            proj["children"][family] = proj["children"].get(family, 0.0) + usd
+
+            bm = by_model.setdefault(
+                family,
+                {
+                    "model": family,
+                    "usd": 0.0,
+                    "tokens": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                },
+            )
+            bm["usd"] += usd
+            bm["tokens"] += sum(getattr(breakdown, cat) for cat in _CATEGORIES)
+            bm["input_tokens"] += _input_tokens_total(breakdown)
+            bm["output_tokens"] += breakdown.output
+            bm["cache_read_tokens"] += breakdown.cache_read
+            bm["cache_write_tokens"] += _cache_write_tokens_total(breakdown)
+
+            if price is not None and usd != 0:
+                key = _bucket_key(first_date, bucket)
+                if key is not None:
+                    over = over_time.setdefault(key, {"bucket": key, "per_model": {}})
+                    over["per_model"][family] = round(over["per_model"].get(family, 0.0) + usd, 6)
+
+    treemap_out = [
+        {
+            "project_id": proj["project_id"],
+            "project_name": proj["project_name"],
+            "usd": round(proj["usd"], 6),
+            "children": [
+                {"model": mdl, "usd": round(usd, 6)}
+                for mdl, usd in sorted(proj["children"].items(), key=lambda kv: kv[1], reverse=True)
+            ],
+        }
+        for proj in sorted(treemap.values(), key=lambda x: x["usd"], reverse=True)
+    ]
+    by_model_out = [
+        {
+            "model": bm["model"],
+            "usd": round(bm["usd"], 6),
+            "tokens": bm["tokens"],
+            "input_tokens": bm["input_tokens"],
+            "output_tokens": bm["output_tokens"],
+            "cache_read_tokens": bm["cache_read_tokens"],
+            "cache_write_tokens": bm["cache_write_tokens"],
+            "effective_usd_per_million": round((bm["usd"] / bm["tokens"]) * 1_000_000, 6) if bm["tokens"] > 0 else 0.0,
+        }
+        for bm in sorted(by_model.values(), key=lambda x: x["usd"], reverse=True)
+    ]
+    categories_out = {
+        cat: {"tokens": categories[cat]["tokens"], "usd": round(categories[cat]["usd"], 6)} for cat in _CATEGORIES
+    }
+    over_time_out = [over_time[key] for key in sorted(over_time)]
+    cache_economics_out = {
+        "observed_input_usd": round(cache_economics["observed_input_usd"], 6),
+        "no_cache_input_usd": round(cache_economics["no_cache_input_usd"], 6),
+        "net_savings_usd": round(cache_economics["no_cache_input_usd"] - cache_economics["observed_input_usd"], 6),
+        "cache_read_tokens": cache_economics["cache_read_tokens"],
+        "cache_write_tokens": cache_economics["cache_write_tokens"],
+        "by_model": [
+            {
+                **model_cache,
+                "observed_input_usd": round(model_cache["observed_input_usd"], 6),
+                "no_cache_input_usd": round(model_cache["no_cache_input_usd"], 6),
+                "net_savings_usd": round(model_cache["no_cache_input_usd"] - model_cache["observed_input_usd"], 6),
+            }
+            for model_cache in sorted(
+                cache_economics["by_model"].values(),
+                key=lambda item: abs(item["no_cache_input_usd"] - item["observed_input_usd"]),
+                reverse=True,
+            )
+        ],
+    }
+
+    bucket_totals = {item["bucket"]: round(sum(item["per_model"].values()), 6) for item in over_time_out}
+    spikes = []
+    bucket_keys = sorted(bucket_totals)
+    for index, key in enumerate(bucket_keys):
+        if index == 0:
+            continue
+        delta = round(bucket_totals[key] - bucket_totals[bucket_keys[index - 1]], 6)
+        if delta <= 0:
+            continue
+        spikes.append({"bucket": key, "total_usd": bucket_totals[key], "delta_usd": delta, "sessions": []})
+    spikes_out = sorted(spikes, key=lambda item: item["delta_usd"], reverse=True)[:5]
+
+    available_projects = sorted(
+        ({"id": pid_id[pid], "name": pid[:8]} for pid in distinct_pids), key=lambda item: item["name"]
+    )
+
+    return {
+        "meta": {
+            "available": price_available,
+            "unpriced_models": sorted(unpriced),
+            "total_usd": round(total_usd, 6),
+            "total_tokens": total_tokens,
+            "available_projects": available_projects,
+            "available_models": sorted(available_models),
+            "bucket": bucket,
+        },
+        "treemap": treemap_out,
+        "over_time": over_time_out,
+        "categories": categories_out,
+        "by_model": by_model_out,
+        "sessions": [],
+        "cache_economics": cache_economics_out,
+        "spikes": spikes_out,
+    }

--- a/backend/src/ccfr/analysis/team_cost.py
+++ b/backend/src/ccfr/analysis/team_cost.py
@@ -103,10 +103,19 @@ def team_cost_analytics(
 
     # Stable across filter changes: ids depend only on the imported bundle
     # set, not on the date/project filters applied below.
-    all_pids = [
-        str(r["project_id"])
-        for r in conn.execute("SELECT DISTINCT project_id FROM team_bundle_sessions ORDER BY project_id")
-    ]
+    project_rows = conn.execute(
+        """
+        SELECT project_id, MAX(project_name) AS project_name
+        FROM team_bundle_sessions
+        GROUP BY project_id
+        ORDER BY project_id
+        """
+    ).fetchall()
+    all_pids = [str(row["project_id"]) for row in project_rows]
+    name_by_pid = {
+        str(row["project_id"]): (str(row["project_name"]) if row["project_name"] else str(row["project_id"])[:8])
+        for row in project_rows
+    }
     pid_id = {pid: index for index, pid in enumerate(all_pids, start=1)}
 
     where: list[str] = []
@@ -210,7 +219,7 @@ def team_cost_analytics(
 
             proj = treemap.setdefault(
                 pid_id[pid],
-                {"project_id": pid_id[pid], "project_name": pid[:8], "usd": 0.0, "children": {}},
+                {"project_id": pid_id[pid], "project_name": name_by_pid[pid], "usd": 0.0, "children": {}},
             )
             proj["usd"] += usd
             proj["children"][family] = proj["children"].get(family, 0.0) + usd
@@ -303,7 +312,7 @@ def team_cost_analytics(
     spikes_out = sorted(spikes, key=lambda item: item["delta_usd"], reverse=True)[:5]
 
     available_projects = sorted(
-        ({"id": pid_id[pid], "name": pid[:8]} for pid in all_pids), key=lambda item: item["name"]
+        ({"id": pid_id[pid], "name": name_by_pid[pid]} for pid in all_pids), key=lambda item: item["name"]
     )
 
     return {

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -34,6 +34,7 @@ from ccfr.analysis.team_bundles import (
 from ccfr.analysis.team_cost import team_cost_analytics
 from ccfr.analysis.usage_map import usage_map_analytics, usage_map_evidence
 from ccfr.analysis.usage_characteristics import usage_characteristics_analytics
+from ccfr.naming import project_display_name
 from ccfr.api.schemas import (
     CacheStatsResponse,
     ContributionExportResponse,
@@ -57,11 +58,14 @@ from ccfr.api.schemas import (
     TeamDashboardResponse,
     TeamBundleUploadRequest,
     TeamExportPreviewResponse,
+    TeamExportRequest,
     TeamExportResponse,
     TeamImportEntry,
     TeamImportRequest,
     TeamImportResponse,
     TeamMemberDeleteResponse,
+    TeamProjectEntry,
+    TeamProjectsResponse,
     TimelineItem,
     TurnCostBreakdown,
     TraceResponse,
@@ -165,21 +169,73 @@ def _current_bundle(conn: Connection):
     )
 
 
-def _current_team_bundle(conn: Connection, *, persist_seq: bool):
+@router.get("/team/projects", response_model=TeamProjectsResponse)
+def team_projects(conn: Connection = Depends(get_db)) -> TeamProjectsResponse:
+    rows = conn.execute(
+        """
+        SELECT p.export_name, p.inferred_cwd,
+               COUNT(DISTINCT s.id) AS session_count,
+               COALESCE(SUM(m.input_tokens), 0) + COALESCE(SUM(m.output_tokens), 0) AS tokens
+        FROM projects p
+        LEFT JOIN sessions s ON s.project_id = p.id
+        LEFT JOIN events e ON e.session_id = s.id
+        LEFT JOIN messages m ON m.event_id = e.id
+        GROUP BY p.id
+        ORDER BY tokens DESC, p.export_name
+        """
+    ).fetchall()
+    projects = [
+        TeamProjectEntry(
+            export_name=str(row["export_name"]),
+            default_label=project_display_name(str(row["export_name"]), row["inferred_cwd"]),
+            session_count=int(row["session_count"]),
+            tokens=int(row["tokens"]),
+        )
+        for row in rows
+    ]
+    return TeamProjectsResponse(projects=projects, prefs=dict(read_settings().team_export_prefs))
+
+
+def _current_team_bundle(conn: Connection, payload: TeamExportRequest, *, persist_seq: bool):
     salt, member_id = contributor_identity()
     settings = read_settings()
     # export-preview must show the NEXT seq without burning it; export persists it.
     seq = settings.team_bundle_seq + 1
+    member_name = (payload.member_name or "").strip() or None
+    if payload.privacy_level == "team" and member_name is None and not persist_seq:
+        member_name = "Unnamed member"  # preview-only placeholder; export requires a real name
+    try:
+        bundle = build_team_bundle(
+            conn,
+            salt=salt,
+            member_id=member_id,
+            app_version=config.app_version(),
+            generated_on=date.today(),
+            generated_seq=seq,
+            privacy_level=payload.privacy_level,
+            member_name=member_name,
+            projects=[{"export_name": item.export_name, "label": item.label} for item in payload.projects],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if persist_seq:
-        write_settings(replace(settings, team_bundle_seq=seq))
-    return build_team_bundle(
-        conn,
-        salt=salt,
-        member_id=member_id,
-        app_version=config.app_version(),
-        generated_on=date.today(),
-        generated_seq=seq,
-    )
+        selected = {item.export_name for item in payload.projects}
+        all_names = [
+            str(row["export_name"])
+            for row in conn.execute("SELECT export_name FROM projects ORDER BY export_name")
+        ]
+        prefs = {
+            "member_name": (payload.member_name or "").strip(),
+            "privacy_level": payload.privacy_level,
+            "project_labels": {
+                item.export_name: item.label.strip()
+                for item in payload.projects
+                if item.label and item.label.strip()
+            },
+            "deselected": [name for name in all_names if name not in selected],
+        }
+        write_settings(replace(settings, team_bundle_seq=seq, team_export_prefs=prefs))
+    return bundle
 
 
 @router.get("/contribution/preview", response_model=ContributionPreviewResponse)
@@ -201,15 +257,15 @@ def contribution_export(conn: Connection = Depends(get_db)) -> ContributionExpor
     return ContributionExportResponse(path=str(path), session_count=len(bundle.sessions))
 
 
-@router.get("/team/export-preview", response_model=TeamExportPreviewResponse)
-def team_export_preview(conn: Connection = Depends(get_db)) -> TeamExportPreviewResponse:
-    bundle = _current_team_bundle(conn, persist_seq=False)
+@router.post("/team/export-preview", response_model=TeamExportPreviewResponse)
+def team_export_preview(payload: TeamExportRequest, conn: Connection = Depends(get_db)) -> TeamExportPreviewResponse:
+    bundle = _current_team_bundle(conn, payload, persist_seq=False)
     return TeamExportPreviewResponse(manifest=team_bundle_manifest(bundle), bundle=bundle.to_dict())
 
 
 @router.post("/team/export", response_model=TeamExportResponse)
-def team_export(conn: Connection = Depends(get_db)) -> TeamExportResponse:
-    bundle = _current_team_bundle(conn, persist_seq=True)
+def team_export(payload: TeamExportRequest, conn: Connection = Depends(get_db)) -> TeamExportResponse:
+    bundle = _current_team_bundle(conn, payload, persist_seq=True)
     out_dir = team_bundle_root() / "exports"
     out_dir.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%fZ")

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -278,11 +278,14 @@ def get_team_cost_analytics(
     date_from: str | None = None,
     date_to: str | None = None,
     model: str | None = None,
+    project_id: int | None = None,
     conn: Connection = Depends(get_db),
     historical: bool = Depends(get_historical_pricing),
 ) -> CostAnalyticsResponse:
     return CostAnalyticsResponse(
-        **team_cost_analytics(conn, date_from=date_from, date_to=date_to, model=model, historical=historical)
+        **team_cost_analytics(
+            conn, date_from=date_from, date_to=date_to, model=model, project_id=project_id, historical=historical
+        )
     )
 
 

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import secrets
 import time
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Callable
@@ -165,14 +165,20 @@ def _current_bundle(conn: Connection):
     )
 
 
-def _current_team_bundle(conn: Connection):
+def _current_team_bundle(conn: Connection, *, persist_seq: bool):
     salt, member_id = contributor_identity()
+    settings = read_settings()
+    # export-preview must show the NEXT seq without burning it; export persists it.
+    seq = settings.team_bundle_seq + 1
+    if persist_seq:
+        write_settings(replace(settings, team_bundle_seq=seq))
     return build_team_bundle(
         conn,
         salt=salt,
         member_id=member_id,
         app_version=config.app_version(),
         generated_on=date.today(),
+        generated_seq=seq,
     )
 
 
@@ -197,13 +203,13 @@ def contribution_export(conn: Connection = Depends(get_db)) -> ContributionExpor
 
 @router.get("/team/export-preview", response_model=TeamExportPreviewResponse)
 def team_export_preview(conn: Connection = Depends(get_db)) -> TeamExportPreviewResponse:
-    bundle = _current_team_bundle(conn)
+    bundle = _current_team_bundle(conn, persist_seq=False)
     return TeamExportPreviewResponse(manifest=team_bundle_manifest(bundle), bundle=bundle.to_dict())
 
 
 @router.post("/team/export", response_model=TeamExportResponse)
 def team_export(conn: Connection = Depends(get_db)) -> TeamExportResponse:
-    bundle = _current_team_bundle(conn)
+    bundle = _current_team_bundle(conn, persist_seq=True)
     out_dir = team_bundle_root() / "exports"
     out_dir.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%fZ")

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import secrets
+import time
 from dataclasses import asdict
 from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import Callable
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlite3 import Connection
@@ -82,8 +84,31 @@ from ccfr.storage import reset_db
 router = APIRouter(prefix="/api")
 
 
-def _progress_callback(conn: Connection, source: Path, project: str | None):
+_TERMINAL_IMPORT_STATUSES = {"completed", "completed_with_errors", "failed"}
+
+
+def _progress_callback(
+    conn: Connection,
+    source: Path,
+    project: str | None,
+    *,
+    min_interval_s: float = 0.5,
+    clock: Callable[[], float] = time.monotonic,
+):
+    last = {"at": float("-inf"), "status": None}
+
     def update(summary: ImportSummary, status: str) -> None:
+        # The importer notifies per file; recomputing whole-DB COUNTs each time
+        # makes big imports O(files x rows). Publish on status changes and
+        # terminal statuses, otherwise at most every min_interval_s.
+        now = clock()
+        if (
+            status == last["status"]
+            and status not in _TERMINAL_IMPORT_STATUSES
+            and now - last["at"] < min_interval_s
+        ):
+            return
+        last["at"], last["status"] = now, status
         import_counts = repository.import_summary_stats(conn, summary.import_id)
         import_progress_store.update(
             {

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -22,6 +22,7 @@ from ccfr.analysis.context_economics import (
 from ccfr.analysis.discovery import discovery_analytics
 from ccfr.analysis.team_bundles import (
     build_team_bundle,
+    delete_team_member,
     import_team_bundle,
     list_team_imports,
     reset_team_bundles,
@@ -58,6 +59,7 @@ from ccfr.api.schemas import (
     TeamImportEntry,
     TeamImportRequest,
     TeamImportResponse,
+    TeamMemberDeleteResponse,
     TimelineItem,
     TurnCostBreakdown,
     TraceResponse,
@@ -231,6 +233,14 @@ def team_imports(conn: Connection = Depends(get_db)) -> list[TeamImportEntry]:
 def team_reset(conn: Connection = Depends(get_db)) -> dict[str, bool]:
     reset_team_bundles(conn)
     return {"ok": True}
+
+
+@router.delete("/team/members/{member_id}", response_model=TeamMemberDeleteResponse)
+def team_delete_member(member_id: str, conn: Connection = Depends(get_db)) -> TeamMemberDeleteResponse:
+    removed = delete_team_member(conn, member_id)
+    if removed == 0:
+        raise HTTPException(status_code=404, detail=f"No imported bundles for member: {member_id}")
+    return TeamMemberDeleteResponse(member_id=member_id, bundles_removed=removed)
 
 
 @router.get("/team/dashboard", response_model=TeamDashboardResponse)

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -224,8 +224,14 @@ def _current_team_bundle(conn: Connection, payload: TeamExportRequest, *, persis
             str(row["export_name"])
             for row in conn.execute("SELECT export_name FROM projects ORDER BY export_name")
         ]
+        # A structural export carries no name; without this, it would blank out
+        # a name previously saved from a team-level export, degrading the next
+        # team-export prefill.
+        prior_name = settings.team_export_prefs.get("member_name", "")
+        if not isinstance(prior_name, str):
+            prior_name = ""
         prefs = {
-            "member_name": (payload.member_name or "").strip(),
+            "member_name": (payload.member_name or "").strip() or prior_name,
             "privacy_level": payload.privacy_level,
             "project_labels": {
                 item.export_name: item.label.strip()

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -20,6 +20,15 @@ from ccfr.analysis.context_economics import (
     session_context_economics,
 )
 from ccfr.analysis.discovery import discovery_analytics
+from ccfr.analysis.team_bundles import (
+    build_team_bundle,
+    import_team_bundle,
+    list_team_imports,
+    reset_team_bundles,
+    team_bundle_manifest,
+    team_dashboard,
+)
+from ccfr.analysis.team_cost import team_cost_analytics
 from ccfr.analysis.usage_map import usage_map_analytics, usage_map_evidence
 from ccfr.analysis.usage_characteristics import usage_characteristics_analytics
 from ccfr.api.schemas import (
@@ -42,6 +51,13 @@ from ccfr.api.schemas import (
     SessionContextEconomicsResponse,
     SettingsResponse,
     SubagentResponse,
+    TeamDashboardResponse,
+    TeamBundleUploadRequest,
+    TeamExportPreviewResponse,
+    TeamExportResponse,
+    TeamImportEntry,
+    TeamImportRequest,
+    TeamImportResponse,
     TimelineItem,
     TurnCostBreakdown,
     TraceResponse,
@@ -54,6 +70,8 @@ from ccfr.config import (
     import_root,
     is_docker,
     resolve_within_import_root,
+    resolve_within_team_bundle_root,
+    team_bundle_root,
     validate_project_name,
 )
 from ccfr.ingest import ImportSummary, discover_projects, import_all_new, import_project
@@ -89,6 +107,7 @@ def _progress_callback(conn: Connection, source: Path, project: str | None):
 def get_config() -> RuntimeConfigResponse:
     return RuntimeConfigResponse(
         import_root=str(import_root()),
+        team_bundle_root=str(team_bundle_root()),
         database_path=str(database_path()),
         is_docker=is_docker(),
     )
@@ -119,6 +138,17 @@ def _current_bundle(conn: Connection):
     )
 
 
+def _current_team_bundle(conn: Connection):
+    salt, member_id = contributor_identity()
+    return build_team_bundle(
+        conn,
+        salt=salt,
+        member_id=member_id,
+        app_version=config.app_version(),
+        generated_on=date.today(),
+    )
+
+
 @router.get("/contribution/preview", response_model=ContributionPreviewResponse)
 def contribution_preview(conn: Connection = Depends(get_db)) -> ContributionPreviewResponse:
     bundle = _current_bundle(conn)
@@ -136,6 +166,89 @@ def contribution_export(conn: Connection = Depends(get_db)) -> ContributionExpor
     with path.open("x", encoding="utf-8") as fh:
         fh.write(json.dumps(bundle.to_dict(), indent=2))
     return ContributionExportResponse(path=str(path), session_count=len(bundle.sessions))
+
+
+@router.get("/team/export-preview", response_model=TeamExportPreviewResponse)
+def team_export_preview(conn: Connection = Depends(get_db)) -> TeamExportPreviewResponse:
+    bundle = _current_team_bundle(conn)
+    return TeamExportPreviewResponse(manifest=team_bundle_manifest(bundle), bundle=bundle.to_dict())
+
+
+@router.post("/team/export", response_model=TeamExportResponse)
+def team_export(conn: Connection = Depends(get_db)) -> TeamExportResponse:
+    bundle = _current_team_bundle(conn)
+    out_dir = team_bundle_root() / "exports"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%fZ")
+    path = out_dir / f"team-bundle-{stamp}-{secrets.token_hex(4)}.json"
+    data = bundle.to_dict()
+    with path.open("x", encoding="utf-8") as fh:
+        fh.write(json.dumps(data, indent=2))
+    return TeamExportResponse(path=str(path), bundle_id=data["bundle_id"], session_count=len(bundle.sessions))
+
+
+@router.post("/team/import", response_model=TeamImportResponse)
+def team_import(payload: TeamImportRequest, conn: Connection = Depends(get_db)) -> TeamImportResponse:
+    try:
+        path = resolve_within_team_bundle_root(payload.path, team_bundle_root())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not path.is_file():
+        raise HTTPException(status_code=400, detail=f"Team bundle not found: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        result = import_team_bundle(conn, data, source_path=path)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON: {exc}") from exc
+    except OSError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return TeamImportResponse(**asdict(result))
+
+
+@router.post("/team/import-bundle", response_model=TeamImportResponse)
+def team_import_bundle(payload: TeamBundleUploadRequest, conn: Connection = Depends(get_db)) -> TeamImportResponse:
+    raw_filename = (payload.filename or "uploaded-team-bundle.json").replace("\\", "/")
+    filename = Path(raw_filename).name or "uploaded-team-bundle.json"
+    if filename in {".", ".."}:
+        filename = "uploaded-team-bundle.json"
+    source_path = team_bundle_root() / "browser-imports" / filename
+    try:
+        result = import_team_bundle(conn, payload.bundle, source_path=source_path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return TeamImportResponse(**asdict(result))
+
+
+@router.get("/team/imports", response_model=list[TeamImportEntry])
+def team_imports(conn: Connection = Depends(get_db)) -> list[TeamImportEntry]:
+    return [TeamImportEntry(**row) for row in list_team_imports(conn)]
+
+
+@router.post("/team/reset", response_model=dict[str, bool])
+def team_reset(conn: Connection = Depends(get_db)) -> dict[str, bool]:
+    reset_team_bundles(conn)
+    return {"ok": True}
+
+
+@router.get("/team/dashboard", response_model=TeamDashboardResponse)
+def get_team_dashboard(conn: Connection = Depends(get_db)) -> TeamDashboardResponse:
+    return TeamDashboardResponse(**team_dashboard(conn))
+
+
+@router.get("/team/analytics/cost", response_model=CostAnalyticsResponse)
+def get_team_cost_analytics(
+    date_from: str | None = None,
+    date_to: str | None = None,
+    model: str | None = None,
+    conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
+) -> CostAnalyticsResponse:
+    return CostAnalyticsResponse(
+        **team_cost_analytics(conn, date_from=date_from, date_to=date_to, model=model, historical=historical)
+    )
 
 
 @router.post("/imports", response_model=ImportSummaryResponse)

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -706,6 +706,7 @@ class TeamImportResponse(BaseModel):
     member_id: str
     session_count: int
     imported: bool
+    status: str
 
 
 class TeamImportEntry(BaseModel):

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -722,6 +722,11 @@ class TeamImportEntry(BaseModel):
     session_count: int
 
 
+class TeamMemberDeleteResponse(BaseModel):
+    member_id: str
+    bundles_removed: int
+
+
 class TeamDashboardResponse(BaseModel):
     meta: dict[str, Any] = Field(default_factory=dict)
     tokens: dict[str, Any] = Field(default_factory=dict)

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -12,6 +12,7 @@ class ImportRequest(BaseModel):
 
 class RuntimeConfigResponse(BaseModel):
     import_root: str
+    team_bundle_root: str
     database_path: str
     is_docker: bool = False
 
@@ -678,3 +679,57 @@ class ContributionPreviewResponse(BaseModel):
 class ContributionExportResponse(BaseModel):
     path: str
     session_count: int
+
+
+class TeamExportPreviewResponse(BaseModel):
+    manifest: dict[str, Any]
+    bundle: dict[str, Any]
+
+
+class TeamExportResponse(BaseModel):
+    path: str
+    bundle_id: str
+    session_count: int
+
+
+class TeamImportRequest(BaseModel):
+    path: str = Field(description="Path to a team bundle JSON file under CCFR_TEAM_BUNDLE_ROOT.")
+
+
+class TeamBundleUploadRequest(BaseModel):
+    filename: str | None = Field(default=None, description="Original local filename selected in the browser.")
+    bundle: dict[str, Any] = Field(description="Parsed team bundle JSON payload.")
+
+
+class TeamImportResponse(BaseModel):
+    bundle_id: str
+    member_id: str
+    session_count: int
+    imported: bool
+
+
+class TeamImportEntry(BaseModel):
+    id: int
+    bundle_id: str
+    profile: str
+    schema_version: int
+    member_id: str
+    generated_at: str
+    app_version: str | None = None
+    imported_at: str
+    source_path: str
+    session_count: int
+
+
+class TeamDashboardResponse(BaseModel):
+    meta: dict[str, Any] = Field(default_factory=dict)
+    tokens: dict[str, Any] = Field(default_factory=dict)
+    stats: dict[str, Any] = Field(default_factory=dict)
+    providers: list[dict[str, Any]] = Field(default_factory=list)
+    models: list[dict[str, Any]] = Field(default_factory=list)
+    stop_reasons: list[dict[str, Any]] = Field(default_factory=list)
+    risk_categories: list[dict[str, Any]] = Field(default_factory=list)
+    subagents: list[dict[str, Any]] = Field(default_factory=list)
+    sequence: list[dict[str, Any]] = Field(default_factory=list)
+    members: list[dict[str, Any]] = Field(default_factory=list)
+    over_time: list[dict[str, Any]] = Field(default_factory=list)

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -20,6 +20,7 @@ class RuntimeConfigResponse(BaseModel):
 class SettingsResponse(BaseModel):
     historical_pricing: bool = True
     privacy_mode: bool = False
+    team_export_prefs: dict[str, Any] = Field(default_factory=dict)
 
 
 class CacheStatsResponse(BaseModel):
@@ -693,6 +694,29 @@ class TeamExportResponse(BaseModel):
     session_count: int
 
 
+class TeamProjectEntry(BaseModel):
+    export_name: str
+    default_label: str
+    session_count: int
+    tokens: int
+
+
+class TeamProjectsResponse(BaseModel):
+    projects: list[TeamProjectEntry] = Field(default_factory=list)
+    prefs: dict[str, Any] = Field(default_factory=dict)
+
+
+class TeamExportProjectSelection(BaseModel):
+    export_name: str
+    label: str | None = None
+
+
+class TeamExportRequest(BaseModel):
+    privacy_level: str = "structural"
+    member_name: str | None = None
+    projects: list[TeamExportProjectSelection] = Field(default_factory=list)
+
+
 class TeamImportRequest(BaseModel):
     path: str = Field(description="Path to a team bundle JSON file under CCFR_TEAM_BUNDLE_ROOT.")
 
@@ -721,6 +745,8 @@ class TeamImportEntry(BaseModel):
     imported_at: str
     source_path: str
     session_count: int
+    member_name: str | None = None
+    privacy_level: str = "structural"
 
 
 class TeamMemberDeleteResponse(BaseModel):
@@ -740,3 +766,6 @@ class TeamDashboardResponse(BaseModel):
     sequence: list[dict[str, Any]] = Field(default_factory=list)
     members: list[dict[str, Any]] = Field(default_factory=list)
     over_time: list[dict[str, Any]] = Field(default_factory=list)
+    projects: list[dict[str, Any]] = Field(default_factory=list)
+    tools: list[dict[str, Any]] = Field(default_factory=list)
+    file_types: list[dict[str, Any]] = Field(default_factory=list)

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -72,6 +72,7 @@ class DiscoveredProjectResponse(BaseModel):
     imported: bool
     session_count: int
     last_imported_at: str | None
+    stale: bool = False
 
 
 class ProjectResponse(BaseModel):

--- a/backend/src/ccfr/config.py
+++ b/backend/src/ccfr/config.py
@@ -16,6 +16,10 @@ def import_root() -> Path:
     return Path(os.getenv("CCFR_IMPORT_ROOT", str(repository_root() / "Data")))
 
 
+def team_bundle_root() -> Path:
+    return Path(os.getenv("CCFR_TEAM_BUNDLE_ROOT", str(data_dir() / "team-bundles")))
+
+
 def resolve_within_import_root(candidate: str | None, root: Path | None = None) -> Path:
     """Resolve a request-supplied path, confining it to the import root.
 
@@ -30,6 +34,17 @@ def resolve_within_import_root(candidate: str | None, root: Path | None = None) 
     path = Path(candidate).resolve()
     if path != base and not path.is_relative_to(base):
         raise ValueError("source_path must be within the import root")
+    return path
+
+
+def resolve_within_team_bundle_root(candidate: str | None, root: Path | None = None) -> Path:
+    """Resolve a request-supplied team bundle path, confining it to the team bundle root."""
+    base = (root if root is not None else team_bundle_root()).resolve()
+    if not candidate:
+        return base
+    path = Path(candidate).resolve()
+    if path != base and not path.is_relative_to(base):
+        raise ValueError("path must be within the team bundle root")
     return path
 
 

--- a/backend/src/ccfr/ingest/file_ext.py
+++ b/backend/src/ccfr/ingest/file_ext.py
@@ -13,7 +13,7 @@ from typing import Any
 # Tools whose input names a single file the assistant touched.
 FILE_ARG_TOOLS = frozenset({"Read", "Edit", "Write", "MultiEdit", "NotebookEdit"})
 
-_EXT_RE = re.compile(r"^[a-z0-9_+-]{1,12}$")
+_EXT_RE = re.compile(r"^[a-z0-9_+-]{1,12}\Z")
 
 
 def file_ext_from_tool_input(tool_name: Any, input_obj: Any) -> str | None:

--- a/backend/src/ccfr/ingest/file_ext.py
+++ b/backend/src/ccfr/ingest/file_ext.py
@@ -1,0 +1,30 @@
+"""Extension-only file-type extraction for tool calls.
+
+Derive-then-drop: the file path in a tool call's input is parsed for its
+extension at ingest time and immediately discarded. Only the normalized
+extension is stored (tool_calls.file_ext), so team bundles can report a
+file-type mix without the export builder ever reading raw tool inputs.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Tools whose input names a single file the assistant touched.
+FILE_ARG_TOOLS = frozenset({"Read", "Edit", "Write", "MultiEdit", "NotebookEdit"})
+
+_EXT_RE = re.compile(r"^[a-z0-9_+-]{1,12}$")
+
+
+def file_ext_from_tool_input(tool_name: Any, input_obj: Any) -> str | None:
+    """Return the normalized extension of a file-arg tool call, else None."""
+    if tool_name not in FILE_ARG_TOOLS or not isinstance(input_obj, dict):
+        return None
+    raw_path = input_obj.get("file_path") or input_obj.get("notebook_path")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    basename = raw_path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    if "." not in basename.lstrip("."):
+        return None  # extensionless file or bare dotfile (".env")
+    ext = basename.rsplit(".", 1)[-1].strip().lower()
+    return ext if _EXT_RE.match(ext) else None

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 from ccfr.analysis.metrics import compute_loop_stats
 from ccfr.analysis.risk_patterns import clear_risk_pattern_tables, rebuild_risk_patterns
+from ccfr.ingest.file_ext import file_ext_from_tool_input
 from ccfr.storage.database import init_db
 
 
@@ -737,10 +738,18 @@ def _insert_content_block(
     if block_type == "tool_use":
         conn.execute(
             """
-            INSERT INTO tool_calls(event_id, session_id, tool_use_id, tool_name, input_preview, raw_json)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO tool_calls(event_id, session_id, tool_use_id, tool_name, input_preview, file_ext, raw_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (event_id, session_pk, tool_use_id, tool_name, _shorten(block_obj.get("input")), _json(_compact_for_storage(block_obj))),
+            (
+                event_id,
+                session_pk,
+                tool_use_id,
+                tool_name,
+                _shorten(block_obj.get("input")),
+                file_ext_from_tool_input(tool_name, block_obj.get("input")),
+                _json(_compact_for_storage(block_obj)),
+            ),
         )
     elif block_type == "tool_result":
         persisted_id = _find_persisted_id(str(block_obj.get("content") or ""), persisted_by_export_path)

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -67,6 +67,7 @@ def import_all_new(
     _prepare_conn(conn)
     file_count = sum(1 for p in source_root.rglob("*") if p.is_file())
     import_id, summary = _create_import_row(conn, source_root, file_count)
+    conn.commit()  # the imports row must survive a later project rollback
     _notify_progress(progress_callback, summary, "running")
 
     session_ids: list[int] = []
@@ -74,10 +75,18 @@ def import_all_new(
     for project_dir in sorted(p for p in source_root.iterdir() if p.is_dir()):
         if not include_existing and _project_exists(conn, project_dir.name):
             continue
-        pid, sids = _import_one_project(
-            conn, import_id, source_root, project_dir, summary,
-            progress_callback=progress_callback,
-        )
+        try:
+            pid, sids = _import_one_project(
+                conn, import_id, source_root, project_dir, summary,
+                progress_callback=progress_callback,
+            )
+            conn.commit()  # project is all-or-nothing: delete+rebuild in one txn
+        except Exception as exc:  # a broken project must not poison the rest
+            conn.rollback()
+            summary.project_count = max(0, summary.project_count - 1)
+            _record_error(conn, summary, project_dir.name, None, f"Project import failed: {exc}")
+            conn.commit()
+            continue
         project_ids.append(pid)
         session_ids.extend(sids)
         _notify_progress(progress_callback, summary, "importing")
@@ -102,15 +111,26 @@ def import_project(
     _prepare_conn(conn)
     file_count = sum(1 for p in project_dir.rglob("*") if p.is_file())
     import_id, summary = _create_import_row(conn, source_root, file_count)
+    conn.commit()
     _notify_progress(progress_callback, summary, "running")
 
-    pid, sids = _import_one_project(
-        conn, import_id, source_root, project_dir, summary,
-        progress_callback=progress_callback,
-    )
+    project_ids: list[int] = []
+    sids: list[int] = []
+    try:
+        pid, sids = _import_one_project(
+            conn, import_id, source_root, project_dir, summary,
+            progress_callback=progress_callback,
+        )
+        conn.commit()
+        project_ids = [pid]
+    except Exception as exc:
+        conn.rollback()
+        summary.project_count = max(0, summary.project_count - 1)
+        _record_error(conn, summary, project_dir.name, None, f"Project import failed: {exc}")
+        conn.commit()
     _notify_progress(progress_callback, summary, "rebuilding")
-    _rebuild_derived(conn, sids, [pid])
-    _finalize_import(conn, summary, import_id, sids, [pid], progress_callback=progress_callback)
+    _rebuild_derived(conn, sids, project_ids)
+    _finalize_import(conn, summary, import_id, sids, project_ids, progress_callback=progress_callback)
     return summary
 
 
@@ -151,8 +171,10 @@ def _validate_root(source_root: Path) -> Path:
 
 
 def _prepare_conn(conn: sqlite3.Connection) -> None:
-    conn.execute("PRAGMA journal_mode = OFF")
-    conn.execute("PRAGMA synchronous = OFF")
+    # storage.connect() sets WAL. NORMAL keeps bulk inserts fast while a crash
+    # mid-import can still roll back to the last per-project commit; the old
+    # journal_mode=OFF setting could corrupt the whole DB on a failed import.
+    conn.execute("PRAGMA synchronous = NORMAL")
     conn.execute("PRAGMA temp_store = MEMORY")
     init_db(conn)
 

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sqlite3
@@ -38,6 +39,7 @@ class DiscoveredProject:
     imported: bool
     session_count: int
     last_imported_at: str | None
+    stale: bool = False
 
 
 @dataclass
@@ -73,7 +75,7 @@ def import_all_new(
     session_ids: list[int] = []
     project_ids: list[int] = []
     for project_dir in sorted(p for p in source_root.iterdir() if p.is_dir()):
-        if not include_existing and _project_exists(conn, project_dir.name):
+        if not include_existing and not _project_needs_import(conn, project_dir):
             continue
         project_count_before = summary.project_count
         errors_before = len(summary.errors)
@@ -151,7 +153,8 @@ def discover_projects(conn: sqlite3.Connection, source_root: Path) -> list[Disco
     for project_dir in sorted(p for p in source_root.iterdir() if p.is_dir()):
         row = conn.execute(
             """
-            SELECT COUNT(DISTINCT s.id) AS session_count, MAX(i.imported_at) AS last_imported_at
+            SELECT COUNT(DISTINCT s.id) AS session_count, MAX(i.imported_at) AS last_imported_at,
+                   MAX(p.source_signature) AS source_signature
             FROM projects p
             LEFT JOIN sessions s ON s.project_id = p.id
             LEFT JOIN imports i ON i.id = p.import_id
@@ -160,12 +163,15 @@ def discover_projects(conn: sqlite3.Connection, source_root: Path) -> list[Disco
             (project_dir.name,),
         ).fetchone()
         last_imported_at = row["last_imported_at"]
+        imported = last_imported_at is not None
+        stale = imported and row["source_signature"] != _project_source_signature(project_dir)
         result.append(
             DiscoveredProject(
                 name=project_dir.name,
-                imported=last_imported_at is not None,
+                imported=imported,
                 session_count=int(row["session_count"] or 0),
                 last_imported_at=last_imported_at,
+                stale=stale,
             )
         )
     return result
@@ -204,6 +210,30 @@ def _project_exists(conn: sqlite3.Connection, export_name: str) -> bool:
     return conn.execute("SELECT 1 FROM projects WHERE export_name = ?", (export_name,)).fetchone() is not None
 
 
+def _project_source_signature(project_dir: Path) -> str:
+    """Fingerprint of the project's on-disk file set (relpath, size, mtime)."""
+    digest = hashlib.sha256()
+    for path in sorted(project_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        stat = path.stat()
+        digest.update(
+            f"{path.relative_to(project_dir).as_posix()}\0{stat.st_size}\0{stat.st_mtime_ns}\0".encode()
+        )
+    return digest.hexdigest()
+
+
+def _project_needs_import(conn: sqlite3.Connection, project_dir: Path) -> bool:
+    row = conn.execute(
+        "SELECT source_signature FROM projects WHERE export_name = ? ORDER BY id DESC LIMIT 1",
+        (project_dir.name,),
+    ).fetchone()
+    if row is None:
+        return True
+    # NULL signature (pre-migration DB) counts as changed: re-import once, self-heals.
+    return row["source_signature"] != _project_source_signature(project_dir)
+
+
 def _import_one_project(
     conn: sqlite3.Connection,
     import_id: int,
@@ -215,6 +245,10 @@ def _import_one_project(
 ) -> tuple[int, list[int]]:
     _delete_project_by_name(conn, project_dir.name)
     project_id = _insert_project(conn, import_id, project_dir.name)
+    conn.execute(
+        "UPDATE projects SET source_signature = ? WHERE id = ?",
+        (_project_source_signature(project_dir), project_id),
+    )
     summary.project_count += 1
     _notify_progress(progress_callback, summary, "importing")
 

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -75,6 +75,8 @@ def import_all_new(
     for project_dir in sorted(p for p in source_root.iterdir() if p.is_dir()):
         if not include_existing and _project_exists(conn, project_dir.name):
             continue
+        project_count_before = summary.project_count
+        errors_before = len(summary.errors)
         try:
             pid, sids = _import_one_project(
                 conn, import_id, source_root, project_dir, summary,
@@ -83,7 +85,10 @@ def import_all_new(
             conn.commit()  # project is all-or-nothing: delete+rebuild in one txn
         except Exception as exc:  # a broken project must not poison the rest
             conn.rollback()
-            summary.project_count = max(0, summary.project_count - 1)
+            # Restore pre-project truth: the rollback erased this project's rows,
+            # including any import_errors it recorded along the way.
+            summary.project_count = project_count_before
+            del summary.errors[errors_before:]
             _record_error(conn, summary, project_dir.name, None, f"Project import failed: {exc}")
             conn.commit()
             continue
@@ -116,6 +121,8 @@ def import_project(
 
     project_ids: list[int] = []
     sids: list[int] = []
+    project_count_before = summary.project_count
+    errors_before = len(summary.errors)
     try:
         pid, sids = _import_one_project(
             conn, import_id, source_root, project_dir, summary,
@@ -125,7 +132,10 @@ def import_project(
         project_ids = [pid]
     except Exception as exc:
         conn.rollback()
-        summary.project_count = max(0, summary.project_count - 1)
+        # Restore pre-project truth: the rollback erased this project's rows,
+        # including any import_errors it recorded along the way.
+        summary.project_count = project_count_before
+        del summary.errors[errors_before:]
         _record_error(conn, summary, project_dir.name, None, f"Project import failed: {exc}")
         conn.commit()
     _notify_progress(progress_callback, summary, "rebuilding")

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -383,6 +383,9 @@ def _parse_jsonl(
             except json.JSONDecodeError as exc:
                 _record_error(conn, summary, rel_path, line_no, f"Invalid JSONL: {exc}")
                 continue
+            if not isinstance(obj, dict):
+                _record_error(conn, summary, rel_path, line_no, "Invalid JSONL: line is not a JSON object")
+                continue
             event_id = _insert_event(conn, session_pk, rel_path, line_no, obj, is_sidechain, agent_id)
             _update_session_from_event(conn, session_pk, obj)
             _insert_message_content(conn, session_pk, event_id, obj, persisted_by_export_path, message_usage_owner)
@@ -754,7 +757,7 @@ def _insert_subagent_meta(
     rel_path = _rel(root, meta_file)
     try:
         meta = json.loads(meta_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         _record_error(conn, summary, rel_path, None, f"Invalid subagent metadata: {exc}")
         return
     agent_id = meta_file.name.removeprefix("agent-").removesuffix(".meta.json")

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -98,9 +98,9 @@ def import_all_new(
         session_ids.extend(sids)
         _notify_progress(progress_callback, summary, "importing")
 
-    _notify_progress(progress_callback, summary, "rebuilding")
-    _rebuild_derived(conn, session_ids, project_ids)
-    _finalize_import(conn, summary, import_id, session_ids, project_ids, progress_callback=progress_callback)
+    _finish_import_or_strand(
+        conn, summary, import_id, session_ids, project_ids, progress_callback=progress_callback
+    )
     return summary
 
 
@@ -140,9 +140,9 @@ def import_project(
         del summary.errors[errors_before:]
         _record_error(conn, summary, project_dir.name, None, f"Project import failed: {exc}")
         conn.commit()
-    _notify_progress(progress_callback, summary, "rebuilding")
-    _rebuild_derived(conn, sids, project_ids)
-    _finalize_import(conn, summary, import_id, sids, project_ids, progress_callback=progress_callback)
+    _finish_import_or_strand(
+        conn, summary, import_id, sids, project_ids, progress_callback=progress_callback
+    )
     return summary
 
 
@@ -204,10 +204,6 @@ def _create_import_row(conn: sqlite3.Connection, source_path: Path, file_count: 
     import_id = int(cur.lastrowid)
     summary = ImportSummary(import_id=import_id, source_path=str(source_path), file_count=file_count)
     return import_id, summary
-
-
-def _project_exists(conn: sqlite3.Connection, export_name: str) -> bool:
-    return conn.execute("SELECT 1 FROM projects WHERE export_name = ?", (export_name,)).fetchone() is not None
 
 
 def _project_source_signature(project_dir: Path) -> str:
@@ -361,6 +357,44 @@ def _finalize_import(
     )
     conn.commit()
     _notify_progress(progress_callback, summary, status)
+
+
+def _finish_import_or_strand(
+    conn: sqlite3.Connection,
+    summary: ImportSummary,
+    import_id: int,
+    session_ids: list[int],
+    project_ids: list[int],
+    *,
+    progress_callback: ProgressCallback | None = None,
+) -> None:
+    """Run the rebuild/finalize tail, guarding against stranding projects.
+
+    Each project above is committed WITH its fresh source_signature before we get
+    here. If _rebuild_derived/_finalize_import then raises, those signatures
+    already match what's on disk, so the next import_all_new() run's skip check
+    (_project_needs_import) would treat these projects as unchanged and never
+    retry them — even though their derived tables (event_edges, session_stats,
+    search_index, risk_findings/patterns) never got rebuilt. Roll back any
+    partial derived writes, null the signatures so the projects are re-imported
+    on the next run, and mark the import failed before re-raising so callers
+    (e.g. the API route) see the failure instead of a silently-stuck "running" row.
+    """
+    try:
+        _notify_progress(progress_callback, summary, "rebuilding")
+        _rebuild_derived(conn, session_ids, project_ids)
+        _finalize_import(conn, summary, import_id, session_ids, project_ids, progress_callback=progress_callback)
+    except Exception:
+        conn.rollback()
+        if project_ids:
+            sp = ",".join("?" * len(project_ids))
+            conn.execute(f"UPDATE projects SET source_signature = NULL WHERE id IN ({sp})", project_ids)
+        conn.execute(
+            "UPDATE imports SET status = 'failed', error_count = ? WHERE id = ?",
+            (len(summary.errors), import_id),
+        )
+        conn.commit()
+        raise
 
 
 def _notify_progress(

--- a/backend/src/ccfr/settings.py
+++ b/backend/src/ccfr/settings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 import secrets
 import uuid
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 
 from ccfr.config import data_dir
@@ -23,6 +23,10 @@ class Settings:
     # same-day bundles (generated_at alone is date-only). Incremented on
     # /team/export, never on the preview endpoint.
     team_bundle_seq: int = 0
+    # Export-page prefill: last member name, level, per-project label overrides,
+    # and deselected export_names (deselected, not selected, so newly imported
+    # projects default to included — protecting full-snapshot semantics).
+    team_export_prefs: dict = field(default_factory=dict)
 
 
 def _settings_path() -> Path:
@@ -45,6 +49,7 @@ def read_settings() -> Settings:
         contributor_salt=raw.get("contributor_salt"),
         contributor_id=raw.get("contributor_id"),
         team_bundle_seq=int(raw.get("team_bundle_seq", 0) or 0),
+        team_export_prefs=raw.get("team_export_prefs") if isinstance(raw.get("team_export_prefs"), dict) else {},
     )
 
 

--- a/backend/src/ccfr/settings.py
+++ b/backend/src/ccfr/settings.py
@@ -19,6 +19,10 @@ class Settings:
     privacy_mode: bool = False
     contributor_salt: str | None = None
     contributor_id: str | None = None
+    # Monotonic per-member counter for team bundle exports, used to order
+    # same-day bundles (generated_at alone is date-only). Incremented on
+    # /team/export, never on the preview endpoint.
+    team_bundle_seq: int = 0
 
 
 def _settings_path() -> Path:
@@ -40,6 +44,7 @@ def read_settings() -> Settings:
         privacy_mode=bool(raw.get("privacy_mode", False)),
         contributor_salt=raw.get("contributor_salt"),
         contributor_id=raw.get("contributor_id"),
+        team_bundle_seq=int(raw.get("team_bundle_seq", 0) or 0),
     )
 
 

--- a/backend/src/ccfr/storage/database.py
+++ b/backend/src/ccfr/storage/database.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -104,6 +105,7 @@ CREATE TABLE IF NOT EXISTS tool_calls (
     tool_use_id TEXT,
     tool_name TEXT,
     input_preview TEXT,
+    file_ext TEXT,
     raw_json TEXT NOT NULL
 );
 
@@ -283,6 +285,7 @@ CREATE TABLE IF NOT EXISTS team_bundles (
     profile TEXT NOT NULL,
     schema_version INTEGER NOT NULL,
     member_id TEXT NOT NULL,
+    member_name TEXT,
     generated_at TEXT NOT NULL,
     generated_seq INTEGER NOT NULL DEFAULT 0,
     app_version TEXT,
@@ -299,6 +302,7 @@ CREATE TABLE IF NOT EXISTS team_bundle_sessions (
     team_bundle_id INTEGER NOT NULL REFERENCES team_bundles(id) ON DELETE CASCADE,
     member_id TEXT NOT NULL,
     project_id TEXT NOT NULL,
+    project_name TEXT,
     session_id TEXT NOT NULL,
     provider TEXT NOT NULL,
     first_date TEXT,
@@ -311,6 +315,8 @@ CREATE TABLE IF NOT EXISTS team_bundle_sessions (
     stop_reasons_json TEXT NOT NULL DEFAULT '{}',
     risk_categories_json TEXT NOT NULL DEFAULT '[]',
     subagents_json TEXT NOT NULL DEFAULT '[]',
+    tools_json TEXT NOT NULL DEFAULT '[]',
+    file_types_json TEXT NOT NULL DEFAULT '[]',
     sequence_json TEXT NOT NULL DEFAULT '[]',
     UNIQUE(team_bundle_id, session_id)
 );
@@ -403,6 +409,54 @@ def migrate_db(conn: sqlite3.Connection) -> None:
     team_bundle_columns = _column_names(conn, "team_bundles")
     if team_bundle_columns and "generated_seq" not in team_bundle_columns:
         conn.execute("ALTER TABLE team_bundles ADD COLUMN generated_seq INTEGER NOT NULL DEFAULT 0")
+
+    # Team privacy levels (L2): member display name on bundles; cleartext project
+    # name, tool mix, and file-type mix on imported sessions; extension-only file
+    # types on local tool calls (derive-then-drop at ingest, never at export).
+    team_bundle_columns = _column_names(conn, "team_bundles")
+    if team_bundle_columns and "member_name" not in team_bundle_columns:
+        conn.execute("ALTER TABLE team_bundles ADD COLUMN member_name TEXT")
+
+    team_session_columns = _column_names(conn, "team_bundle_sessions")
+    if team_session_columns and "project_name" not in team_session_columns:
+        conn.execute("ALTER TABLE team_bundle_sessions ADD COLUMN project_name TEXT")
+    if team_session_columns and "tools_json" not in team_session_columns:
+        conn.execute("ALTER TABLE team_bundle_sessions ADD COLUMN tools_json TEXT NOT NULL DEFAULT '[]'")
+    if team_session_columns and "file_types_json" not in team_session_columns:
+        conn.execute("ALTER TABLE team_bundle_sessions ADD COLUMN file_types_json TEXT NOT NULL DEFAULT '[]'")
+
+    tool_call_columns = _column_names(conn, "tool_calls")
+    if tool_call_columns and "file_ext" not in tool_call_columns:
+        conn.execute("ALTER TABLE tool_calls ADD COLUMN file_ext TEXT")
+        _backfill_tool_call_file_ext(conn)
+
+
+def _backfill_tool_call_file_ext(conn: sqlite3.Connection) -> None:
+    """One-time backfill after adding tool_calls.file_ext.
+
+    Parses raw_json in the LOCAL index only (never at export time) to derive the
+    extension-only file type for rows imported before the column existed.
+    """
+    # Imported lazily: at call time both modules are fully loaded, so the
+    # storage <- ingest import cannot bite during package initialization.
+    from ccfr.ingest.file_ext import FILE_ARG_TOOLS, file_ext_from_tool_input
+
+    placeholders = ",".join("?" * len(FILE_ARG_TOOLS))
+    rows = conn.execute(
+        f"SELECT id, tool_name, raw_json FROM tool_calls WHERE tool_name IN ({placeholders})",
+        sorted(FILE_ARG_TOOLS),
+    ).fetchall()
+    updates: list[tuple[str, int]] = []
+    for row in rows:
+        try:
+            block = json.loads(row["raw_json"] or "{}")
+        except json.JSONDecodeError:
+            continue
+        input_obj = block.get("input") if isinstance(block, dict) else None
+        ext = file_ext_from_tool_input(row["tool_name"], input_obj)
+        if ext:
+            updates.append((ext, int(row["id"])))
+    conn.executemany("UPDATE tool_calls SET file_ext = ? WHERE id = ?", updates)
 
 
 def connect(path: Path) -> sqlite3.Connection:

--- a/backend/src/ccfr/storage/database.py
+++ b/backend/src/ccfr/storage/database.py
@@ -284,6 +284,7 @@ CREATE TABLE IF NOT EXISTS team_bundles (
     schema_version INTEGER NOT NULL,
     member_id TEXT NOT NULL,
     generated_at TEXT NOT NULL,
+    generated_seq INTEGER NOT NULL DEFAULT 0,
     app_version TEXT,
     imported_at TEXT NOT NULL,
     source_path TEXT NOT NULL,
@@ -396,6 +397,12 @@ def migrate_db(conn: sqlite3.Connection) -> None:
     project_columns = _column_names(conn, "projects")
     if project_columns and "source_signature" not in project_columns:
         conn.execute("ALTER TABLE projects ADD COLUMN source_signature TEXT")
+
+    # Per-member export sequence for same-day bundle ordering (sub-project C). Added to
+    # older databases whose team_bundles predates the column.
+    team_bundle_columns = _column_names(conn, "team_bundles")
+    if team_bundle_columns and "generated_seq" not in team_bundle_columns:
+        conn.execute("ALTER TABLE team_bundles ADD COLUMN generated_seq INTEGER NOT NULL DEFAULT 0")
 
 
 def connect(path: Path) -> sqlite3.Connection:

--- a/backend/src/ccfr/storage/database.py
+++ b/backend/src/ccfr/storage/database.py
@@ -276,6 +276,47 @@ CREATE INDEX IF NOT EXISTS idx_risk_findings_session ON risk_findings(session_id
 CREATE INDEX IF NOT EXISTS idx_risk_findings_category ON risk_findings(category);
 CREATE INDEX IF NOT EXISTS idx_risk_findings_score ON risk_findings(score);
 
+CREATE TABLE IF NOT EXISTS team_bundles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bundle_id TEXT NOT NULL UNIQUE,
+    profile TEXT NOT NULL,
+    schema_version INTEGER NOT NULL,
+    member_id TEXT NOT NULL,
+    generated_at TEXT NOT NULL,
+    app_version TEXT,
+    imported_at TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    session_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_bundles_member ON team_bundles(member_id);
+CREATE INDEX IF NOT EXISTS idx_team_bundles_imported_at ON team_bundles(imported_at);
+
+CREATE TABLE IF NOT EXISTS team_bundle_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_bundle_id INTEGER NOT NULL REFERENCES team_bundles(id) ON DELETE CASCADE,
+    member_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    first_date TEXT,
+    last_date TEXT,
+    duration_s INTEGER NOT NULL DEFAULT 0,
+    models_json TEXT NOT NULL DEFAULT '[]',
+    tokens_json TEXT NOT NULL DEFAULT '{}',
+    tokens_by_model_json TEXT NOT NULL DEFAULT '{}',
+    stats_json TEXT NOT NULL DEFAULT '{}',
+    stop_reasons_json TEXT NOT NULL DEFAULT '{}',
+    risk_categories_json TEXT NOT NULL DEFAULT '[]',
+    subagents_json TEXT NOT NULL DEFAULT '[]',
+    sequence_json TEXT NOT NULL DEFAULT '[]',
+    UNIQUE(team_bundle_id, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_bundle_sessions_bundle ON team_bundle_sessions(team_bundle_id);
+CREATE INDEX IF NOT EXISTS idx_team_bundle_sessions_member ON team_bundle_sessions(member_id);
+CREATE INDEX IF NOT EXISTS idx_team_bundle_sessions_first_date ON team_bundle_sessions(first_date);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5(
     kind,
     ref_id UNINDEXED,
@@ -288,6 +329,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts5(
 
 DROP_TABLES = [
     "search_index",
+    "team_bundle_sessions",
+    "team_bundles",
     "risk_findings",
     "pattern_hits",
     "event_features",
@@ -339,6 +382,14 @@ def migrate_db(conn: sqlite3.Connection) -> None:
           AND COALESCE(cache_read_tokens, 0) = 0
         """
     )
+
+    # Per-model token attribution for team bundles (sub-project B). Added to
+    # older databases whose team_bundle_sessions predates the column.
+    team_session_columns = _column_names(conn, "team_bundle_sessions")
+    if team_session_columns and "tokens_by_model_json" not in team_session_columns:
+        conn.execute(
+            "ALTER TABLE team_bundle_sessions ADD COLUMN tokens_by_model_json TEXT NOT NULL DEFAULT '{}'"
+        )
 
 
 def connect(path: Path) -> sqlite3.Connection:

--- a/backend/src/ccfr/storage/database.py
+++ b/backend/src/ccfr/storage/database.py
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS projects (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     import_id INTEGER NOT NULL REFERENCES imports(id) ON DELETE CASCADE,
     export_name TEXT NOT NULL,
-    inferred_cwd TEXT
+    inferred_cwd TEXT,
+    source_signature TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_projects_export_name ON projects(export_name);
@@ -390,6 +391,11 @@ def migrate_db(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE team_bundle_sessions ADD COLUMN tokens_by_model_json TEXT NOT NULL DEFAULT '{}'"
         )
+
+    # On-disk change detection for already-imported projects (sub-project A).
+    project_columns = _column_names(conn, "projects")
+    if project_columns and "source_signature" not in project_columns:
+        conn.execute("ALTER TABLE projects ADD COLUMN source_signature TEXT")
 
 
 def connect(path: Path) -> sqlite3.Connection:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -11,3 +11,31 @@ def test_pricing_dir_defaults_beside_pricing_csv(monkeypatch):
 def test_pricing_dir_env_override(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("CCFR_PRICING_DIR", str(tmp_path / "sheets"))
     assert config.pricing_dir() == tmp_path / "sheets"
+
+
+def test_team_bundle_root_defaults_under_data_dir(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv("CCFR_TEAM_BUNDLE_ROOT", raising=False)
+    monkeypatch.setenv("CCFR_DATA_DIR", str(tmp_path / "data"))
+    assert config.team_bundle_root() == tmp_path / "data" / "team-bundles"
+
+
+def test_team_bundle_root_env_override(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CCFR_TEAM_BUNDLE_ROOT", str(tmp_path / "team"))
+    assert config.team_bundle_root() == tmp_path / "team"
+
+
+def test_resolve_within_team_bundle_root_rejects_escape(tmp_path: Path):
+    root = tmp_path / "team"
+    root.mkdir()
+    inside = root / "bundle.json"
+    outside = tmp_path / "outside.json"
+    inside.write_text("{}", encoding="utf-8")
+    outside.write_text("{}", encoding="utf-8")
+
+    assert config.resolve_within_team_bundle_root(str(inside), root) == inside.resolve()
+    try:
+        config.resolve_within_team_bundle_root(str(outside), root)
+    except ValueError as exc:
+        assert "team bundle root" in str(exc)
+    else:
+        raise AssertionError("expected path escape to fail")

--- a/backend/tests/test_context_economics.py
+++ b/backend/tests/test_context_economics.py
@@ -745,6 +745,62 @@ def test_detect_stale_continuation_skips_small_resumed_context() -> None:
     assert findings == []
 
 
+def _flat_priced_thread(calls: list[CallRec]) -> ThreadRec:
+    # Named distinctly from _priced_thread (line 459 above), which already has
+    # a different signature (calls, items) and derives prices via accrue_tax.
+    # A same-named redefinition here would silently replace that binding for
+    # every earlier test in this module (Python module-level defs are resolved
+    # at call time), breaking the many `_priced_thread(calls, items)` callers.
+    thread = ThreadRec(
+        session_db_id=1, session_title="t", project_name="p", agent_id=None,
+        calls=calls, epochs=split_epochs([c.context_tokens for c in calls]),
+        contributors=[],
+    )
+    thread.read_prices = [1e-6] * len(calls)      # $1/MTok read
+    thread.write_prices = [1.25e-6] * len(calls)  # $1.25/MTok write
+    return thread
+
+
+def test_late_compaction_savings_tokens_is_a_footprint_not_token_turns() -> None:
+    # 10 calls pinned at 120k context: eligible at call 0, tail of 9 calls.
+    calls = [_call(i + 1, 120_000, ts=f"2026-01-01T00:{i:02d}:00Z") for i in range(10)]
+    thread = _flat_priced_thread(calls)
+    claims = Claims.for_threads([thread])
+
+    findings, _ = detect_late_compaction([thread], claims)
+
+    assert len(findings) == 1
+    f = findings[0]
+    dropped = int(120_000 * (1 - 0.3))            # 84_000 ballast tokens
+    assert f.savings_tokens == dropped            # once — NOT dropped * 9 tail calls
+    assert f.carried_tokens == dropped
+    assert f.carried_turns == 9
+    # USD is per-call carry and stays cumulative: 9 * 84k * $1/MTok - rewrite cost.
+    assert f.savings_usd == pytest.approx(9 * 84_000 * 1e-6 - 36_000 * 1.25e-6)
+
+
+def test_stale_continuation_savings_tokens_is_a_footprint() -> None:
+    # 8 calls: minute-spaced ramp to 90k, then a 2h gap before two tail calls.
+    contexts = [10_000, 30_000, 50_000, 70_000, 80_000, 90_000, 90_000, 90_000]
+    times = ["00:00", "00:01", "00:02", "00:03", "00:04", "00:05", "02:05", "02:06"]
+    calls = [
+        _call(i + 1, ctx, ts=f"2026-01-01T{t}:00Z")
+        for i, (ctx, t) in enumerate(zip(contexts, times))
+    ]
+    thread = _flat_priced_thread(calls)
+    claims = Claims.for_threads([thread])
+
+    findings, _ = detect_stale_continuation([thread], claims)
+
+    assert len(findings) == 1
+    f = findings[0]
+    avoidable = 90_000 - 10_000                   # pre-gap context minus baseline
+    assert f.savings_tokens == avoidable          # once — NOT avoidable * 2 tail calls
+    assert f.carried_tokens == avoidable
+    assert f.carried_turns == 2
+    assert f.savings_usd == pytest.approx(2 * avoidable * 1e-6)
+
+
 # ---------------------------------------------------------------------------
 # Corpus aggregation: context_economics_analytics
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_context_economics.py
+++ b/backend/tests/test_context_economics.py
@@ -12,6 +12,7 @@ from ccfr.analysis.context_economics import (
     EpochRec,
     RawItem,
     _percentile,
+    _raw_item,
     calibrate_contributors,
     split_epochs,
 )
@@ -145,6 +146,43 @@ def test_calibrate_many_items_still_sum_to_delta() -> None:
     items = {1: [RawItem(kind="user", label=f"m{n}", raw_chars=4_000) for n in range(7)]}
     contributors = [c for c in calibrate_contributors(calls, epochs, items) if c.kind != "baseline"]
     assert sum(c.est_tokens for c in contributors) == 10
+
+
+# ---------------------------------------------------------------------------
+# _raw_item: sizing individual tool results
+# ---------------------------------------------------------------------------
+
+def test_raw_item_sizes_parallel_results_by_their_own_length() -> None:
+    # One user event carrying two parallel tool_results: the event JSON is 20k
+    # chars, but this result's own payload is only 400 chars.
+    row = {
+        "tool_result_id": 1, "tool_name": "Read", "call_json": None,
+        "size_bytes": None, "raw_len": 20_000, "result_raw_len": 400,
+        "event_id": 7, "type": "user",
+    }
+    item = _raw_item(row)
+    assert item.kind == "tool_result"
+    assert item.raw_chars == 400
+
+
+def test_raw_item_persisted_output_still_wins() -> None:
+    row = {
+        "tool_result_id": 1, "tool_name": "Bash", "call_json": None,
+        "size_bytes": 12_345, "raw_len": 20_000, "result_raw_len": 400,
+        "event_id": 7, "type": "user",
+    }
+    assert _raw_item(row).raw_chars == 12_345
+
+
+def test_raw_item_user_message_uses_event_length() -> None:
+    row = {
+        "tool_result_id": None, "tool_name": None, "call_json": None,
+        "size_bytes": None, "raw_len": 5_000, "result_raw_len": None,
+        "event_id": 8, "type": "user",
+    }
+    item = _raw_item(row)
+    assert item.kind == "user"
+    assert item.raw_chars == 5_000
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from ccfr.storage import init_db
+from ccfr.storage import init_db, reset_db
 
 
 def test_init_db_migrates_legacy_message_cost_columns() -> None:
@@ -56,3 +56,66 @@ def test_init_db_creates_analytics_indexes() -> None:
     assert {"idx_tool_results_event", "idx_tool_results_session_use"} <= tool_result_indexes
     assert {"idx_persisted_outputs_session"} <= persisted_indexes
     assert {"idx_event_edges_session", "idx_event_edges_source", "idx_event_edges_target"} <= edge_indexes
+
+
+def test_init_db_and_reset_cover_team_bundle_tables() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
+    assert {"team_bundles", "team_bundle_sessions"} <= tables
+
+    cur = conn.execute(
+        """
+        INSERT INTO team_bundles(
+            bundle_id, profile, schema_version, member_id, generated_at,
+            app_version, imported_at, source_path, session_count
+        )
+        VALUES ('bundle', 'team_strict', 1, 'member', '2026-06-18', '0.1.0',
+                '2026-06-18T00:00:00Z', 'bundle.json', 1)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO team_bundle_sessions(
+            team_bundle_id, member_id, project_id, session_id, provider
+        )
+        VALUES (?, 'member', 'pid', 'sid', 'claude')
+        """,
+        (cur.lastrowid,),
+    )
+
+    reset_db(conn)
+
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == 0
+
+
+def test_init_db_creates_tokens_by_model_column() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(team_bundle_sessions)").fetchall()}
+    assert "tokens_by_model_json" in columns
+
+
+def test_migrate_db_adds_tokens_by_model_to_legacy_team_table() -> None:
+    from ccfr.storage.database import migrate_db
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # A database created before per-model tokens: messages exists (the message
+    # migration needs it), team_bundle_sessions lacks the new column.
+    conn.executescript(
+        """
+        CREATE TABLE messages (id INTEGER PRIMARY KEY, input_tokens INTEGER DEFAULT 0);
+        CREATE TABLE team_bundle_sessions (id INTEGER PRIMARY KEY, session_id TEXT);
+        """
+    )
+
+    migrate_db(conn)
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(team_bundle_sessions)").fetchall()}
+    assert "tokens_by_model_json" in columns

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 
 from ccfr.storage import init_db, reset_db
@@ -119,3 +120,41 @@ def test_migrate_db_adds_tokens_by_model_to_legacy_team_table() -> None:
 
     columns = {row[1] for row in conn.execute("PRAGMA table_info(team_bundle_sessions)").fetchall()}
     assert "tokens_by_model_json" in columns
+
+
+def test_migrate_adds_and_backfills_file_ext_on_legacy_tool_calls():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # Legacy shape: tool_calls without file_ext, holding an already-imported Read call.
+    conn.execute(
+        """
+        CREATE TABLE tool_calls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id INTEGER NOT NULL,
+            session_id INTEGER NOT NULL,
+            tool_use_id TEXT,
+            tool_name TEXT,
+            input_preview TEXT,
+            raw_json TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO tool_calls(event_id, session_id, tool_use_id, tool_name, input_preview, raw_json)"
+        " VALUES (1, 1, 't1', 'Read', 'preview', ?)",
+        (json.dumps({"type": "tool_use", "name": "Read", "input": {"file_path": "src/App.TSX"}}),),
+    )
+    init_db(conn)
+
+    row = conn.execute("SELECT file_ext FROM tool_calls").fetchone()
+    assert row["file_ext"] == "tsx"
+
+
+def test_migrate_adds_team_privacy_level_columns():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    bundle_cols = {r[1] for r in conn.execute("PRAGMA table_info(team_bundles)")}
+    session_cols = {r[1] for r in conn.execute("PRAGMA table_info(team_bundle_sessions)")}
+    assert "member_name" in bundle_cols
+    assert {"project_name", "tools_json", "file_types_json"} <= session_cols

--- a/backend/tests/test_file_ext.py
+++ b/backend/tests/test_file_ext.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from ccfr.ingest.file_ext import file_ext_from_tool_input
+
+
+def test_extracts_lowercased_extension_from_file_path():
+    assert file_ext_from_tool_input("Read", {"file_path": "src/app/Main.TSX"}) == "tsx"
+    assert file_ext_from_tool_input("Edit", {"file_path": "D:\\Code\\x\\importer.py"}) == "py"
+    assert file_ext_from_tool_input("NotebookEdit", {"notebook_path": "nb/analysis.ipynb"}) == "ipynb"
+
+
+def test_multi_dot_names_keep_only_the_last_extension():
+    assert file_ext_from_tool_input("Write", {"file_path": "dist/archive.tar.gz"}) == "gz"
+
+
+def test_extensionless_dotfile_and_non_file_tools_yield_none():
+    assert file_ext_from_tool_input("Read", {"file_path": "Makefile"}) is None
+    assert file_ext_from_tool_input("Read", {"file_path": ".env"}) is None
+    assert file_ext_from_tool_input("Bash", {"command": "cat notes.txt"}) is None
+    assert file_ext_from_tool_input("Read", None) is None
+    assert file_ext_from_tool_input("Read", {"file_path": "   "}) is None
+
+
+def test_weird_or_oversized_extensions_are_dropped():
+    assert file_ext_from_tool_input("Read", {"file_path": "a.b/c.d e"}) is None  # space fails the charset
+    assert file_ext_from_tool_input("Read", {"file_path": "x." + "y" * 13}) is None  # > 12 chars

--- a/backend/tests/test_import_api.py
+++ b/backend/tests/test_import_api.py
@@ -230,3 +230,34 @@ def test_stats_reflect_current_cache(client) -> None:
 
     c.post("/api/imports/reset")
     assert c.get("/api/stats").json()["project_count"] == 0
+
+
+def test_progress_callback_throttles_db_stat_queries(monkeypatch):
+    from ccfr.api import repository
+    from ccfr.ingest import ImportSummary
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+
+    calls = {"stats": 0}
+    monkeypatch.setattr(repository, "import_summary_stats", lambda c, i: calls.__setitem__("stats", calls["stats"] + 1) or {})
+    monkeypatch.setattr(repository, "cache_stats", lambda c: {})
+
+    fake = {"now": 0.0}
+    cb = routes._progress_callback(conn, Path("."), None, min_interval_s=0.5, clock=lambda: fake["now"])
+    summary = ImportSummary(import_id=1, source_path="x")
+
+    for _ in range(100):
+        cb(summary, "importing")          # same status, same instant: 1 query
+    assert calls["stats"] == 1
+
+    fake["now"] = 1.0
+    cb(summary, "importing")              # interval elapsed: re-query
+    assert calls["stats"] == 2
+
+    cb(summary, "rebuilding")             # status change publishes immediately
+    assert calls["stats"] == 3
+
+    cb(summary, "completed")              # terminal always publishes
+    assert calls["stats"] == 4

--- a/backend/tests/test_importer.py
+++ b/backend/tests/test_importer.py
@@ -501,3 +501,37 @@ def test_import_stores_cache_breakdown_and_costs_per_model(tmp_path: Path, monke
     # base 5 + 5m 3.75 + 1h 4 + read 1.0 + output 10 = 23.75
     assert cost["usd"] == 23.75
     assert cost["tokens"]["cache_read"] == 2_000_000
+
+
+def test_non_object_jsonl_line_is_recorded_not_fatal(tmp_path: Path) -> None:
+    project = tmp_path / "d--Sample"
+    project.mkdir()
+    session_id = "11111111-1111-1111-1111-111111111111"
+    (project / f"{session_id}.jsonl").write_text(
+        "\n".join(
+            [
+                '{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"hello"}}',
+                "42",
+                "null",
+                '{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    conn = memory_conn()
+    summary = import_export(conn, tmp_path)
+    assert summary.event_count == 2
+    assert summary.error_count == 2
+    assert conn.execute("SELECT COUNT(*) FROM import_errors").fetchone()[0] == 2
+
+
+def test_invalid_utf8_subagent_meta_is_recorded_not_fatal(tmp_path: Path) -> None:
+    _write_project(tmp_path, "d--Sample", "11111111-1111-1111-1111-111111111111")
+    subagents = tmp_path / "d--Sample" / "11111111-1111-1111-1111-111111111111" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-x.meta.json").write_bytes(b"\xff\xfe{ not utf8")
+    conn = memory_conn()
+    summary = import_export(conn, tmp_path)
+    assert summary.error_count == 1
+    assert summary.project_count == 1
+    assert conn.execute("SELECT COUNT(*) FROM subagents").fetchone()[0] == 0

--- a/backend/tests/test_importer.py
+++ b/backend/tests/test_importer.py
@@ -535,3 +535,58 @@ def test_invalid_utf8_subagent_meta_is_recorded_not_fatal(tmp_path: Path) -> Non
     assert summary.error_count == 1
     assert summary.project_count == 1
     assert conn.execute("SELECT COUNT(*) FROM subagents").fetchone()[0] == 0
+
+
+def test_import_keeps_a_rollback_journal(tmp_path: Path) -> None:
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    conn = memory_conn()
+    import_export(conn, tmp_path)
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() != "off"
+
+
+def test_failed_project_rolls_back_and_others_survive(tmp_path: Path, monkeypatch) -> None:
+    import ccfr.ingest.importer as importer_mod
+    from ccfr.ingest import import_all_new
+
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    _write_project(tmp_path, "d--Beta", "22222222-2222-2222-2222-222222222222")
+
+    original = importer_mod._parse_jsonl
+
+    def boom(conn, summary, root, path, *args, **kwargs):
+        if "d--Beta" in str(path):
+            raise RuntimeError("disk exploded")
+        return original(conn, summary, root, path, *args, **kwargs)
+
+    monkeypatch.setattr(importer_mod, "_parse_jsonl", boom)
+    conn = memory_conn()
+    summary = import_all_new(conn, tmp_path, include_existing=True)
+
+    names = [r[0] for r in conn.execute("SELECT export_name FROM projects ORDER BY export_name")]
+    assert names == ["d--Alpha"]
+    assert summary.error_count == 1
+    assert conn.execute("SELECT status FROM imports ORDER BY id DESC LIMIT 1").fetchone()[0] == "completed_with_errors"
+
+
+def test_failed_reimport_preserves_previous_project_data(tmp_path: Path, monkeypatch) -> None:
+    import ccfr.ingest.importer as importer_mod
+    from ccfr.ingest import import_all_new
+
+    _write_project(tmp_path, "d--Beta", "22222222-2222-2222-2222-222222222222")
+    conn = memory_conn()
+    import_all_new(conn, tmp_path, include_existing=True)
+    assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+    original = importer_mod._parse_jsonl
+
+    def boom(conn_, summary, root, path, *args, **kwargs):
+        if "d--Beta" in str(path):
+            raise RuntimeError("disk exploded")
+        return original(conn_, summary, root, path, *args, **kwargs)
+
+    monkeypatch.setattr(importer_mod, "_parse_jsonl", boom)
+    import_all_new(conn, tmp_path, include_existing=True)
+
+    # The failed re-import must roll back its delete: old Beta data intact.
+    assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 2

--- a/backend/tests/test_importer.py
+++ b/backend/tests/test_importer.py
@@ -649,3 +649,41 @@ def test_rolled_back_recoverable_errors_do_not_linger_in_summary(tmp_path: Path,
     assert summary.error_count == 1
     assert summary.errors[0]["message"].startswith("Project import failed")
     assert conn.execute("SELECT COUNT(*) FROM import_errors").fetchone()[0] == 1
+
+
+def test_import_all_new_reimports_project_changed_on_disk(tmp_path: Path) -> None:
+    from ccfr.ingest import import_all_new
+
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    conn = memory_conn()
+    import_all_new(conn, tmp_path)
+    assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+    # A new session lands in the SAME project directory.
+    _write_project(tmp_path, "d--Alpha", "33333333-3333-3333-3333-333333333333")
+    import_all_new(conn, tmp_path)
+    assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 2
+
+
+def test_import_all_new_skips_unchanged_project(tmp_path: Path) -> None:
+    from ccfr.ingest import import_all_new
+
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    conn = memory_conn()
+    import_all_new(conn, tmp_path)
+    first_ids = [r[0] for r in conn.execute("SELECT id FROM sessions ORDER BY id")]
+    import_all_new(conn, tmp_path)
+    # Unchanged on disk: skipped entirely, session rows not rebuilt.
+    assert [r[0] for r in conn.execute("SELECT id FROM sessions ORDER BY id")] == first_ids
+
+
+def test_discover_projects_flags_stale(tmp_path: Path) -> None:
+    from ccfr.ingest import discover_projects, import_all_new
+
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    conn = memory_conn()
+    import_all_new(conn, tmp_path)
+    assert discover_projects(conn, tmp_path)[0].stale is False
+
+    _write_project(tmp_path, "d--Alpha", "33333333-3333-3333-3333-333333333333")
+    assert discover_projects(conn, tmp_path)[0].stale is True

--- a/backend/tests/test_importer.py
+++ b/backend/tests/test_importer.py
@@ -4,6 +4,8 @@ import json
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from ccfr.api import repository
 from ccfr.ingest import import_export
 from ccfr.storage import init_db
@@ -687,3 +689,26 @@ def test_discover_projects_flags_stale(tmp_path: Path) -> None:
 
     _write_project(tmp_path, "d--Alpha", "33333333-3333-3333-3333-333333333333")
     assert discover_projects(conn, tmp_path)[0].stale is True
+
+
+def test_failed_rebuild_marks_import_failed_and_next_run_retries(tmp_path: Path, monkeypatch) -> None:
+    import ccfr.ingest.importer as importer_mod
+    from ccfr.ingest import import_all_new
+
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    conn = memory_conn()
+
+    def boom(conn_, session_ids, project_ids):
+        raise RuntimeError("rebuild exploded")
+
+    monkeypatch.setattr(importer_mod, "_rebuild_derived", boom)
+    with pytest.raises(RuntimeError):
+        import_all_new(conn, tmp_path, include_existing=True)
+
+    assert conn.execute("SELECT status FROM imports ORDER BY id DESC LIMIT 1").fetchone()[0] == "failed"
+    assert conn.execute("SELECT source_signature FROM projects").fetchone()[0] is None
+
+    monkeypatch.undo()
+    import_all_new(conn, tmp_path)  # incremental run must NOT skip the stranded project
+    assert conn.execute("SELECT status FROM imports ORDER BY id DESC LIMIT 1").fetchone()[0] == "completed"
+    assert conn.execute("SELECT COUNT(*) FROM session_stats").fetchone()[0] > 0

--- a/backend/tests/test_importer.py
+++ b/backend/tests/test_importer.py
@@ -712,3 +712,16 @@ def test_failed_rebuild_marks_import_failed_and_next_run_retries(tmp_path: Path,
     import_all_new(conn, tmp_path)  # incremental run must NOT skip the stranded project
     assert conn.execute("SELECT status FROM imports ORDER BY id DESC LIMIT 1").fetchone()[0] == "completed"
     assert conn.execute("SELECT COUNT(*) FROM session_stats").fetchone()[0] > 0
+
+
+def test_import_populates_file_ext_for_file_arg_tools(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, sanitized_export(tmp_path))
+
+    rows = conn.execute("SELECT tool_name, file_ext FROM tool_calls ORDER BY id").fetchall()
+    read_exts = [row["file_ext"] for row in rows if row["tool_name"] == "Read"]
+    assert read_exts == ["py", "py", "py"]  # alpha fixture reads three .py files
+    other = {row["file_ext"] for row in rows if row["tool_name"] != "Read"}
+    assert other == {None}  # Bash / Agent calls carry no file extension

--- a/backend/tests/test_importer.py
+++ b/backend/tests/test_importer.py
@@ -590,3 +590,62 @@ def test_failed_reimport_preserves_previous_project_data(tmp_path: Path, monkeyp
     # The failed re-import must roll back its delete: old Beta data intact.
     assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
     assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 2
+
+
+def test_failure_before_project_insert_keeps_counts_truthful(tmp_path: Path, monkeypatch) -> None:
+    import ccfr.ingest.importer as importer_mod
+    from ccfr.ingest import import_all_new
+
+    _write_project(tmp_path, "d--Alpha", "11111111-1111-1111-1111-111111111111")
+    _write_project(tmp_path, "d--Beta", "22222222-2222-2222-2222-222222222222")
+
+    original = importer_mod._insert_project
+
+    def boom(conn, import_id, export_name):
+        if export_name == "d--Beta":
+            raise RuntimeError("insert failed")
+        return original(conn, import_id, export_name)
+
+    monkeypatch.setattr(importer_mod, "_insert_project", boom)
+    conn = memory_conn()
+    summary = import_all_new(conn, tmp_path, include_existing=True)
+
+    # Alpha imported and still counted; Beta failed BEFORE its count bump.
+    assert summary.project_count == 1
+    assert summary.error_count == 1
+    assert conn.execute("SELECT COUNT(*) FROM projects").fetchone()[0] == 1
+
+
+def test_rolled_back_recoverable_errors_do_not_linger_in_summary(tmp_path: Path, monkeypatch) -> None:
+    import ccfr.ingest.importer as importer_mod
+    from ccfr.ingest import import_all_new
+
+    # Beta has a recoverable bad line (recorded mid-transaction) and a memory
+    # file whose insert we make fatal — the rollback must also purge the
+    # recoverable entry from the in-memory summary.
+    project = tmp_path / "d--Beta"
+    project.mkdir()
+    (project / "22222222-2222-2222-2222-222222222222.jsonl").write_text(
+        "\n".join(
+            [
+                '{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"hi"}}',
+                "{bad json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    memory_dir = project / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "note.md").write_text("note", encoding="utf-8")
+
+    def boom(conn, summary, root, memory_file, project_id):
+        raise RuntimeError("memory insert failed")
+
+    monkeypatch.setattr(importer_mod, "_insert_memory", boom)
+    conn = memory_conn()
+    summary = import_all_new(conn, tmp_path, include_existing=True)
+
+    # Only the project-failure entry remains, matching the persisted rows.
+    assert summary.error_count == 1
+    assert summary.errors[0]["message"].startswith("Project import failed")
+    assert conn.execute("SELECT COUNT(*) FROM import_errors").fetchone()[0] == 1

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -14,6 +14,14 @@ def test_round_trip(monkeypatch, tmp_path):
     assert (tmp_path / "settings.json").exists()
 
 
+def test_team_bundle_seq_defaults_to_zero_and_round_trips(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    assert read_settings().team_bundle_seq == 0
+
+    write_settings(Settings(team_bundle_seq=3))
+    assert read_settings().team_bundle_seq == 3
+
+
 def test_corrupt_file_falls_back_to_defaults(monkeypatch, tmp_path):
     monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
     (tmp_path / "settings.json").write_text("{not json", encoding="utf-8")

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from ccfr import settings as settings_mod
 from ccfr.settings import Settings, read_settings, write_settings
 
@@ -20,6 +22,16 @@ def test_team_bundle_seq_defaults_to_zero_and_round_trips(monkeypatch, tmp_path)
 
     write_settings(Settings(team_bundle_seq=3))
     assert read_settings().team_bundle_seq == 3
+
+
+def test_settings_round_trips_team_export_prefs(tmp_path, monkeypatch):
+    import ccfr.settings as settings_mod
+
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    prefs = {"member_name": "Avery", "privacy_level": "team",
+             "project_labels": {"d--Alpha": "alpha"}, "deselected": ["d--Beta"]}
+    settings_mod.write_settings(replace(settings_mod.read_settings(), team_export_prefs=prefs))
+    assert settings_mod.read_settings().team_export_prefs == prefs
 
 
 def test_corrupt_file_falls_back_to_defaults(monkeypatch, tmp_path):

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -10,10 +10,12 @@ def test_settings_get_default_and_put_round_trip(monkeypatch, tmp_path):
 
     got = client.get("/api/settings")
     assert got.status_code == 200
-    assert got.json() == {"historical_pricing": True, "privacy_mode": False}
+    assert got.json() == {"historical_pricing": True, "privacy_mode": False, "team_export_prefs": {}}
 
     put = client.put("/api/settings", json={"historical_pricing": False})
     assert put.status_code == 200
-    assert put.json() == {"historical_pricing": False, "privacy_mode": False}
+    assert put.json() == {"historical_pricing": False, "privacy_mode": False, "team_export_prefs": {}}
 
-    assert client.get("/api/settings").json() == {"historical_pricing": False, "privacy_mode": False}
+    assert client.get("/api/settings").json() == {
+        "historical_pricing": False, "privacy_mode": False, "team_export_prefs": {}
+    }

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -33,15 +33,14 @@ def _bundle_from_sanitized(tmp_path):
         conn.close()
 
 
-def test_team_bundle_has_profile_and_pseudonymous_ids(tmp_path):
+def test_team_bundle_v2_structural_shape(tmp_path):
     bundle = _bundle_from_sanitized(tmp_path)
     data = bundle.to_dict()
 
-    assert data["schema_version"] == 1
-    assert data["profile"] == "team_strict"
-    assert data["member_id"] == "22222222-2222-2222-2222-222222222222"
-    assert data["generated_at"] == "2026-06-18"
-    assert len(data["bundle_id"]) == 64
+    assert data["schema_version"] == 2
+    assert data["privacy_level"] == "structural"
+    assert "profile" not in data
+    assert "member_name" not in data
 
     blob = json.dumps(data)
     assert ALPHA_SESSION_ID not in blob
@@ -222,11 +221,12 @@ def test_validate_team_bundle_buckets_raw_tokens_by_model(tmp_path):
 def test_validate_team_bundle_rejects_invalid_profile_and_schema(tmp_path):
     data = _bundle_from_sanitized(tmp_path).to_dict()
 
-    bad_profile = {**data, "profile": "loose"}
-    with pytest.raises(ValueError, match="profile"):
-        team_bundles.validate_team_bundle(bad_profile)
+    bad_level = copy.deepcopy(data)
+    bad_level["privacy_level"] = "everything"
+    with pytest.raises(ValueError, match="privacy_level"):
+        team_bundles.validate_team_bundle(bad_level)
 
-    bad_schema = {**data, "schema_version": 2}
+    bad_schema = {**data, "schema_version": 99}
     with pytest.raises(ValueError, match="schema_version"):
         team_bundles.validate_team_bundle(bad_schema)
 
@@ -257,19 +257,19 @@ def _team_conn() -> sqlite3.Connection:
 
 
 def _redated(bundle_dict: dict, generated_at: str) -> dict:
-    newer = copy.deepcopy(bundle_dict)
-    newer.pop("bundle_id", None)
-    newer["generated_at"] = generated_at
-    newer["bundle_id"] = team_bundles.bundle_content_id(newer)
-    return newer
+    updated = copy.deepcopy(bundle_dict)
+    updated["generated_at"] = generated_at
+    updated.pop("bundle_id", None)
+    updated["bundle_id"] = team_bundles.bundle_content_id_v2(updated)
+    return updated
 
 
 def _reseq(bundle_dict: dict, generated_at: str, generated_seq: int) -> dict:
     updated = copy.deepcopy(bundle_dict)
-    updated.pop("bundle_id", None)
     updated["generated_at"] = generated_at
     updated["generated_seq"] = generated_seq
-    updated["bundle_id"] = team_bundles.bundle_content_id(updated)
+    updated.pop("bundle_id", None)
+    updated["bundle_id"] = team_bundles.bundle_content_id_v2(updated)
     return updated
 
 
@@ -280,7 +280,7 @@ def test_team_dashboard_counts_subagent_sessions_once_per_session(tmp_path):
         {"agent_type": "custom", "event_count": 3},
         {"agent_type": "custom", "event_count": 2},
     ]
-    bundle["bundle_id"] = team_bundles.bundle_content_id(bundle)
+    bundle["bundle_id"] = team_bundles.bundle_content_id_v2(bundle)
     conn = _team_conn()
 
     team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
@@ -350,7 +350,7 @@ def _with_fewer_sessions(bundle_dict: dict) -> dict:
     thinned = copy.deepcopy(bundle_dict)
     thinned.pop("bundle_id", None)
     thinned["sessions"] = thinned["sessions"][:-1]
-    thinned["bundle_id"] = team_bundles.bundle_content_id(thinned)
+    thinned["bundle_id"] = team_bundles.bundle_content_id_v2(thinned)
     return thinned
 
 
@@ -395,16 +395,27 @@ def test_same_day_in_order_import_replaces(tmp_path):
     )
 
 
+def _legacy_v1_bundle(generated_at: str = "2026-06-18") -> dict:
+    base = {
+        "schema_version": 1,
+        "profile": "team_strict",
+        "member_id": "22222222-2222-2222-2222-222222222222",
+        "generated_at": generated_at,
+        "app_version": "0.1.0",
+        "sessions": [],
+    }
+    base["bundle_id"] = team_bundles.bundle_content_id(base)
+    return base
+
+
 def test_legacy_bundle_without_generated_seq_validates_and_imports_as_zero(tmp_path):
     bundle = _bundle_from_sanitized(tmp_path).to_dict()
-    assert len(bundle["sessions"]) > 1
-    legacy = _with_fewer_sessions(bundle)
-    legacy.pop("generated_seq", None)
-    legacy.pop("bundle_id", None)
-    legacy["bundle_id"] = team_bundles.bundle_content_id(legacy)
+    legacy = _legacy_v1_bundle()
 
     canonical = team_bundles.validate_team_bundle(legacy)
     assert canonical["generated_seq"] == 0
+    assert canonical["privacy_level"] == "structural"
+    assert canonical["profile"] == "team_strict"
 
     conn = _team_conn()
     result = team_bundles.import_team_bundle(conn, legacy, source_path=Path("a.json"))
@@ -424,11 +435,7 @@ def test_legacy_bundle_on_a_later_date_beats_an_earlier_high_seq_bundle(tmp_path
     first = team_bundles.import_team_bundle(conn, earlier_high_seq, source_path=Path("a.json"))
     assert first.imported and first.status == "imported"
 
-    legacy_later = copy.deepcopy(bundle)
-    legacy_later.pop("generated_seq", None)
-    legacy_later.pop("bundle_id", None)
-    legacy_later["generated_at"] = "2026-06-19"
-    legacy_later["bundle_id"] = team_bundles.bundle_content_id(legacy_later)
+    legacy_later = _legacy_v1_bundle(generated_at="2026-06-19")
 
     second = team_bundles.import_team_bundle(conn, legacy_later, source_path=Path("b.json"))
     assert second.imported and second.status == "replaced"
@@ -453,7 +460,7 @@ def test_delete_team_member_removes_only_that_member(tmp_path):
     other = copy.deepcopy(bundle)
     other.pop("bundle_id", None)
     other["member_id"] = "33333333-3333-3333-3333-333333333333"
-    other["bundle_id"] = team_bundles.bundle_content_id(other)
+    other["bundle_id"] = team_bundles.bundle_content_id_v2(other)
     conn = _team_conn()
     team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
     team_bundles.import_team_bundle(conn, other, source_path=Path("b.json"))
@@ -468,3 +475,168 @@ def test_delete_team_member_removes_only_that_member(tmp_path):
         == len(other["sessions"])
     )
     assert team_bundles.delete_team_member(conn, bundle["member_id"]) == 0
+
+
+def _team_level_bundle(tmp_path, projects=None, member_name="Avery", label=None):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, sanitized_export(tmp_path))
+    selection = projects
+    if selection is None:
+        selection = [{"export_name": "d--Alpha", "label": label}]
+    try:
+        return team_bundles.build_team_bundle(
+            conn,
+            salt="00ff" * 16,
+            member_id="22222222-2222-2222-2222-222222222222",
+            app_version="0.1.0",
+            generated_on=datetime.date(2026, 7, 3),
+            privacy_level=team_bundles.LEVEL_TEAM,
+            member_name=member_name,
+            projects=selection,
+        )
+    finally:
+        conn.close()
+
+
+def test_team_level_bundle_names_projects_tools_and_file_types(tmp_path):
+    data = _team_level_bundle(tmp_path).to_dict()
+
+    assert data["privacy_level"] == "team"
+    assert data["member_name"] == "Avery"
+    # Selection filtered to the Alpha project only (2 of the 3 fixture sessions).
+    assert len(data["sessions"]) == 2
+    by_first_date = {session["first_date"]: session for session in data["sessions"]}
+    session = by_first_date["2026-01-03"]
+    # Default label is the leaf of the inferred cwd (/workspace/alpha), not the export name.
+    assert session["project_name"] == "alpha"
+    assert "pid" not in session
+    tool_names = {tool["name"]: tool["calls"] for tool in session["tools"]}
+    assert tool_names["Read"] == 3
+    assert tool_names["Agent"] == 1
+    # Sidechain (subagent) events belong to the parent session, so Bash may
+    # count the main call plus the subagent's call — require at least the main one.
+    assert tool_names["Bash"] >= 1
+    assert session["file_types"] == [{"ext": "py", "count": 3}]
+    assert {sub["agent_type"] for sub in session["subagents"]} == {"general-purpose"}
+
+    blob = json.dumps(data)
+    assert "/workspace" not in blob          # real paths stay home
+    assert "importer.py" not in blob         # file names stay home
+    assert "uv run pytest" not in blob       # commands stay home
+    assert "d--Alpha" not in blob            # raw export folder name stays home
+
+
+def test_team_level_label_override_wins(tmp_path):
+    data = _team_level_bundle(tmp_path, label="payments-api").to_dict()
+    assert {session["project_name"] for session in data["sessions"]} == {"payments-api"}
+
+
+def test_build_rejects_bad_level_and_name_combinations(tmp_path):
+    # sanitized_export() always writes to a fixed "sanitized-claude-export"
+    # subdirectory, so each call in this test needs its own tmp_path (same
+    # workaround as test_team_bundle_pseudonymous_ids_are_stable_for_same_salt).
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    with pytest.raises(ValueError, match="member_name"):
+        _team_level_bundle(first, member_name=None)
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, sanitized_export(second))
+    with pytest.raises(ValueError, match="structural"):
+        team_bundles.build_team_bundle(
+            conn, salt="00ff" * 16, member_id="m", app_version="0.1.0",
+            generated_on=datetime.date(2026, 7, 3), member_name="Avery",
+        )
+    with pytest.raises(ValueError, match="unknown project"):
+        team_bundles.build_team_bundle(
+            conn, salt="00ff" * 16, member_id="m", app_version="0.1.0",
+            generated_on=datetime.date(2026, 7, 3),
+            projects=[{"export_name": "d--Nope", "label": None}],
+        )
+    with pytest.raises(ValueError, match="empty"):
+        team_bundles.build_team_bundle(
+            conn, salt="00ff" * 16, member_id="m", app_version="0.1.0",
+            generated_on=datetime.date(2026, 7, 3), projects=[],
+        )
+    conn.close()
+
+
+def test_validate_enforces_levels_in_both_directions(tmp_path):
+    # Separate subdirectories: sanitized_export() isn't safe to call twice
+    # against the same tmp_path (see test_build_rejects_bad_level_... above).
+    structural_dir = tmp_path / "structural"
+    team_dir = tmp_path / "team"
+    structural_dir.mkdir()
+    team_dir.mkdir()
+    structural = _bundle_from_sanitized(structural_dir).to_dict()
+    named = copy.deepcopy(structural)
+    named["member_name"] = "Avery"
+    with pytest.raises(ValueError, match="member_name"):
+        team_bundles.validate_team_bundle(named)
+
+    team = _team_level_bundle(team_dir).to_dict()
+    nameless = copy.deepcopy(team)
+    del nameless["member_name"]
+    with pytest.raises(ValueError, match="member_name"):
+        team_bundles.validate_team_bundle(nameless)
+
+    with_pid = copy.deepcopy(team)
+    with_pid["sessions"][0]["pid"] = "ab" * 32
+    with pytest.raises(ValueError, match="pid"):
+        team_bundles.validate_team_bundle(with_pid)
+
+    smuggled = copy.deepcopy(structural)
+    smuggled["sessions"][0]["project_name"] = "secret"
+    with pytest.raises(ValueError, match="project_name"):
+        team_bundles.validate_team_bundle(smuggled)
+
+
+def test_validate_rejects_reserved_levels(tmp_path):
+    bundle = _team_level_bundle(tmp_path).to_dict()
+    for reserved in ("sessions", "raw"):
+        mutated = copy.deepcopy(bundle)
+        mutated["privacy_level"] = reserved
+        with pytest.raises(ValueError, match="not yet supported"):
+            team_bundles.validate_team_bundle(mutated)
+
+
+def test_validate_rejects_bad_tools_and_file_types(tmp_path):
+    bundle = _team_level_bundle(tmp_path).to_dict()
+
+    bad_tool_key = copy.deepcopy(bundle)
+    bad_tool_key["sessions"][0]["tools"] = [{"name": "Read", "calls": 1, "cmd": "rm"}]
+    with pytest.raises(ValueError, match="cmd"):
+        team_bundles.validate_team_bundle(bad_tool_key)
+
+    bad_ext = copy.deepcopy(bundle)
+    bad_ext["sessions"][0]["file_types"] = [{"ext": "PY!", "count": 1}]
+    with pytest.raises(ValueError, match="extension"):
+        team_bundles.validate_team_bundle(bad_ext)
+
+
+def test_normalize_project_key():
+    assert team_bundles.normalize_project_key("Agent-Dashboard") == "agent-dashboard"
+    assert team_bundles.normalize_project_key("agent dashboard") == "agent-dashboard"
+    assert team_bundles.normalize_project_key("Payments API (v2)") == "payments-api-v2"
+    with pytest.raises(ValueError):
+        team_bundles.normalize_project_key("??!")
+
+
+def test_manifest_is_level_aware(tmp_path):
+    # Separate subdirectories: see test_build_rejects_bad_level_... above.
+    structural_dir = tmp_path / "structural"
+    team_dir = tmp_path / "team"
+    structural_dir.mkdir()
+    team_dir.mkdir()
+    structural = team_bundles.team_bundle_manifest(_bundle_from_sanitized(structural_dir))
+    team = team_bundles.team_bundle_manifest(_team_level_bundle(team_dir))
+    assert structural["privacy_level"] == "structural"
+    assert team["privacy_level"] == "team"
+    assert any("member name" in item.lower() for item in team["included_fields"])
+    assert any("tool" in item.lower() for item in team["included_fields"])
+    assert not any("member name" in item.lower() for item in structural["included_fields"])

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -264,6 +264,15 @@ def _redated(bundle_dict: dict, generated_at: str) -> dict:
     return newer
 
 
+def _reseq(bundle_dict: dict, generated_at: str, generated_seq: int) -> dict:
+    updated = copy.deepcopy(bundle_dict)
+    updated.pop("bundle_id", None)
+    updated["generated_at"] = generated_at
+    updated["generated_seq"] = generated_seq
+    updated["bundle_id"] = team_bundles.bundle_content_id(updated)
+    return updated
+
+
 def test_team_dashboard_counts_subagent_sessions_once_per_session(tmp_path):
     bundle = _bundle_from_sanitized(tmp_path).to_dict()
     bundle.pop("bundle_id", None)
@@ -327,6 +336,116 @@ def test_reimport_identical_bundle_stays_duplicate(tmp_path):
     result = team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
     assert not result.imported and result.status == "duplicate"
     assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == len(bundle["sessions"])
+
+
+def _with_fewer_sessions(bundle_dict: dict) -> dict:
+    """A distinct-content variant (drops one session) so its bundle_id differs.
+
+    generated_seq is deliberately excluded from bundle_content_id's key tuple
+    (two identical-content same-day bundles legitimately share an id, and the
+    duplicate check handles that case) -- so tests that exercise the
+    (generated_at, generated_seq) ordering must vary content, not just seq, to
+    avoid tripping the duplicate check instead of the ordering logic.
+    """
+    thinned = copy.deepcopy(bundle_dict)
+    thinned.pop("bundle_id", None)
+    thinned["sessions"] = thinned["sessions"][:-1]
+    thinned["bundle_id"] = team_bundles.bundle_content_id(thinned)
+    return thinned
+
+
+def test_same_day_out_of_order_import_marks_earlier_seq_as_stale(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    assert len(bundle["sessions"]) > 1
+    seq_two = _reseq(bundle, "2026-06-18", 2)
+    seq_one = _reseq(_with_fewer_sessions(bundle), "2026-06-18", 1)
+    conn = _team_conn()
+
+    first = team_bundles.import_team_bundle(conn, seq_two, source_path=Path("a.json"))
+    second = team_bundles.import_team_bundle(conn, seq_one, source_path=Path("b.json"))
+
+    assert first.imported and first.status == "imported"
+    assert not second.imported and second.status == "stale"
+    # The first (higher-seq) bundle's row and sessions must be untouched.
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 1
+    assert conn.execute("SELECT generated_seq FROM team_bundles").fetchone()[0] == 2
+    assert (
+        conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0]
+        == len(bundle["sessions"])
+    )
+
+
+def test_same_day_in_order_import_replaces(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    assert len(bundle["sessions"]) > 1
+    seq_one = _reseq(_with_fewer_sessions(bundle), "2026-06-18", 1)
+    seq_two = _reseq(bundle, "2026-06-18", 2)
+    conn = _team_conn()
+
+    first = team_bundles.import_team_bundle(conn, seq_one, source_path=Path("a.json"))
+    second = team_bundles.import_team_bundle(conn, seq_two, source_path=Path("b.json"))
+
+    assert first.imported and first.status == "imported"
+    assert second.imported and second.status == "replaced"
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 1
+    assert conn.execute("SELECT generated_seq FROM team_bundles").fetchone()[0] == 2
+    assert (
+        conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0]
+        == len(bundle["sessions"])
+    )
+
+
+def test_legacy_bundle_without_generated_seq_validates_and_imports_as_zero(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    assert len(bundle["sessions"]) > 1
+    legacy = _with_fewer_sessions(bundle)
+    legacy.pop("generated_seq", None)
+    legacy.pop("bundle_id", None)
+    legacy["bundle_id"] = team_bundles.bundle_content_id(legacy)
+
+    canonical = team_bundles.validate_team_bundle(legacy)
+    assert canonical["generated_seq"] == 0
+
+    conn = _team_conn()
+    result = team_bundles.import_team_bundle(conn, legacy, source_path=Path("a.json"))
+    assert result.imported and result.status == "imported"
+    assert conn.execute("SELECT generated_seq FROM team_bundles").fetchone()[0] == 0
+
+    # A same-day bundle with seq 1 must beat the legacy (implicit seq 0) bundle.
+    beats_legacy = _reseq(bundle, str(legacy["generated_at"]), 1)
+    second = team_bundles.import_team_bundle(conn, beats_legacy, source_path=Path("b.json"))
+    assert second.imported and second.status == "replaced"
+
+
+def test_legacy_bundle_on_a_later_date_beats_an_earlier_high_seq_bundle(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    earlier_high_seq = _reseq(bundle, "2026-06-18", 5)
+    conn = _team_conn()
+    first = team_bundles.import_team_bundle(conn, earlier_high_seq, source_path=Path("a.json"))
+    assert first.imported and first.status == "imported"
+
+    legacy_later = copy.deepcopy(bundle)
+    legacy_later.pop("generated_seq", None)
+    legacy_later.pop("bundle_id", None)
+    legacy_later["generated_at"] = "2026-06-19"
+    legacy_later["bundle_id"] = team_bundles.bundle_content_id(legacy_later)
+
+    second = team_bundles.import_team_bundle(conn, legacy_later, source_path=Path("b.json"))
+    assert second.imported and second.status == "replaced"
+
+
+def test_validate_team_bundle_rejects_negative_generated_seq(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+    bad = {**data, "generated_seq": -1}
+    with pytest.raises(ValueError, match="generated_seq"):
+        team_bundles.validate_team_bundle(bad)
+
+
+def test_validate_team_bundle_rejects_non_int_generated_seq(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+    bad = {**data, "generated_seq": "x"}
+    with pytest.raises(ValueError, match="generated_seq"):
+        team_bundles.validate_team_bundle(bad)
 
 
 def test_delete_team_member_removes_only_that_member(tmp_path):

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -640,3 +640,92 @@ def test_manifest_is_level_aware(tmp_path):
     assert any("member name" in item.lower() for item in team["included_fields"])
     assert any("tool" in item.lower() for item in team["included_fields"])
     assert not any("member name" in item.lower() for item in structural["included_fields"])
+
+
+def test_import_team_level_bundle_persists_names_and_key(tmp_path):
+    conn = _team_conn()
+    bundle = _team_level_bundle(tmp_path, label="Payments API").to_dict()
+    result = team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+
+    assert result.imported is True
+    bundle_row = conn.execute("SELECT member_name, profile FROM team_bundles").fetchone()
+    assert bundle_row["member_name"] == "Avery"
+    assert bundle_row["profile"] == "team"
+    session_row = conn.execute(
+        "SELECT project_id, project_name, tools_json, file_types_json FROM team_bundle_sessions LIMIT 1"
+    ).fetchone()
+    assert session_row["project_name"] == "Payments API"
+    assert session_row["project_id"] == "payments-api"  # normalized grouping key
+    assert "Read" in session_row["tools_json"]
+    assert '"py"' in session_row["file_types_json"]
+
+    listed = team_bundles.list_team_imports(conn)
+    assert listed[0]["member_name"] == "Avery"
+    assert listed[0]["privacy_level"] == "team"
+
+
+def test_import_structural_bundle_keeps_hash_key_and_null_name(tmp_path):
+    conn = _team_conn()
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+
+    bundle_row = conn.execute("SELECT member_name, profile FROM team_bundles").fetchone()
+    assert bundle_row["member_name"] is None
+    assert bundle_row["profile"] == "structural"
+    session_row = conn.execute("SELECT project_id, project_name FROM team_bundle_sessions LIMIT 1").fetchone()
+    assert len(session_row["project_id"]) == 64
+    assert session_row["project_name"] is None
+    assert team_bundles.list_team_imports(conn)[0]["privacy_level"] == "structural"
+
+
+def test_dashboard_groups_members_by_name_across_machines(tmp_path):
+    conn = _team_conn()
+    laptop = _team_level_bundle(tmp_path).to_dict()  # member_id 2222..., name Avery
+    desktop = copy.deepcopy(laptop)
+    desktop["member_id"] = "33333333-3333-3333-3333-333333333333"
+    desktop["bundle_id"] = team_bundles.bundle_content_id_v2(
+        {k: v for k, v in desktop.items() if k != "bundle_id"}
+    )
+    team_bundles.import_team_bundle(conn, laptop, source_path=Path("a.json"))
+    team_bundles.import_team_bundle(conn, desktop, source_path=Path("b.json"))
+
+    dashboard = team_bundles.team_dashboard(conn)
+    assert dashboard["meta"]["member_count"] == 1  # one human, two machines
+    member = dashboard["members"][0]
+    assert member["member_name"] == "Avery"
+    assert len(member["member_ids"]) == 2
+    assert member["bundle_count"] == 2
+    assert member["session_count"] == 4  # 2 alpha sessions per machine
+
+
+def test_dashboard_mixed_levels_fall_back_gracefully(tmp_path):
+    # Separate subdirectories: sanitized_export() isn't safe to call twice
+    # against the same tmp_path (see test_build_rejects_bad_level_... above).
+    team_dir = tmp_path / "team"
+    structural_dir = tmp_path / "structural"
+    team_dir.mkdir()
+    structural_dir.mkdir()
+    conn = _team_conn()
+    named = _team_level_bundle(team_dir).to_dict()
+    anonymous = _bundle_from_sanitized(structural_dir).to_dict()
+    anonymous["member_id"] = "44444444-4444-4444-4444-444444444444"
+    anonymous["bundle_id"] = team_bundles.bundle_content_id_v2(
+        {k: v for k, v in anonymous.items() if k != "bundle_id"}
+    )
+    team_bundles.import_team_bundle(conn, named, source_path=Path("a.json"))
+    team_bundles.import_team_bundle(conn, anonymous, source_path=Path("b.json"))
+
+    dashboard = team_bundles.team_dashboard(conn)
+    names = {member["member_name"] for member in dashboard["members"]}
+    assert "Avery" in names
+    assert "member-44444444" in names  # UUID-prefix fallback label
+
+    project_names = {project["project_name"] for project in dashboard["projects"]}
+    assert "alpha" in project_names  # named project
+    assert any(len(name) == 8 and name not in {"alpha"} for name in project_names)  # hash-prefix fallback
+
+    tools = {tool["name"]: tool for tool in dashboard["tools"]}
+    assert tools["Read"]["call_count"] == 3
+    assert tools["Read"]["session_count"] == 1
+    file_types = {entry["ext"]: entry for entry in dashboard["file_types"]}
+    assert file_types["py"]["count"] == 3

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -264,6 +264,24 @@ def _redated(bundle_dict: dict, generated_at: str) -> dict:
     return newer
 
 
+def test_team_dashboard_counts_subagent_sessions_once_per_session(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    bundle.pop("bundle_id", None)
+    bundle["sessions"][0]["subagents"] = [
+        {"agent_type": "custom", "event_count": 3},
+        {"agent_type": "custom", "event_count": 2},
+    ]
+    bundle["bundle_id"] = team_bundles.bundle_content_id(bundle)
+    conn = _team_conn()
+
+    team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+    dashboard = team_bundles.team_dashboard(conn)
+
+    custom = next(item for item in dashboard["subagents"] if item["agent_type"] == "custom")
+    assert custom["session_count"] == 1
+    assert custom["event_count"] == 5
+
+
 def test_reimport_newer_bundle_replaces_members_previous_sessions(tmp_path):
     bundle = _bundle_from_sanitized(tmp_path).to_dict()
     newer = _redated(bundle, "2026-06-19")

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -247,3 +247,65 @@ def test_validate_team_bundle_canonicalizes_raw_symbol_and_model(tmp_path):
     assert "SECRET_SERVER" not in blob
     assert canonical["sessions"][0]["models"] == ["other"]
     assert canonical["sessions"][0]["sequence"][0]["sym"] == "CALL:mcp"
+
+
+def _team_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    return conn
+
+
+def _redated(bundle_dict: dict, generated_at: str) -> dict:
+    newer = copy.deepcopy(bundle_dict)
+    newer.pop("bundle_id", None)
+    newer["generated_at"] = generated_at
+    newer["bundle_id"] = team_bundles.bundle_content_id(newer)
+    return newer
+
+
+def test_reimport_newer_bundle_replaces_members_previous_sessions(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    newer = _redated(bundle, "2026-06-19")
+    conn = _team_conn()
+
+    first = team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+    second = team_bundles.import_team_bundle(conn, newer, source_path=Path("b.json"))
+
+    assert first.imported and first.status == "imported"
+    assert second.imported and second.status == "replaced"
+    # Exactly one bundle row for the member; sessions counted once.
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 1
+    assert (
+        conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0]
+        == len(bundle["sessions"])
+    )
+    dash = team_bundles.team_dashboard(conn)
+    assert dash["meta"]["session_count"] == len(bundle["sessions"])
+    assert dash["meta"]["bundle_count"] == 1
+    assert len(dash["members"]) == 1
+
+
+def test_import_stale_bundle_is_skipped(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()   # generated 2026-06-18
+    newer = _redated(bundle, "2026-06-19")
+    conn = _team_conn()
+
+    team_bundles.import_team_bundle(conn, newer, source_path=Path("b.json"))
+    result = team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+
+    assert not result.imported and result.status == "stale"
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 1
+    assert (
+        conn.execute("SELECT generated_at FROM team_bundles").fetchone()[0]
+        == "2026-06-19"
+    )
+
+
+def test_reimport_identical_bundle_stays_duplicate(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    conn = _team_conn()
+    team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+    result = team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+    assert not result.imported and result.status == "duplicate"
+    assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == len(bundle["sessions"])

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -618,6 +618,13 @@ def test_validate_rejects_bad_tools_and_file_types(tmp_path):
     with pytest.raises(ValueError, match="extension"):
         team_bundles.validate_team_bundle(bad_ext)
 
+    # `$` (unlike `\Z`) matches just before a trailing newline, so a naive
+    # regex would let "py\n" slip through as a valid extension.
+    bad_ext_trailing_newline = copy.deepcopy(bundle)
+    bad_ext_trailing_newline["sessions"][0]["file_types"] = [{"ext": "py\n", "count": 1}]
+    with pytest.raises(ValueError, match="extension"):
+        team_bundles.validate_team_bundle(bad_ext_trailing_newline)
+
 
 def test_normalize_project_key():
     assert team_bundles.normalize_project_key("Agent-Dashboard") == "agent-dashboard"

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -309,3 +309,25 @@ def test_reimport_identical_bundle_stays_duplicate(tmp_path):
     result = team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
     assert not result.imported and result.status == "duplicate"
     assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == len(bundle["sessions"])
+
+
+def test_delete_team_member_removes_only_that_member(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path).to_dict()
+    other = copy.deepcopy(bundle)
+    other.pop("bundle_id", None)
+    other["member_id"] = "33333333-3333-3333-3333-333333333333"
+    other["bundle_id"] = team_bundles.bundle_content_id(other)
+    conn = _team_conn()
+    team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+    team_bundles.import_team_bundle(conn, other, source_path=Path("b.json"))
+
+    removed = team_bundles.delete_team_member(conn, bundle["member_id"])
+
+    assert removed == 1
+    members = [r[0] for r in conn.execute("SELECT DISTINCT member_id FROM team_bundles")]
+    assert members == [other["member_id"]]
+    assert (
+        conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0]
+        == len(other["sessions"])
+    )
+    assert team_bundles.delete_team_member(conn, bundle["member_id"]) == 0

--- a/backend/tests/test_team_bundles.py
+++ b/backend/tests/test_team_bundles.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import copy
+import datetime
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ccfr.analysis import team_bundles
+from ccfr.analysis.contribution import bucket_model
+from ccfr.ingest import import_export
+from ccfr.storage import init_db
+from tests.fixtures import ALPHA_SESSION_ID, BETA_SESSION_ID, sanitized_export
+from tests.test_contribution import SENTINELS, _allowed_syms, _export_with_sentinels
+
+
+def _bundle_from_sanitized(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, sanitized_export(tmp_path))
+    try:
+        return team_bundles.build_team_bundle(
+            conn,
+            salt="00ff" * 16,
+            member_id="22222222-2222-2222-2222-222222222222",
+            app_version="0.1.0",
+            generated_on=datetime.date(2026, 6, 18),
+        )
+    finally:
+        conn.close()
+
+
+def test_team_bundle_has_profile_and_pseudonymous_ids(tmp_path):
+    bundle = _bundle_from_sanitized(tmp_path)
+    data = bundle.to_dict()
+
+    assert data["schema_version"] == 1
+    assert data["profile"] == "team_strict"
+    assert data["member_id"] == "22222222-2222-2222-2222-222222222222"
+    assert data["generated_at"] == "2026-06-18"
+    assert len(data["bundle_id"]) == 64
+
+    blob = json.dumps(data)
+    assert ALPHA_SESSION_ID not in blob
+    assert BETA_SESSION_ID not in blob
+    assert "d--Alpha" not in blob
+    for session in data["sessions"]:
+        assert len(session["pid"]) == 64
+        assert len(session["sid"]) == 64
+        int(session["pid"], 16)
+        int(session["sid"], 16)
+        assert session["provider"] == "claude"
+        assert "T" not in session["first_date"]
+        assert "T" not in session["last_date"]
+
+
+def test_team_bundle_pseudonymous_ids_are_stable_for_same_salt(tmp_path):
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left.mkdir()
+    right.mkdir()
+    first = _bundle_from_sanitized(left).to_dict()
+    second = _bundle_from_sanitized(right).to_dict()
+
+    first_ids = [(session["pid"], session["sid"]) for session in first["sessions"]]
+    second_ids = [(session["pid"], session["sid"]) for session in second["sessions"]]
+    assert first_ids == second_ids
+    assert first["bundle_id"] == second["bundle_id"]
+
+
+def test_team_bundle_never_leaks_sentinels(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, _export_with_sentinels(tmp_path))
+    try:
+        bundle = team_bundles.build_team_bundle(
+            conn,
+            salt="abcd" * 16,
+            member_id="member",
+            app_version="0.1.0",
+            generated_on=datetime.date(2026, 6, 18),
+        )
+    finally:
+        conn.close()
+
+    blob = json.dumps(bundle.to_dict())
+    for sentinel in SENTINELS:
+        assert sentinel not in blob, f"leaked sentinel: {sentinel}"
+
+
+def test_team_bundle_sequence_is_closed_vocabulary(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, _export_with_sentinels(tmp_path))
+    try:
+        bundle = team_bundles.build_team_bundle(
+            conn,
+            salt="abcd" * 16,
+            member_id="member",
+            app_version="0.1.0",
+            generated_on=datetime.date(2026, 6, 18),
+        )
+    finally:
+        conn.close()
+
+    allowed = _allowed_syms()
+    steps = [step for session in bundle.to_dict()["sessions"] for step in session["sequence"]]
+    assert steps
+    for step in steps:
+        assert step["fam"] in {"tool_call", "tool_result"}
+        assert step["sym"] in allowed
+
+
+def test_team_dashboard_date_to_includes_sessions_without_last_date():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    cur = conn.execute(
+        """
+        INSERT INTO team_bundles(
+            bundle_id, profile, schema_version, member_id, generated_at,
+            app_version, imported_at, source_path, session_count
+        )
+        VALUES ('bundle', 'team_strict', 1, 'member', '2026-01-01',
+                '0.1.0', '2026-01-01T00:00:00Z', 'bundle.json', 2)
+        """
+    )
+    bundle_pk = cur.lastrowid
+    conn.executemany(
+        """
+        INSERT INTO team_bundle_sessions(
+            team_bundle_id, member_id, project_id, session_id, provider,
+            first_date, last_date
+        )
+        VALUES (?, 'member', ?, ?, 'claude', ?, ?)
+        """,
+        [
+            (bundle_pk, "p", "early", "2026-01-01", "2026-06-15"),
+            (bundle_pk, "p", "late", "2027-01-01", None),
+        ],
+    )
+    conn.commit()
+
+    result = team_bundles.team_dashboard(conn)
+
+    # The later session has no last_date; date_to must still reflect its first_date.
+    assert result["meta"]["date_to"] == "2027-01-01"
+
+
+def test_import_team_bundle_round_trips_tokens_by_model(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, sanitized_export(tmp_path))
+    bundle = team_bundles.build_team_bundle(
+        conn,
+        salt="00ff" * 16,
+        member_id="member",
+        app_version="0.1.0",
+        generated_on=datetime.date(2026, 6, 18),
+    )
+    data = bundle.to_dict()
+
+    team_bundles.import_team_bundle(conn, data, source_path=Path("bundle.json"))
+
+    stored = {
+        row["session_id"]: json.loads(row["tokens_by_model_json"])
+        for row in conn.execute("SELECT session_id, tokens_by_model_json FROM team_bundle_sessions").fetchall()
+    }
+    assert any(stored.values())
+    for session in data["sessions"]:
+        assert stored[session["sid"]] == session["tokens_by_model"]
+    conn.close()
+
+
+def test_team_bundle_tokens_by_model_sum_to_session_tokens(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+
+    assert any(session["tokens_by_model"] for session in data["sessions"])
+    for session in data["sessions"]:
+        tbm = session["tokens_by_model"]
+        for key in team_bundles.TOKEN_KEYS:
+            assert sum(vals[key] for vals in tbm.values()) == session["tokens"][key]
+        # Keys are bucketed model families (idempotent under bucket_model).
+        for family in tbm:
+            assert bucket_model(family) == family
+
+
+def test_validate_team_bundle_accepts_legacy_without_tokens_by_model(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+    data.pop("bundle_id")
+    for session in data["sessions"]:
+        session.pop("tokens_by_model", None)
+
+    canonical = team_bundles.validate_team_bundle(data)
+
+    for session in canonical["sessions"]:
+        assert session["tokens_by_model"] == {}
+
+
+def test_validate_team_bundle_buckets_raw_tokens_by_model(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+    mutated = copy.deepcopy(data)
+    mutated.pop("bundle_id")
+    mutated["sessions"][0]["tokens_by_model"] = {
+        "SECRET_MODEL_zzz": {"input": 5, "output": 3, "base": 5, "cache_5m": 0, "cache_1h": 0, "cache_read": 0}
+    }
+
+    canonical = team_bundles.validate_team_bundle(mutated)
+
+    assert "SECRET_MODEL_zzz" not in json.dumps(canonical)
+    assert canonical["sessions"][0]["tokens_by_model"] == {
+        "other": {"input": 5, "output": 3, "base": 5, "cache_5m": 0, "cache_1h": 0, "cache_read": 0}
+    }
+
+
+def test_validate_team_bundle_rejects_invalid_profile_and_schema(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+
+    bad_profile = {**data, "profile": "loose"}
+    with pytest.raises(ValueError, match="profile"):
+        team_bundles.validate_team_bundle(bad_profile)
+
+    bad_schema = {**data, "schema_version": 2}
+    with pytest.raises(ValueError, match="schema_version"):
+        team_bundles.validate_team_bundle(bad_schema)
+
+
+def test_validate_team_bundle_canonicalizes_raw_symbol_and_model(tmp_path):
+    data = _bundle_from_sanitized(tmp_path).to_dict()
+    mutated = copy.deepcopy(data)
+    mutated.pop("bundle_id")
+    mutated["sessions"][0]["models"] = ["SECRET_MODEL_zzz"]
+    mutated["sessions"][0]["sequence"] = [
+        {"sym": "CALL:mcp__SECRET_SERVER__deploy", "fam": "tool_call", "dt_s": 1, "out_tok": 2}
+    ]
+
+    canonical = team_bundles.validate_team_bundle(mutated)
+
+    blob = json.dumps(canonical)
+    assert "SECRET_MODEL_zzz" not in blob
+    assert "SECRET_SERVER" not in blob
+    assert canonical["sessions"][0]["models"] == ["other"]
+    assert canonical["sessions"][0]["sequence"][0]["sym"] == "CALL:mcp"

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ccfr.api import routes
+from ccfr.api.deps import get_db
+from ccfr.analysis.team_bundles import bundle_content_id
+from ccfr.ingest import import_export
+from ccfr.main import create_app
+from ccfr.storage import init_db
+from tests.fixtures import sanitized_export
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import ccfr.settings as settings_mod
+
+    data_dir = tmp_path / "settings"
+    bundle_root = tmp_path / "team-bundles"
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: data_dir)
+    monkeypatch.setattr(routes, "team_bundle_root", lambda: bundle_root)
+    monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_export(conn, sanitized_export(tmp_path))
+
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: conn
+    with TestClient(app) as c:
+        yield c, conn, bundle_root
+    conn.close()
+
+
+def test_config_exposes_team_bundle_root(client):
+    c, _conn, bundle_root = client
+
+    resp = c.get("/api/config")
+
+    assert resp.status_code == 200
+    assert resp.json()["team_bundle_root"] == str(bundle_root)
+
+
+def test_team_export_writes_under_bundle_root_without_network(client, monkeypatch):
+    import socket
+    import urllib.request
+
+    c, _conn, bundle_root = client
+
+    def _no_net(*args, **kwargs):
+        raise AssertionError("team bundle export must not make a network connection")
+
+    monkeypatch.setattr(socket, "create_connection", _no_net)
+    monkeypatch.setattr(urllib.request, "urlopen", _no_net)
+
+    resp = c.post("/api/team/export")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    written = list((bundle_root / "exports").glob("team-bundle-*.json"))
+    assert len(written) == 1
+    assert body["path"] == str(written[0])
+    parsed = json.loads(written[0].read_text(encoding="utf-8"))
+    assert parsed["profile"] == "team_strict"
+    assert parsed["bundle_id"] == body["bundle_id"]
+    assert body["session_count"] == 3
+
+
+def test_team_import_is_no_network_and_idempotent(client, monkeypatch):
+    import socket
+    import urllib.request
+
+    c, conn, bundle_root = client
+    export = c.post("/api/team/export").json()
+
+    def _no_net(*args, **kwargs):
+        raise AssertionError("team bundle import must not make a network connection")
+
+    monkeypatch.setattr(socket, "create_connection", _no_net)
+    monkeypatch.setattr(urllib.request, "urlopen", _no_net)
+
+    first = c.post("/api/team/import", json={"path": export["path"]})
+    second = c.post("/api/team/import", json={"path": export["path"]})
+
+    assert first.status_code == 200
+    assert first.json()["imported"] is True
+    assert second.status_code == 200
+    assert second.json()["imported"] is False
+    assert first.json()["bundle_id"] == second.json()["bundle_id"]
+    assert len(c.get("/api/team/imports").json()) == 1
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == 3
+    assert Path(export["path"]).is_relative_to(bundle_root)
+
+
+def test_team_import_accepts_browser_selected_bundle_payload(client, monkeypatch):
+    import socket
+    import urllib.request
+
+    c, conn, bundle_root = client
+    bundle = c.get("/api/team/export-preview").json()["bundle"]
+
+    def _no_net(*args, **kwargs):
+        raise AssertionError("team bundle upload import must not make a network connection")
+
+    monkeypatch.setattr(socket, "create_connection", _no_net)
+    monkeypatch.setattr(urllib.request, "urlopen", _no_net)
+
+    first = c.post(
+        "/api/team/import-bundle",
+        json={"filename": "..\\member-beta.json", "bundle": bundle},
+    )
+    second = c.post(
+        "/api/team/import-bundle",
+        json={"filename": "member-beta.json", "bundle": bundle},
+    )
+
+    assert first.status_code == 200
+    assert first.json()["imported"] is True
+    assert second.status_code == 200
+    assert second.json()["imported"] is False
+    assert first.json()["bundle_id"] == second.json()["bundle_id"]
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 1
+    source_path = c.get("/api/team/imports").json()[0]["source_path"]
+    assert source_path == str(bundle_root / "browser-imports" / "member-beta.json")
+
+
+def test_team_import_accepts_legacy_precanonical_export_hash(client):
+    c, _conn, _bundle_root = client
+    bundle = c.get("/api/team/export-preview").json()["bundle"]
+    bundle["sessions"][0]["sequence"] = [
+        {"sym": "CALL:mcp", "fam": "tool_call", "dt_s": 0, "out_tok": 1}
+    ]
+    raw_base = {key: bundle[key] for key in (
+        "schema_version", "profile", "member_id", "generated_at", "app_version", "sessions",
+    )}
+    bundle["bundle_id"] = bundle_content_id(raw_base)
+
+    resp = c.post("/api/team/import-bundle", json={"filename": "legacy-team-bundle.json", "bundle": bundle})
+
+    assert resp.status_code == 200
+    assert resp.json()["imported"] is True
+    assert resp.json()["bundle_id"] != bundle["bundle_id"]
+    dashboard = c.get("/api/team/dashboard").json()
+    assert {"sym": "CALL:other", "count": 1} in dashboard["sequence"]
+
+
+def test_team_import_rejects_outside_root_and_invalid_profile_schema(client, tmp_path):
+    c, _conn, bundle_root = client
+    bundle = c.get("/api/team/export-preview").json()["bundle"]
+
+    outside = tmp_path / "outside-team-bundle.json"
+    outside.write_text(json.dumps(bundle), encoding="utf-8")
+    assert c.post("/api/team/import", json={"path": str(outside)}).status_code == 400
+
+    bad_profile = {**bundle, "profile": "loose"}
+    bad_profile_path = bundle_root / "bad-profile.json"
+    bad_profile_path.parent.mkdir(parents=True, exist_ok=True)
+    bad_profile_path.write_text(json.dumps(bad_profile), encoding="utf-8")
+    resp = c.post("/api/team/import", json={"path": str(bad_profile_path)})
+    assert resp.status_code == 400
+    assert "profile" in resp.json()["detail"]
+
+    bad_schema = {**bundle, "schema_version": 2}
+    bad_schema_path = bundle_root / "bad-schema.json"
+    bad_schema_path.write_text(json.dumps(bad_schema), encoding="utf-8")
+    resp = c.post("/api/team/import", json={"path": str(bad_schema_path)})
+    assert resp.status_code == 400
+    assert "schema_version" in resp.json()["detail"]
+
+    resp = c.post("/api/team/import-bundle", json={"filename": "bad-profile.json", "bundle": bad_profile})
+    assert resp.status_code == 400
+    assert "profile" in resp.json()["detail"]
+
+
+def test_team_dashboard_aggregates_imported_bundles(client):
+    c, _conn, _bundle_root = client
+    export = c.post("/api/team/export").json()
+    assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
+
+    resp = c.get("/api/team/dashboard")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"]["bundle_count"] == 1
+    assert body["meta"]["member_count"] == 1
+    assert body["meta"]["session_count"] == 3
+    assert body["tokens"]["input"] > 0
+    assert body["tokens"]["output"] > 0
+    assert {"provider": "claude", "session_count": 3} in body["providers"]
+    assert any(item["reason"] == "tool_use" for item in body["stop_reasons"])
+    assert any(item["agent_type"] == "general-purpose" for item in body["subagents"])
+    assert body["over_time"]
+
+
+def test_team_dashboard_reports_distinct_project_count(client):
+    c, conn, _bundle_root = client
+    export = c.post("/api/team/export").json()
+    assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
+
+    expected = conn.execute(
+        "SELECT COUNT(DISTINCT project_id) FROM team_bundle_sessions"
+    ).fetchone()[0]
+    body = c.get("/api/team/dashboard").json()
+
+    assert expected > 0
+    assert body["meta"].get("project_count") == expected
+
+
+def test_team_cost_endpoint_returns_cost_shape(client):
+    c, _conn, _bundle_root = client
+    export = c.post("/api/team/export").json()
+    assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
+
+    resp = c.get("/api/team/analytics/cost")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sessions"] == []
+    assert "meta" in body and "by_model" in body and "categories" in body
+
+
+def test_team_reset_clears_only_team_tables(client):
+    c, conn, _bundle_root = client
+    export = c.post("/api/team/export").json()
+    assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
+    assert c.get("/api/projects").json()
+
+    resp = c.post("/api/team/reset")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert c.get("/api/team/dashboard").json()["meta"]["session_count"] == 0
+    assert c.get("/api/projects").json()
+    assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == 0

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -348,6 +348,21 @@ def test_team_level_export_writes_names_and_persists_prefs(client):
     assert prefs["deselected"] == ["d--Beta"]
 
 
+def test_structural_export_preserves_prior_saved_member_name(client):
+    c, _conn, _bundle_root = client
+    team_resp = c.post("/api/team/export", json=_export_body(level="team", member_name="Avery"))
+    assert team_resp.status_code == 200
+    assert c.get("/api/team/projects").json()["prefs"]["member_name"] == "Avery"
+
+    # A later structural export carries no name -- it must not blank out the
+    # name saved by the earlier team-level export.
+    structural_resp = c.post("/api/team/export", json=_export_body())
+    assert structural_resp.status_code == 200
+
+    prefs = c.get("/api/team/projects").json()["prefs"]
+    assert prefs["member_name"] == "Avery"
+
+
 def test_team_export_level_violations_return_400(client):
     c, _conn, _root = client
     # Team export without a name.

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -38,6 +38,17 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     conn.close()
 
 
+ALL_PROJECTS = [{"export_name": "d--Alpha", "label": None}, {"export_name": "d--Beta", "label": None}]
+
+
+def _export_body(level="structural", member_name=None, projects=None):
+    return {
+        "privacy_level": level,
+        "member_name": member_name,
+        "projects": ALL_PROJECTS if projects is None else projects,
+    }
+
+
 def test_config_exposes_team_bundle_root(client):
     c, _conn, bundle_root = client
 
@@ -59,7 +70,7 @@ def test_team_export_writes_under_bundle_root_without_network(client, monkeypatc
     monkeypatch.setattr(socket, "create_connection", _no_net)
     monkeypatch.setattr(urllib.request, "urlopen", _no_net)
 
-    resp = c.post("/api/team/export")
+    resp = c.post("/api/team/export", json=_export_body())
 
     assert resp.status_code == 200
     body = resp.json()
@@ -76,16 +87,16 @@ def test_team_export_writes_under_bundle_root_without_network(client, monkeypatc
 def test_team_export_increments_seq_while_preview_does_not_consume_it(client):
     c, _conn, _bundle_root = client
 
-    first = c.post("/api/team/export").json()
+    first = c.post("/api/team/export", json=_export_body()).json()
     first_bundle = json.loads(Path(first["path"]).read_text(encoding="utf-8"))
     assert first_bundle["generated_seq"] == 1
 
-    preview_bundle = c.get("/api/team/export-preview").json()["bundle"]
+    preview_bundle = c.post("/api/team/export-preview", json=_export_body()).json()["bundle"]
     assert preview_bundle["generated_seq"] == 2
 
     # The preview above must not have burned a sequence number: the next real
     # export still gets 2, not 3.
-    second = c.post("/api/team/export").json()
+    second = c.post("/api/team/export", json=_export_body()).json()
     second_bundle = json.loads(Path(second["path"]).read_text(encoding="utf-8"))
     assert second_bundle["generated_seq"] == 2
 
@@ -95,7 +106,7 @@ def test_team_import_is_no_network_and_idempotent(client, monkeypatch):
     import urllib.request
 
     c, conn, bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
 
     def _no_net(*args, **kwargs):
         raise AssertionError("team bundle import must not make a network connection")
@@ -122,7 +133,7 @@ def test_team_import_accepts_browser_selected_bundle_payload(client, monkeypatch
     import urllib.request
 
     c, conn, bundle_root = client
-    bundle = c.get("/api/team/export-preview").json()["bundle"]
+    bundle = c.post("/api/team/export-preview", json=_export_body()).json()["bundle"]
 
     def _no_net(*args, **kwargs):
         raise AssertionError("team bundle upload import must not make a network connection")
@@ -151,7 +162,7 @@ def test_team_import_accepts_browser_selected_bundle_payload(client, monkeypatch
 
 def test_team_import_accepts_legacy_precanonical_export_hash(client):
     c, _conn, _bundle_root = client
-    bundle = c.get("/api/team/export-preview").json()["bundle"]
+    bundle = c.post("/api/team/export-preview", json=_export_body()).json()["bundle"]
     bundle["sessions"][0]["sequence"] = [
         {"sym": "CALL:mcp", "fam": "tool_call", "dt_s": 0, "out_tok": 1}
     ]
@@ -177,7 +188,7 @@ def test_team_import_accepts_legacy_precanonical_export_hash(client):
 
 def test_team_import_rejects_outside_root_and_invalid_profile_schema(client, tmp_path):
     c, _conn, bundle_root = client
-    bundle = c.get("/api/team/export-preview").json()["bundle"]
+    bundle = c.post("/api/team/export-preview", json=_export_body()).json()["bundle"]
 
     outside = tmp_path / "outside-team-bundle.json"
     outside.write_text(json.dumps(bundle), encoding="utf-8")
@@ -205,7 +216,7 @@ def test_team_import_rejects_outside_root_and_invalid_profile_schema(client, tmp
 
 def test_team_dashboard_aggregates_imported_bundles(client):
     c, _conn, _bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
     assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
 
     resp = c.get("/api/team/dashboard")
@@ -225,7 +236,7 @@ def test_team_dashboard_aggregates_imported_bundles(client):
 
 def test_team_dashboard_reports_distinct_project_count(client):
     c, conn, _bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
     assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
 
     expected = conn.execute(
@@ -239,7 +250,7 @@ def test_team_dashboard_reports_distinct_project_count(client):
 
 def test_team_cost_endpoint_returns_cost_shape(client):
     c, _conn, _bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
     assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
 
     resp = c.get("/api/team/analytics/cost")
@@ -252,7 +263,7 @@ def test_team_cost_endpoint_returns_cost_shape(client):
 
 def test_team_cost_endpoint_filters_by_project_id(client):
     c, _conn, _bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
     assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
 
     baseline = c.get("/api/team/analytics/cost").json()
@@ -273,7 +284,7 @@ def test_team_cost_endpoint_filters_by_project_id(client):
 @pytest.fixture()
 def imported_bundle(client):
     c, _conn, _bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
     assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
     return c.get("/api/team/imports").json()[0]
 
@@ -291,7 +302,7 @@ def test_delete_member_endpoint(client, imported_bundle):
 
 def test_team_reset_clears_only_team_tables(client):
     c, conn, _bundle_root = client
-    export = c.post("/api/team/export").json()
+    export = c.post("/api/team/export", json=_export_body()).json()
     assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
     assert c.get("/api/projects").json()
 
@@ -303,3 +314,78 @@ def test_team_reset_clears_only_team_tables(client):
     assert c.get("/api/projects").json()
     assert conn.execute("SELECT COUNT(*) FROM team_bundles").fetchone()[0] == 0
     assert conn.execute("SELECT COUNT(*) FROM team_bundle_sessions").fetchone()[0] == 0
+
+
+def test_team_projects_lists_labels_counts_and_prefs(client):
+    c, _conn, _root = client
+    resp = c.get("/api/team/projects")
+    assert resp.status_code == 200
+    body = resp.json()
+    by_name = {p["export_name"]: p for p in body["projects"]}
+    assert by_name["d--Alpha"]["default_label"] == "alpha"
+    assert by_name["d--Alpha"]["session_count"] == 2
+    assert by_name["d--Beta"]["default_label"] == "beta"
+    assert by_name["d--Beta"]["tokens"] == 27  # 18 in + 9 out from the beta fixture
+    assert body["prefs"] == {}
+
+
+def test_team_level_export_writes_names_and_persists_prefs(client):
+    c, _conn, bundle_root = client
+    body = _export_body(level="team", member_name="Avery",
+                        projects=[{"export_name": "d--Alpha", "label": "Payments API"}])
+    resp = c.post("/api/team/export", json=body)
+    assert resp.status_code == 200
+    written = json.loads(Path(resp.json()["path"]).read_text(encoding="utf-8"))
+    assert written["privacy_level"] == "team"
+    assert written["member_name"] == "Avery"
+    assert {s["project_name"] for s in written["sessions"]} == {"Payments API"}
+    assert resp.json()["session_count"] == 2  # beta excluded by selection
+
+    prefs = c.get("/api/team/projects").json()["prefs"]
+    assert prefs["member_name"] == "Avery"
+    assert prefs["privacy_level"] == "team"
+    assert prefs["project_labels"] == {"d--Alpha": "Payments API"}
+    assert prefs["deselected"] == ["d--Beta"]
+
+
+def test_team_export_level_violations_return_400(client):
+    c, _conn, _root = client
+    # Team export without a name.
+    resp = c.post("/api/team/export", json=_export_body(level="team"))
+    assert resp.status_code == 400
+    assert "member_name" in resp.json()["detail"]
+    # Structural export with a name.
+    resp = c.post("/api/team/export", json=_export_body(member_name="Avery"))
+    assert resp.status_code == 400
+    # Empty selection.
+    resp = c.post("/api/team/export", json=_export_body(projects=[]))
+    assert resp.status_code == 400
+    # Unknown project.
+    resp = c.post("/api/team/export", json=_export_body(projects=[{"export_name": "d--Nope", "label": None}]))
+    assert resp.status_code == 400
+    # Nothing was written or burned.
+    preview = c.post("/api/team/export-preview", json=_export_body()).json()
+    assert preview["bundle"]["generated_seq"] == 1
+
+
+def test_team_preview_at_team_level_uses_placeholder_name(client):
+    c, _conn, _root = client
+    resp = c.post("/api/team/export-preview", json=_export_body(level="team"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bundle"]["member_name"] == "Unnamed member"
+    assert body["manifest"]["privacy_level"] == "team"
+
+
+def test_team_imports_list_carries_name_and_level(client):
+    c, _conn, _root = client
+    exported = c.post(
+        "/api/team/export",
+        json=_export_body(level="team", member_name="Avery",
+                          projects=[{"export_name": "d--Alpha", "label": None}]),
+    ).json()
+    imported = c.post("/api/team/import", json={"path": exported["path"]})
+    assert imported.status_code == 200
+    entries = c.get("/api/team/imports").json()
+    assert entries[0]["member_name"] == "Avery"
+    assert entries[0]["privacy_level"] == "team"

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -226,6 +226,26 @@ def test_team_cost_endpoint_returns_cost_shape(client):
     assert "meta" in body and "by_model" in body and "categories" in body
 
 
+def test_team_cost_endpoint_filters_by_project_id(client):
+    c, _conn, _bundle_root = client
+    export = c.post("/api/team/export").json()
+    assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
+
+    baseline = c.get("/api/team/analytics/cost").json()
+    projects = baseline["meta"]["available_projects"]
+    assert len(projects) == 2
+    target_id = projects[0]["id"]
+
+    resp = c.get("/api/team/analytics/cost", params={"project_id": target_id})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Filtering by one project's id must not drop it from the selector, and
+    # must not leak the other project's spend into the treemap.
+    assert len(body["meta"]["available_projects"]) == 2
+    assert all(entry["project_id"] == target_id for entry in body["treemap"])
+
+
 @pytest.fixture()
 def imported_bundle(client):
     c, _conn, _bundle_root = client

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -226,6 +226,25 @@ def test_team_cost_endpoint_returns_cost_shape(client):
     assert "meta" in body and "by_model" in body and "categories" in body
 
 
+@pytest.fixture()
+def imported_bundle(client):
+    c, _conn, _bundle_root = client
+    export = c.post("/api/team/export").json()
+    assert c.post("/api/team/import", json={"path": export["path"]}).status_code == 200
+    return c.get("/api/team/imports").json()[0]
+
+
+def test_delete_member_endpoint(client, imported_bundle):
+    c, _conn, _bundle_root = client
+    member_id = imported_bundle["member_id"]
+
+    response = c.delete(f"/api/team/members/{member_id}")
+
+    assert response.status_code == 200
+    assert response.json() == {"member_id": member_id, "bundles_removed": 1}
+    assert c.delete(f"/api/team/members/{member_id}").status_code == 404
+
+
 def test_team_reset_clears_only_team_tables(client):
     c, conn, _bundle_root = client
     export = c.post("/api/team/export").json()

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -67,7 +67,8 @@ def test_team_export_writes_under_bundle_root_without_network(client, monkeypatc
     assert len(written) == 1
     assert body["path"] == str(written[0])
     parsed = json.loads(written[0].read_text(encoding="utf-8"))
-    assert parsed["profile"] == "team_strict"
+    assert parsed["privacy_level"] == "structural"
+    assert "profile" not in parsed
     assert parsed["bundle_id"] == body["bundle_id"]
     assert body["session_count"] == 3
 
@@ -154,6 +155,12 @@ def test_team_import_accepts_legacy_precanonical_export_hash(client):
     bundle["sessions"][0]["sequence"] = [
         {"sym": "CALL:mcp", "fam": "tool_call", "dt_s": 0, "out_tok": 1}
     ]
+    # Downgrade the fresh v2 structural preview to a v1 payload: the dual-id
+    # (precanonical-hash) leniency this test exercises is legacy-only
+    # (team_bundles._validate_v1) -- v2 bundles have no such leniency.
+    bundle["schema_version"] = 1
+    bundle["profile"] = "team_strict"
+    del bundle["privacy_level"]
     raw_base = {key: bundle[key] for key in (
         "schema_version", "profile", "member_id", "generated_at", "app_version", "sessions",
     )}
@@ -184,7 +191,7 @@ def test_team_import_rejects_outside_root_and_invalid_profile_schema(client, tmp
     assert resp.status_code == 400
     assert "profile" in resp.json()["detail"]
 
-    bad_schema = {**bundle, "schema_version": 2}
+    bad_schema = {**bundle, "schema_version": 99}
     bad_schema_path = bundle_root / "bad-schema.json"
     bad_schema_path.write_text(json.dumps(bad_schema), encoding="utf-8")
     resp = c.post("/api/team/import", json={"path": str(bad_schema_path)})

--- a/backend/tests/test_team_bundles_api.py
+++ b/backend/tests/test_team_bundles_api.py
@@ -72,6 +72,23 @@ def test_team_export_writes_under_bundle_root_without_network(client, monkeypatc
     assert body["session_count"] == 3
 
 
+def test_team_export_increments_seq_while_preview_does_not_consume_it(client):
+    c, _conn, _bundle_root = client
+
+    first = c.post("/api/team/export").json()
+    first_bundle = json.loads(Path(first["path"]).read_text(encoding="utf-8"))
+    assert first_bundle["generated_seq"] == 1
+
+    preview_bundle = c.get("/api/team/export-preview").json()["bundle"]
+    assert preview_bundle["generated_seq"] == 2
+
+    # The preview above must not have burned a sequence number: the next real
+    # export still gets 2, not 3.
+    second = c.post("/api/team/export").json()
+    second_bundle = json.loads(Path(second["path"]).read_text(encoding="utf-8"))
+    assert second_bundle["generated_seq"] == 2
+
+
 def test_team_import_is_no_network_and_idempotent(client, monkeypatch):
     import socket
     import urllib.request

--- a/backend/tests/test_team_cost.py
+++ b/backend/tests/test_team_cost.py
@@ -87,3 +87,38 @@ def test_team_cost_unavailable_without_price_table(tmp_path: Path, monkeypatch: 
     assert payload["meta"]["total_usd"] == 0
     assert set(payload["meta"]["unpriced_models"]) == {"claude-opus-4-8", "claude-sonnet-4-6"}
     conn.close()
+
+
+def test_team_cost_filters_by_project_id(seeded: sqlite3.Connection) -> None:
+    baseline = team_cost.team_cost_analytics(seeded)
+    pid_by_name = {p["name"]: p["id"] for p in baseline["meta"]["available_projects"]}
+    assert set(pid_by_name) == {"projectA", "projectB"}
+
+    filtered = team_cost.team_cost_analytics(seeded, project_id=pid_by_name["projectA"])
+
+    # Only projectA's opus spend ($30) should remain; projectB's sonnet spend is excluded.
+    assert round(filtered["meta"]["total_usd"], 2) == 30.0
+    assert len(filtered["treemap"]) == 1
+    assert filtered["treemap"][0]["project_id"] == pid_by_name["projectA"]
+    # The selector still offers both projects even while one is filtered.
+    assert {p["name"] for p in filtered["meta"]["available_projects"]} == {"projectA", "projectB"}
+
+
+def test_team_cost_unknown_project_id_returns_zero(seeded: sqlite3.Connection) -> None:
+    filtered = team_cost.team_cost_analytics(seeded, project_id=9999)
+
+    assert filtered["meta"]["total_usd"] == 0
+    assert filtered["treemap"] == []
+    # An unknown id must not silently fall back to unfiltered totals.
+    assert filtered["meta"]["total_usd"] != team_cost.team_cost_analytics(seeded)["meta"]["total_usd"]
+
+
+def test_team_cost_project_ids_stable_across_date_filter(seeded: sqlite3.Connection) -> None:
+    baseline = team_cost.team_cost_analytics(seeded)
+    pid_by_name_baseline = {p["name"]: p["id"] for p in baseline["meta"]["available_projects"]}
+
+    # Restrict the date window to exclude projectB's session (2026-05-02).
+    filtered = team_cost.team_cost_analytics(seeded, date_from="2026-05-01", date_to="2026-05-01")
+    pid_by_name_filtered = {p["name"]: p["id"] for p in filtered["meta"]["available_projects"]}
+
+    assert pid_by_name_filtered == pid_by_name_baseline

--- a/backend/tests/test_team_cost.py
+++ b/backend/tests/test_team_cost.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ccfr.analysis import team_cost
+from ccfr.storage import init_db
+
+OPUS = {"input": 1_000_000, "output": 1_000_000, "base": 1_000_000, "cache_5m": 0, "cache_1h": 0, "cache_read": 0}
+SONNET = {"input": 1_000_000, "output": 1_000_000, "base": 1_000_000, "cache_5m": 0, "cache_1h": 0, "cache_read": 0}
+
+
+def _seed_team(conn: sqlite3.Connection) -> None:
+    tb = conn.execute(
+        """
+        INSERT INTO team_bundles(
+            bundle_id, profile, schema_version, member_id, generated_at,
+            app_version, imported_at, source_path, session_count
+        )
+        VALUES ('b', 'team_strict', 1, 'm', '2026-05-01', '0.1.0', '2026-05-01T00:00:00Z', 'b.json', 2)
+        """
+    ).lastrowid
+    conn.executemany(
+        """
+        INSERT INTO team_bundle_sessions(
+            team_bundle_id, member_id, project_id, session_id, provider,
+            first_date, last_date, tokens_by_model_json
+        )
+        VALUES (?, 'm', ?, ?, 'claude', ?, ?, ?)
+        """,
+        [
+            (tb, "projectA" * 8, "sidA", "2026-05-01", "2026-05-01", json.dumps({"claude-opus-4-8": OPUS})),
+            (tb, "projectB" * 8, "sidB", "2026-05-02", "2026-05-02", json.dumps({"claude-sonnet-4-6": SONNET})),
+        ],
+    )
+    conn.commit()
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    _seed_team(conn)
+    return conn
+
+
+@pytest.fixture()
+def seeded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    csv = tmp_path / "pricing.csv"
+    csv.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens\n"
+        "claude-opus-4-8,5,6.25,10,0.50,25\n"
+        "claude-sonnet-4-6,3,3.75,6,0.30,15\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(team_cost, "pricing_path", lambda: csv)
+    return _conn()
+
+
+def test_team_cost_totals_and_by_model(seeded: sqlite3.Connection) -> None:
+    payload = team_cost.team_cost_analytics(seeded)
+
+    assert payload["meta"]["available"] is True
+    # opus: 1M base*5 + 1M output*25 = $30 ; sonnet: 1M*3 + 1M*15 = $18 ; total $48
+    assert payload["meta"]["total_usd"] == 48.0
+    assert payload["meta"]["total_tokens"] == 4_000_000
+    assert payload["sessions"] == []
+
+    by_model = {m["model"]: m for m in payload["by_model"]}
+    assert round(by_model["claude-opus-4-8"]["usd"], 2) == 30.0
+    assert round(by_model["claude-sonnet-4-6"]["usd"], 2) == 18.0
+    assert len(payload["treemap"]) == 2
+    assert payload["over_time"]
+    assert sorted(payload["meta"]["available_models"]) == ["claude-opus-4-8", "claude-sonnet-4-6"]
+
+
+def test_team_cost_unavailable_without_price_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(team_cost, "pricing_path", lambda: tmp_path / "missing.csv")
+    conn = _conn()
+
+    payload = team_cost.team_cost_analytics(conn)
+
+    assert payload["meta"]["available"] is False
+    assert payload["meta"]["total_usd"] == 0
+    assert set(payload["meta"]["unpriced_models"]) == {"claude-opus-4-8", "claude-sonnet-4-6"}
+    conn.close()

--- a/backend/tests/test_team_cost.py
+++ b/backend/tests/test_team_cost.py
@@ -133,18 +133,22 @@ def _team_conn() -> sqlite3.Connection:
     return conn
 
 
-def _team_level_bundle_for_cost(tmp_path: Path) -> dict:
-    return _team_level_bundle(tmp_path).to_dict()
+def _team_level_bundle_for_cost(tmp_path: Path, label: str | None = None) -> dict:
+    return _team_level_bundle(tmp_path, label=label).to_dict()
 
 
 def test_team_cost_uses_project_names_for_named_bundles(tmp_path):
     conn = _team_conn()
-    bundle = _team_level_bundle_for_cost(tmp_path)
+    # A label longer than 8 chars whose display form ("Payments API") differs
+    # from its normalized grouping key ("payments-api") makes this test
+    # discriminate: the old pid[:8] fallback could only ever surface
+    # "payments", never the real display name.
+    bundle = _team_level_bundle_for_cost(tmp_path, label="Payments API")
     team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
 
     result = team_cost_analytics(conn)
     names = {project["name"] for project in result["meta"]["available_projects"]}
-    assert "alpha" in names
-    assert all(len(name) != 8 or name == "alpha" for name in names)
+    assert "Payments API" in names
+    assert "payments" not in names  # the old pid[:8]-style prefix must not appear
     if result["treemap"]:
-        assert result["treemap"][0]["project_name"] == "alpha"
+        assert result["treemap"][0]["project_name"] == "Payments API"

--- a/backend/tests/test_team_cost.py
+++ b/backend/tests/test_team_cost.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from ccfr.analysis import team_cost
+from ccfr.analysis import team_bundles, team_cost
+from ccfr.analysis.team_cost import team_cost_analytics
 from ccfr.storage import init_db
+from tests.test_team_bundles import _team_level_bundle
 
 OPUS = {"input": 1_000_000, "output": 1_000_000, "base": 1_000_000, "cache_5m": 0, "cache_1h": 0, "cache_read": 0}
 SONNET = {"input": 1_000_000, "output": 1_000_000, "base": 1_000_000, "cache_5m": 0, "cache_1h": 0, "cache_read": 0}
@@ -122,3 +124,27 @@ def test_team_cost_project_ids_stable_across_date_filter(seeded: sqlite3.Connect
     pid_by_name_filtered = {p["name"]: p["id"] for p in filtered["meta"]["available_projects"]}
 
     assert pid_by_name_filtered == pid_by_name_baseline
+
+
+def _team_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    return conn
+
+
+def _team_level_bundle_for_cost(tmp_path: Path) -> dict:
+    return _team_level_bundle(tmp_path).to_dict()
+
+
+def test_team_cost_uses_project_names_for_named_bundles(tmp_path):
+    conn = _team_conn()
+    bundle = _team_level_bundle_for_cost(tmp_path)
+    team_bundles.import_team_bundle(conn, bundle, source_path=Path("a.json"))
+
+    result = team_cost_analytics(conn)
+    names = {project["name"] for project in result["meta"]["available_projects"]}
+    assert "alpha" in names
+    assert all(len(name) != 8 or name == "alpha" for name in names)
+    if result["treemap"]:
+        assert result["treemap"][0]["project_name"] == "alpha"

--- a/backend/tests/test_usage_map.py
+++ b/backend/tests/test_usage_map.py
@@ -238,10 +238,12 @@ def _add_assistant_event(conn: sqlite3.Connection, event_id: int, session_id: in
         )
         # In real exports the result lives on a later user-type event; the loader
         # joins on (session_id, tool_use_id) only, so attaching it here is fine.
+        # Populate raw_json with 10k chars to simulate real tool result content.
+        tool_result_json = json.dumps({"content": "x" * 10_000})
         conn.execute(
             "INSERT INTO tool_results (event_id, session_id, tool_use_id, is_error, raw_json) "
-            "VALUES (?, ?, ?, ?, '{}')",
-            (event_id, session_id, tool_use_id, 1 if is_error else 0),
+            "VALUES (?, ?, ?, ?, ?)",
+            (event_id, session_id, tool_use_id, 1 if is_error else 0, tool_result_json),
         )
     conn.commit()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,11 @@ services:
       CCFR_DATA_DIR: /app/data
       CCFR_DB_PATH: /app/data/ccfr.sqlite3
       CCFR_IMPORT_ROOT: /imports
+      CCFR_TEAM_BUNDLE_ROOT: /team-bundles
     volumes:
       - ./Data:/imports:ro
       - ccfr-data:/app/data
+      - ./TeamBundles:/team-bundles
       # Mount pricing.csv read-only so edits take effect on the next request (no rebuild).
       - ./pricing.csv:/app/pricing.csv:ro
       # Mount the dated price-snapshot dir too, so historical pricing works in

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -12,6 +12,7 @@ vi.mock("./api/client", () => ({
   discoverSourceProjects: vi.fn(async () => []),
   getSettings: vi.fn(async () => ({ historical_pricing: true, privacy_mode: false })),
   updateSettings: vi.fn(async (s: { historical_pricing: boolean; privacy_mode: boolean }) => s),
+  getTeamProjects: vi.fn(async () => ({ projects: [], prefs: {} })),
   getTeamPreview: vi.fn(async () => ({
     manifest: {
       session_count: 0,

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -12,7 +12,39 @@ vi.mock("./api/client", () => ({
   discoverSourceProjects: vi.fn(async () => []),
   getSettings: vi.fn(async () => ({ historical_pricing: true, privacy_mode: false })),
   updateSettings: vi.fn(async (s: { historical_pricing: boolean; privacy_mode: boolean }) => s),
-  getRuntimeConfig: vi.fn(async () => ({ import_root: "/srv/Data", database_path: "/srv/ccfr.sqlite3", is_docker: false })),
+  getTeamPreview: vi.fn(async () => ({
+    manifest: {
+      session_count: 0,
+      sequence_step_count: 0,
+      included_fields: [],
+      excluded: [],
+      fingerprint_caveat: "Local team bundles are structural fingerprints.",
+    },
+    bundle: { sessions: [] },
+  })),
+  exportTeamBundle: vi.fn(async () => ({ path: "/srv/team-bundles/team-bundle.json", bundle_id: "bundle", session_count: 0 })),
+  importTeamBundle: vi.fn(async () => ({ bundle_id: "bundle", member_id: "member", session_count: 0, imported: true })),
+  importTeamBundleFile: vi.fn(async () => ({ bundle_id: "bundle", member_id: "member", imported: true, session_count: 0 })),
+  listTeamImports: vi.fn(async () => []),
+  getTeamDashboard: vi.fn(async () => ({
+    meta: { bundle_count: 0, member_count: 0, project_count: 0, session_count: 0, date_from: null, date_to: null },
+    tokens: { input: 0, output: 0, base: 0, cache_5m: 0, cache_1h: 0, cache_read: 0, total: 0 },
+    stats: {},
+    providers: [],
+    models: [],
+    stop_reasons: [],
+    risk_categories: [],
+    subagents: [],
+    members: [],
+    over_time: [],
+    sequence: [],
+  })),
+  getRuntimeConfig: vi.fn(async () => ({
+    import_root: "/srv/Data",
+    team_bundle_root: "/srv/team-bundles",
+    database_path: "/srv/ccfr.sqlite3",
+    is_docker: false,
+  })),
   getCacheStats: vi.fn(async () => ({
     project_count: 0, session_count: 0, event_count: 0,
     subagent_count: 0, memory_count: 0, persisted_output_count: 0,
@@ -221,6 +253,38 @@ describe("App", () => {
     // The technique subnav appears and the subgroup headline renders.
     expect(await screen.findByRole("button", { name: "Subgroups" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: /What drives/ })).toBeInTheDocument();
+  });
+
+  it("switches to team scope and shows the team overview", async () => {
+    renderApp();
+    // Explore is a local-only view, present in the default (local) scope.
+    expect(await screen.findByRole("button", { name: "Explore" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Team" }));
+    fireEvent.click(screen.getByRole("button", { name: "Overview" }));
+
+    // Team scope hides the drilldown-only views (Cost stays, Explore goes)...
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Explore" })).not.toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Cost" })).toBeInTheDocument();
+    // ...and Overview renders the team overview (empty in this mock).
+    expect(await screen.findByText(/No team bundles imported yet/i)).toBeInTheDocument();
+  });
+
+  it("exposes a local-only Export view and a team-only bundle Import", async () => {
+    renderApp();
+
+    // Local scope: Export shares this machine's bundle.
+    fireEvent.click(await screen.findByRole("button", { name: "Export" }));
+    expect(await screen.findByRole("heading", { name: /Export a team bundle/i })).toBeInTheDocument();
+
+    // Team scope drops Export (nothing local to share) and the Import view
+    // becomes the team-bundle importer, not the projects importer.
+    fireEvent.click(screen.getByRole("button", { name: "Team" }));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Export" })).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+    expect(await screen.findByRole("heading", { name: /Import a team bundle/i })).toBeInTheDocument();
+    expect(screen.queryByText("Projects in source")).not.toBeInTheDocument();
   });
 
   it("returns from a session to the originating Overview view", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,9 +7,13 @@ import TriageBoard from "./triage/TriageBoard";
 import SessionWorkspace from "./pages/SessionWorkspace";
 import CostAnalyticsPage from "./analytics/CostAnalyticsPage";
 import DiscoverPage from "./discover/DiscoverPage";
+import TeamOverview from "./team/TeamOverview";
+import TeamBundleExport from "./team/TeamBundleExport";
+import TeamBundleImport from "./team/TeamBundleImport";
 import GlossaryDialog from "./glossary/GlossaryDialog";
 import Sidebar from "./shell/Sidebar";
 import type { View } from "./shell/navConfig";
+import { useDataScope } from "./shell/useDataScope";
 import { DEFAULT_TECHNIQUE } from "./discover/techniques";
 import { useCollapsed } from "./shell/useCollapsed";
 import { useGlossaryHint } from "./shell/useGlossaryHint";
@@ -30,6 +34,7 @@ function App() {
   const projects = useQuery({ queryKey: ["projects"], queryFn: listProjects });
   const sessions = useQuery({ queryKey: ["sessions", {}], queryFn: () => listSessions() });
   const [view, setView] = React.useState<View>("import");
+  const { scope, setScope } = useDataScope();
   const [discoverTechnique, setDiscoverTechnique] = React.useState<string>(DEFAULT_TECHNIQUE);
   const [selectedSession, setSelectedSession] = React.useState<SessionCard | null>(null);
   const [sessionOrigin, setSessionOrigin] = React.useState<SessionOrigin | null>(null);
@@ -50,6 +55,15 @@ function App() {
       setView((current) => (current === "import" ? "map" : current));
     }
   }, [imports.data?.length]);
+
+  // Team scope only exposes the aggregate views (Import, Overview, Cost). If the
+  // user flips to team while on a local-only view (Export, Explore, a session),
+  // fall back to Overview rather than showing a view with no team equivalent.
+  React.useEffect(() => {
+    if (scope === "team" && view !== "import" && view !== "map" && view !== "cost") {
+      setView("map");
+    }
+  }, [scope, view]);
 
   const openSession = (session: SessionCard, origin: SessionOrigin) => {
     setFocusEventId(null);
@@ -90,10 +104,12 @@ function App() {
     <div className="app-shell">
       <Sidebar
         view={view}
+        scope={scope}
         discoverTechnique={discoverTechnique}
         collapsed={collapsed}
         theme={theme}
         onSelectView={setView}
+        onSelectScope={setScope}
         onSelectTechnique={selectTechnique}
         onToggleCollapsed={toggleCollapsed}
         onToggleTheme={toggle}
@@ -109,8 +125,11 @@ function App() {
       <main className="app-main">
         <GlossaryDialog open={glossaryOpen} onClose={() => setGlossaryOpen(false)} />
 
-        {view === "import" && <ImportPage />}
-        {view === "map" && (
+        {view === "import" && scope === "local" && <ImportPage />}
+        {view === "import" && scope === "team" && <TeamBundleImport />}
+        {view === "export" && <TeamBundleExport />}
+        {view === "map" && scope === "team" && <TeamOverview onGoToImport={() => setView("import")} />}
+        {view === "map" && scope === "local" && (
           <TriageBoard
             projects={projects.data ?? []}
             sessions={sessions.data ?? []}
@@ -120,18 +139,19 @@ function App() {
         )}
         {view === "cost" && (
           <CostAnalyticsPage
-            onOpenSession={(sessionId) => openSessionById(sessionId, null, "cost")}
+            scope={scope}
+            onOpenSession={scope === "team" ? () => {} : (sessionId) => openSessionById(sessionId, null, "cost")}
             historical={historicalPricing}
           />
         )}
-        {view === "discover" && (
+        {view === "discover" && scope === "local" && (
           <DiscoverPage
             projects={projects.data ?? []}
             onOpenSession={(sessionId, eventId = null) => openSessionById(sessionId, eventId, "discover")}
             technique={discoverTechnique}
           />
         )}
-        {view === "session" && selectedSession && (
+        {view === "session" && scope === "local" && selectedSession && (
           <SessionWorkspace
             session={selectedSession}
             initialEventId={focusEventId}

--- a/frontend/src/analytics/CostAnalyticsPage.test.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.test.tsx
@@ -5,8 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CostAnalyticsResponse, TurnCostBreakdown } from "../api/types";
 
 // vi.hoisted gives a mock handle usable inside the hoisted vi.mock factory.
-const { getCostAnalytics, getSessionTurnCosts } = vi.hoisted(() => ({ getCostAnalytics: vi.fn(), getSessionTurnCosts: vi.fn() }));
-vi.mock("../api/client", () => ({ getCostAnalytics, getSessionTurnCosts }));
+const { getCostAnalytics, getTeamCostAnalytics, getSessionTurnCosts } = vi.hoisted(() => ({
+  getCostAnalytics: vi.fn(),
+  getTeamCostAnalytics: vi.fn(),
+  getSessionTurnCosts: vi.fn(),
+}));
+vi.mock("../api/client", () => ({ getCostAnalytics, getTeamCostAnalytics, getSessionTurnCosts }));
 
 import CostAnalyticsPage from "./CostAnalyticsPage";
 
@@ -153,16 +157,18 @@ const turnBreakdown: TurnCostBreakdown = {
 
 beforeEach(() => {
   getCostAnalytics.mockReset();
+  getTeamCostAnalytics.mockReset();
   getSessionTurnCosts.mockReset();
   getCostAnalytics.mockResolvedValue(payload);
+  getTeamCostAnalytics.mockResolvedValue(payload);
   getSessionTurnCosts.mockResolvedValue(turnBreakdown);
 });
 
-function renderPage(onOpenSession = () => {}, historical?: boolean) {
+function renderPage(onOpenSession = () => {}, historical?: boolean, scope: "local" | "team" = "local") {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <CostAnalyticsPage onOpenSession={onOpenSession} historical={historical} />
+      <CostAnalyticsPage onOpenSession={onOpenSession} historical={historical} scope={scope} />
     </QueryClientProvider>,
   );
 }
@@ -177,6 +183,18 @@ describe("CostAnalyticsPage", () => {
     expect(await screen.findByText("Session insights")).toBeInTheDocument();
     expect(await screen.findAllByText("Turn distribution")).not.toHaveLength(0);
     expect(screen.queryByRole("button", { name: "Review" })).not.toBeInTheDocument();
+  });
+
+  it("in team scope uses the team cost endpoint and hides the session-level panels", async () => {
+    renderPage(() => {}, undefined, "team");
+
+    // Aggregate panels still render...
+    expect(await screen.findByText("Cost by model")).toBeInTheDocument();
+    expect(getTeamCostAnalytics).toHaveBeenCalled();
+    expect(getCostAnalytics).not.toHaveBeenCalled();
+    // ...but the session-level panels (no team equivalent) are gone.
+    expect(screen.queryByText("Session insights")).not.toBeInTheDocument();
+    expect(screen.queryByText("Turn distribution")).not.toBeInTheDocument();
   });
 
   it("applies custom start and end date filters", async () => {

--- a/frontend/src/analytics/CostAnalyticsPage.test.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.test.tsx
@@ -197,6 +197,46 @@ describe("CostAnalyticsPage", () => {
     expect(screen.queryByText("Turn distribution")).not.toBeInTheDocument();
   });
 
+  it("clears the project/model filters but preserves dates when scope changes", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const view = render(
+      <QueryClientProvider client={qc}>
+        <CostAnalyticsPage onOpenSession={() => {}} scope="local" />
+      </QueryClientProvider>,
+    );
+    await screen.findAllByText("alpha");
+
+    fireEvent.change(screen.getByLabelText("Project"), { target: { value: "1" } });
+    await vi.waitFor(() =>
+      expect(getCostAnalytics.mock.calls.some(([f]) => f.projectId === 1)).toBe(true),
+    );
+    // Let the refetch resolve (repopulating meta.available_models) before the
+    // Model select's options exist to pick from.
+    await screen.findAllByText("alpha");
+
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "claude-opus-4-8" } });
+    await vi.waitFor(() =>
+      expect(getCostAnalytics.mock.calls.some(([f]) => f.projectId === 1 && f.model === "claude-opus-4-8")).toBe(true),
+    );
+    const localDateFrom = getCostAnalytics.mock.calls[getCostAnalytics.mock.calls.length - 1][0].dateFrom;
+
+    view.rerender(
+      <QueryClientProvider client={qc}>
+        <CostAnalyticsPage onOpenSession={() => {}} scope="team" />
+      </QueryClientProvider>,
+    );
+
+    // The team endpoint must never see the local scope's projectId/model (different
+    // namespaces), but the scope-agnostic date filters must survive the switch.
+    await vi.waitFor(() =>
+      expect(getTeamCostAnalytics.mock.calls.some(([f]) => f.projectId == null && f.model == null)).toBe(true),
+    );
+    const teamCall = getTeamCostAnalytics.mock.calls[getTeamCostAnalytics.mock.calls.length - 1][0];
+    expect(teamCall.projectId).toBeFalsy();
+    expect(teamCall.model).toBeFalsy();
+    expect(teamCall.dateFrom).toBe(localDateFrom);
+  });
+
   it("applies custom start and end date filters", async () => {
     renderPage();
     await screen.findAllByText("alpha");

--- a/frontend/src/analytics/CostAnalyticsPage.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getCostAnalytics } from "../api/client";
+import { getCostAnalytics, getTeamCostAnalytics } from "../api/client";
 import type { CostAnalyticsFilters, SpendSpike } from "../api/types";
+import type { DataScope } from "../shell/useDataScope";
 import { buildModelColorMap, formatSignedUsd, formatTokens, formatUsd, largestSpike } from "./chartGeometry";
 import FilterBar from "./FilterBar";
 import CostByProject from "./CostByProject";
@@ -16,6 +17,9 @@ interface Props {
   onOpenSession: (sessionId: number) => void;
   /** Whether historical (date-effective) pricing is active; drives the pricing-mode note. */
   historical?: boolean;
+  /** In team scope, Cost is computed from imported bundles and the session-level
+   * panels (which have no team equivalent) are hidden. Defaults to local. */
+  scope?: DataScope;
 }
 
 function defaultFrom(): string {
@@ -65,15 +69,16 @@ function SpikeSessionsPanel({
   );
 }
 
-export default function CostAnalyticsPage({ onOpenSession, historical = true }: Props) {
+export default function CostAnalyticsPage({ onOpenSession, historical = true, scope = "local" }: Props) {
+  const isTeam = scope === "team";
   const [filters, setFilters] = React.useState<CostAnalyticsFilters>({ dateFrom: defaultFrom() });
   const [selectedSpikeBucket, setSelectedSpikeBucket] = React.useState<string | null>(null);
   const query = useQuery({
-    // `historical` is part of the key so flipping the price mode is a distinct
-    // query (and a distinct request URL), not a same-URL refetch that could be
-    // served stale from cache.
-    queryKey: ["cost-analytics", filters, historical],
-    queryFn: () => getCostAnalytics(filters, historical),
+    // `historical` and `scope` are part of the key so flipping the price mode or
+    // the data scope is a distinct query (and request URL), not a same-URL
+    // refetch that could be served stale from cache.
+    queryKey: ["cost-analytics", scope, filters, historical],
+    queryFn: () => (isTeam ? getTeamCostAnalytics(filters, historical) : getCostAnalytics(filters, historical)),
   });
 
   const payload = query.data;
@@ -120,7 +125,7 @@ export default function CostAnalyticsPage({ onOpenSession, historical = true }: 
               ))}
             />
             <div className="cost-bento">
-              {selectedSpike && (
+              {!isTeam && selectedSpike && (
                 <SpikeSessionsPanel spike={selectedSpike} onOpenSession={onOpenSession} />
               )}
               <section className="tile">
@@ -139,18 +144,22 @@ export default function CostAnalyticsPage({ onOpenSession, historical = true }: 
                 <h2>Cost by model</h2>
                 <CostByModel payload={payload} colors={colors} available={payload.meta.available} />
               </section>
-              <section className="tile tile-full">
-                <h2>Turn distribution</h2>
-                <TurnDistributionSection
-                  sessions={payload.sessions}
-                  onOpenSession={onOpenSession}
-                  available={payload.meta.available}
-                />
-              </section>
-              <section className="tile tile-full">
-                <h2>Session insights</h2>
-                <SessionInsights payload={payload} onOpenSession={onOpenSession} available={payload.meta.available} />
-              </section>
+              {!isTeam && (
+                <>
+                  <section className="tile tile-full">
+                    <h2>Turn distribution</h2>
+                    <TurnDistributionSection
+                      sessions={payload.sessions}
+                      onOpenSession={onOpenSession}
+                      available={payload.meta.available}
+                    />
+                  </section>
+                  <section className="tile tile-full">
+                    <h2>Session insights</h2>
+                    <SessionInsights payload={payload} onOpenSession={onOpenSession} available={payload.meta.available} />
+                  </section>
+                </>
+              )}
             </div>
           </>
         )}

--- a/frontend/src/analytics/CostAnalyticsPage.tsx
+++ b/frontend/src/analytics/CostAnalyticsPage.tsx
@@ -73,6 +73,13 @@ export default function CostAnalyticsPage({ onOpenSession, historical = true, sc
   const isTeam = scope === "team";
   const [filters, setFilters] = React.useState<CostAnalyticsFilters>({ dateFrom: defaultFrom() });
   const [selectedSpikeBucket, setSelectedSpikeBucket] = React.useState<string | null>(null);
+
+  // projectId/model are scope-namespaced (local ids vs team synthetic ids /
+  // bucketed families); carrying them across a scope switch mis-filters the
+  // other scope's data. Dates are scope-agnostic and survive the switch.
+  React.useEffect(() => {
+    setFilters((f) => (f.projectId || f.model ? { ...f, projectId: null, model: null } : f));
+  }, [scope]);
   const query = useQuery({
     // `historical` and `scope` are part of the key so flipping the price mode or
     // the data scope is a distinct query (and request URL), not a same-URL

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -4,10 +4,12 @@ import {
   getCostAnalytics,
   getTeamDashboard,
   getTeamPreview,
+  getTeamProjects,
   importTeamBundle,
   importTeamBundleFile,
   listTeamImports,
 } from "./client";
+import type { TeamExportRequestBody } from "./types";
 
 function okJson(body: unknown) {
   return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
@@ -52,12 +54,25 @@ describe("api client", () => {
   });
 
   it("uses the planned team bundle API routes", async () => {
-    await getTeamPreview();
-    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/export-preview");
+    await getTeamProjects();
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/projects");
 
-    await exportTeamBundle();
+    const exportBody: TeamExportRequestBody = {
+      privacy_level: "structural",
+      projects: [{ export_name: "d--Alpha", label: null }],
+    };
+
+    await getTeamPreview(exportBody);
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/export-preview");
+    const previewInit = fetchMock.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(previewInit.method).toBe("POST");
+    expect(JSON.parse(String(previewInit.body))).toEqual(exportBody);
+
+    await exportTeamBundle(exportBody);
     expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/export");
-    expect((fetchMock.mock.calls.at(-1)?.[1] as RequestInit).method).toBe("POST");
+    const exportInit = fetchMock.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(exportInit.method).toBe("POST");
+    expect(JSON.parse(String(exportInit.body))).toEqual(exportBody);
 
     await importTeamBundle("D:\\TeamBundles\\team-a.json");
     expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/import");

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getCostAnalytics } from "./client";
+import {
+  exportTeamBundle,
+  getCostAnalytics,
+  getTeamDashboard,
+  getTeamPreview,
+  importTeamBundle,
+  importTeamBundleFile,
+  listTeamImports,
+} from "./client";
 
 function okJson(body: unknown) {
   return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
@@ -33,5 +41,43 @@ describe("api client", () => {
   it("omits the historical param when the mode is not provided", async () => {
     await getCostAnalytics({ dateFrom: "2026-05-18" });
     expect(fetchMock.mock.calls[0][0] as string).not.toContain("historical=");
+  });
+
+  it("surfaces FastAPI error details as the thrown message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: "bundle_id does not match bundle content" }), { status: 400 }),
+    );
+
+    await expect(importTeamBundleFile("bad.json", {})).rejects.toThrow("bundle_id does not match bundle content");
+  });
+
+  it("uses the planned team bundle API routes", async () => {
+    await getTeamPreview();
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/export-preview");
+
+    await exportTeamBundle();
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/export");
+    expect((fetchMock.mock.calls.at(-1)?.[1] as RequestInit).method).toBe("POST");
+
+    await importTeamBundle("D:\\TeamBundles\\team-a.json");
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/import");
+    const importInit = fetchMock.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(importInit.method).toBe("POST");
+    expect(JSON.parse(String(importInit.body))).toEqual({ path: "D:\\TeamBundles\\team-a.json" });
+
+    await importTeamBundleFile("team-a.json", { profile: "team_strict" });
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/import-bundle");
+    const fileImportInit = fetchMock.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(fileImportInit.method).toBe("POST");
+    expect(JSON.parse(String(fileImportInit.body))).toEqual({
+      filename: "team-a.json",
+      bundle: { profile: "team_strict" },
+    });
+
+    await listTeamImports();
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/imports");
+
+    await getTeamDashboard();
+    expect(fetchMock.mock.calls.at(-1)?.[0]).toBe("/api/team/dashboard");
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,11 +20,13 @@ import type {
   Settings,
   Subagent,
   TeamDashboard,
+  TeamExportRequestBody,
   TeamExportResult,
   TeamImportRecord,
   TeamImportResult,
   TeamMemberDeleteResult,
   TeamPreview,
+  TeamProjectsResult,
   TimelineItem,
   TurnCostBreakdown,
   TraceResponse,
@@ -262,12 +264,22 @@ export function exportContribution() {
   return request<ContributionExportResult>("/contribution/export", { method: "POST" });
 }
 
-export function getTeamPreview() {
-  return request<TeamPreview>("/team/export-preview");
+export function getTeamProjects() {
+  return request<TeamProjectsResult>("/team/projects");
 }
 
-export function exportTeamBundle() {
-  return request<TeamExportResult>("/team/export", { method: "POST" });
+export function getTeamPreview(body: TeamExportRequestBody) {
+  return request<TeamPreview>("/team/export-preview", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function exportTeamBundle(body: TeamExportRequestBody) {
+  return request<TeamExportResult>("/team/export", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
 
 export function importTeamBundle(path?: string | null) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -23,6 +23,7 @@ import type {
   TeamExportResult,
   TeamImportRecord,
   TeamImportResult,
+  TeamMemberDeleteResult,
   TeamPreview,
   TimelineItem,
   TurnCostBreakdown,
@@ -285,6 +286,12 @@ export function importTeamBundleFile(filename: string, bundle: unknown) {
 
 export function listTeamImports() {
   return request<TeamImportRecord[]>("/team/imports");
+}
+
+export function deleteTeamMember(memberId: string) {
+  return request<TeamMemberDeleteResult>(`/team/members/${encodeURIComponent(memberId)}`, {
+    method: "DELETE",
+  });
 }
 
 export function getTeamDashboard() {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,11 @@ import type {
   SessionContextEconomicsResponse,
   Settings,
   Subagent,
+  TeamDashboard,
+  TeamExportResult,
+  TeamImportRecord,
+  TeamImportResult,
+  TeamPreview,
   TimelineItem,
   TurnCostBreakdown,
   TraceResponse,
@@ -32,6 +37,25 @@ import type {
 // backend isn't reachable via the proxy (e.g. a built/Docker frontend).
 const API_BASE = (import.meta.env.VITE_API_BASE ?? "/api").replace(/\/$/, "");
 
+function errorMessageFromBody(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { detail?: unknown };
+    if (typeof parsed.detail === "string") return parsed.detail;
+    if (Array.isArray(parsed.detail)) {
+      return parsed.detail
+        .map((item) => {
+          if (typeof item === "string") return item;
+          if (item && typeof item === "object" && "msg" in item) return String(item.msg);
+          return JSON.stringify(item);
+        })
+        .join("; ");
+    }
+  } catch {
+    // Plain-text error body.
+  }
+  return body;
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, {
     // Always hit the backend: analytics responses carry no cache headers and some
@@ -43,7 +67,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   });
   if (!response.ok) {
     const detail = await response.text();
-    throw new Error(detail || `Request failed: ${response.status}`);
+    throw new Error(errorMessageFromBody(detail) || `Request failed: ${response.status}`);
   }
   return response.json() as Promise<T>;
 }
@@ -144,7 +168,7 @@ export function search(q: string, sessionId?: number) {
   return request<SearchResult[]>(`/search?${params.toString()}`);
 }
 
-export function getCostAnalytics(filters: CostAnalyticsFilters = {}, historical?: boolean) {
+function costRequest(path: string, filters: CostAnalyticsFilters, historical?: boolean) {
   const params = new URLSearchParams();
   if (filters.dateFrom) params.set("date_from", filters.dateFrom);
   if (filters.dateTo) params.set("date_to", filters.dateTo);
@@ -154,7 +178,16 @@ export function getCostAnalytics(filters: CostAnalyticsFilters = {}, historical?
   // request (the backend falls back to the persisted setting when it's absent).
   if (historical !== undefined) params.set("historical", String(historical));
   const query = params.toString();
-  return request<CostAnalyticsResponse>(`/analytics/cost${query ? `?${query}` : ""}`);
+  return request<CostAnalyticsResponse>(`${path}${query ? `?${query}` : ""}`);
+}
+
+export function getCostAnalytics(filters: CostAnalyticsFilters = {}, historical?: boolean) {
+  return costRequest("/analytics/cost", filters, historical);
+}
+
+// Same response shape as getCostAnalytics, computed over imported team bundles.
+export function getTeamCostAnalytics(filters: CostAnalyticsFilters = {}, historical?: boolean) {
+  return costRequest("/team/analytics/cost", filters, historical);
 }
 
 export function getDiscoveryAnalytics(filters: DiscoveryFilters = {}) {
@@ -226,4 +259,34 @@ export function getContributionPreview() {
 
 export function exportContribution() {
   return request<ContributionExportResult>("/contribution/export", { method: "POST" });
+}
+
+export function getTeamPreview() {
+  return request<TeamPreview>("/team/export-preview");
+}
+
+export function exportTeamBundle() {
+  return request<TeamExportResult>("/team/export", { method: "POST" });
+}
+
+export function importTeamBundle(path?: string | null) {
+  return request<TeamImportResult>("/team/import", {
+    method: "POST",
+    body: JSON.stringify({ path: path || null }),
+  });
+}
+
+export function importTeamBundleFile(filename: string, bundle: unknown) {
+  return request<TeamImportResult>("/team/import-bundle", {
+    method: "POST",
+    body: JSON.stringify({ filename, bundle }),
+  });
+}
+
+export function listTeamImports() {
+  return request<TeamImportRecord[]>("/team/imports");
+}
+
+export function getTeamDashboard() {
+  return request<TeamDashboard>("/team/dashboard");
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -14,6 +14,7 @@ export interface ImportSummary {
 
 export interface RuntimeConfig {
   import_root: string;
+  team_bundle_root?: string;
   database_path: string;
   is_docker: boolean;
 }
@@ -665,4 +666,76 @@ export interface ContributionPreview {
 export interface ContributionExportResult {
   path: string;
   session_count: number;
+}
+
+// GET /api/team/export-preview -> TeamExportPreviewResponse { manifest, bundle }.
+export interface TeamPreview {
+  manifest: ContributionManifest;
+  bundle: { sessions?: unknown[] } & Record<string, unknown>;
+}
+
+// POST /api/team/export -> TeamExportResponse.
+export interface TeamExportResult {
+  path: string;
+  bundle_id: string;
+  session_count: number;
+}
+
+// POST /api/team/import and /api/team/import-bundle -> TeamImportResponse.
+export interface TeamImportResult {
+  bundle_id: string;
+  member_id: string;
+  session_count: number;
+  imported: boolean;
+}
+
+// GET /api/team/imports -> list[TeamImportEntry].
+export interface TeamImportRecord {
+  id: number;
+  bundle_id: string;
+  profile: string;
+  schema_version: number;
+  member_id: string;
+  generated_at: string;
+  app_version?: string | null;
+  imported_at: string;
+  source_path: string;
+  session_count: number;
+}
+
+// GET /api/team/dashboard -> TeamDashboardResponse (team_dashboard()).
+export interface TeamDashboard {
+  meta?: {
+    bundle_count?: number;
+    member_count?: number;
+    project_count?: number;
+    session_count?: number;
+    date_from?: string | null;
+    date_to?: string | null;
+  };
+  tokens?: {
+    input?: number;
+    output?: number;
+    base?: number;
+    cache_5m?: number;
+    cache_1h?: number;
+    cache_read?: number;
+    total?: number;
+  };
+  stats?: {
+    turns?: number;
+    tool_calls?: number;
+    subagents?: number;
+    errors?: number;
+    loops?: number;
+    [key: string]: number | undefined;
+  };
+  providers?: Array<{ provider: string; session_count: number }>;
+  models?: Array<{ model: string; session_count: number }>;
+  stop_reasons?: Array<{ reason: string; count: number }>;
+  risk_categories?: Array<{ category: string; session_count: number }>;
+  subagents?: Array<{ agent_type: string; event_count: number; session_count: number }>;
+  sequence?: Array<{ sym: string; count: number }>;
+  members?: Array<Record<string, unknown>>;
+  over_time?: Array<{ date: string; session_count: number; tokens: number }>;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -690,6 +690,12 @@ export interface TeamImportResult {
   status: "imported" | "replaced" | "duplicate" | "stale";
 }
 
+// DELETE /api/team/members/{member_id} -> TeamMemberDeleteResponse.
+export interface TeamMemberDeleteResult {
+  member_id: string;
+  bundles_removed: number;
+}
+
 // GET /api/team/imports -> list[TeamImportEntry].
 export interface TeamImportRecord {
   id: number;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -649,6 +649,7 @@ export interface UsageCharacteristicsResponse {
 export interface Settings {
   historical_pricing: boolean;
   privacy_mode: boolean;
+  team_export_prefs?: Record<string, unknown>;
 }
 
 export interface ContributionManifest {
@@ -657,6 +658,7 @@ export interface ContributionManifest {
   included_fields: string[];
   excluded: string[];
   fingerprint_caveat: string;
+  privacy_level?: string;
 }
 
 export interface ContributionPreview {
@@ -667,6 +669,35 @@ export interface ContributionPreview {
 export interface ContributionExportResult {
   path: string;
   session_count: number;
+}
+
+export type TeamPrivacyLevel = "structural" | "team";
+
+// GET /api/team/projects -> TeamProjectsResponse.
+export interface TeamProjectEntry {
+  export_name: string;
+  default_label: string;
+  session_count: number;
+  tokens: number;
+}
+
+export interface TeamExportPrefs {
+  member_name?: string | null;
+  privacy_level?: TeamPrivacyLevel;
+  project_labels?: Record<string, string>;
+  deselected?: string[];
+}
+
+export interface TeamProjectsResult {
+  projects: TeamProjectEntry[];
+  prefs: TeamExportPrefs;
+}
+
+// POST /api/team/export and /api/team/export-preview request body.
+export interface TeamExportRequestBody {
+  privacy_level: TeamPrivacyLevel;
+  member_name?: string | null;
+  projects: { export_name: string; label?: string | null }[];
 }
 
 // GET /api/team/export-preview -> TeamExportPreviewResponse { manifest, bundle }.
@@ -709,6 +740,8 @@ export interface TeamImportRecord {
   imported_at: string;
   source_path: string;
   session_count: number;
+  member_name?: string | null;
+  privacy_level?: string;
 }
 
 // GET /api/team/dashboard -> TeamDashboardResponse (team_dashboard()).
@@ -744,6 +777,22 @@ export interface TeamDashboard {
   risk_categories?: Array<{ category: string; session_count: number }>;
   subagents?: Array<{ agent_type: string; event_count: number; session_count: number }>;
   sequence?: Array<{ sym: string; count: number }>;
-  members?: Array<Record<string, unknown>>;
+  members?: {
+    member_name: string;
+    member_ids: string[];
+    bundle_count: number;
+    project_count: number;
+    session_count: number;
+    tokens: number;
+  }[];
+  projects?: {
+    project_key: string;
+    project_name: string;
+    member_count: number;
+    session_count: number;
+    tokens: number;
+  }[];
+  tools?: { name: string; call_count: number; session_count: number }[];
+  file_types?: { ext: string; count: number; session_count: number }[];
   over_time?: Array<{ date: string; session_count: number; tokens: number }>;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -61,6 +61,7 @@ export interface DiscoveredProject {
   imported: boolean;
   session_count: number;
   last_imported_at: string | null;
+  stale?: boolean;
 }
 
 export interface SessionCard {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -687,6 +687,7 @@ export interface TeamImportResult {
   member_id: string;
   session_count: number;
   imported: boolean;
+  status: "imported" | "replaced" | "duplicate" | "stale";
 }
 
 // GET /api/team/imports -> list[TeamImportEntry].

--- a/frontend/src/contribute/ContributePage.tsx
+++ b/frontend/src/contribute/ContributePage.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { AlertTriangle, ArrowRight, ArrowUpRight, Check, Download, FileJson, Lock, ScanSearch } from "lucide-react";
+import { ArrowRight, ArrowUpRight, Check, Download, FileJson } from "lucide-react";
 import { exportContribution, getContributionPreview } from "../api/client";
 import { Blurred } from "../shell/Blurred";
 import { type ContributionSession, compactInt } from "./specimen";
 import SpecimenModal from "./SpecimenModal";
+import PrivacyLedger from "./PrivacyLedger";
 
 // Contributions go to an open, public dataset repo. Step 2 deep-links to GitHub's
 // file-upload page for the contributions/ folder; for anyone without write access
@@ -117,56 +118,13 @@ export default function ContributePage() {
         </div>
       </section>
 
-      <section className="privacy-ledger" aria-labelledby="privacy-ledger-title">
-        <div className="privacy-ledger-head">
-          <h2 id="privacy-ledger-title">What stays vs. what travels</h2>
-          <p className="privacy-note privacy-warning" role="note">
-            <AlertTriangle size={14} aria-hidden="true" />
-            <span>{manifest.fingerprint_caveat}</span>
-          </p>
-        </div>
-
-        <div className="privacy-grid">
-          <section className="privacy-column stays" aria-labelledby="privacy-stays">
-            <h2 id="privacy-stays">
-              <Lock size={13} aria-hidden="true" /> Stays on this machine
-            </h2>
-            <ul>
-              {manifest.excluded.map((f) => (
-                <li key={f}>{f}</li>
-              ))}
-            </ul>
-          </section>
-
-          <section className="privacy-column travels" aria-labelledby="privacy-travels">
-            <h2 id="privacy-travels">
-              <ArrowUpRight size={13} aria-hidden="true" /> Travels in the bundle
-            </h2>
-            <ul>
-              {manifest.included_fields.map((f) => (
-                <li key={f}>{f}</li>
-              ))}
-            </ul>
-          </section>
-        </div>
-
-        <div className="ledger-foot">
-          {sample ? (
-            <>
-              <span>Inspect the exact first session that will be exported.</span>
-              <button
-                type="button"
-                className="specimen-trigger"
-                onClick={() => setSpecimenOpen(true)}
-              >
-                <ScanSearch size={14} aria-hidden="true" /> Inspect specimen
-              </button>
-            </>
-          ) : (
-            <span>No sessions are available for export yet.</span>
-          )}
-        </div>
-      </section>
+      <PrivacyLedger
+        caveat={manifest.fingerprint_caveat}
+        excluded={manifest.excluded}
+        included={manifest.included_fields}
+        hasSpecimen={Boolean(sample)}
+        onInspectSpecimen={() => setSpecimenOpen(true)}
+      />
 
       {sample ? (
         <SpecimenModal sample={sample} open={specimenOpen} onClose={() => setSpecimenOpen(false)} />

--- a/frontend/src/contribute/PrivacyLedger.tsx
+++ b/frontend/src/contribute/PrivacyLedger.tsx
@@ -1,0 +1,78 @@
+import { AlertTriangle, ArrowUpRight, Lock, ScanSearch } from "lucide-react";
+
+interface Props {
+  title?: string;
+  caveat: string;
+  excluded: string[];
+  included: string[];
+  staysTitle?: string;
+  travelsTitle?: string;
+  specimenLabel?: string;
+  specimenDescription?: string;
+  emptyDescription?: string;
+  hasSpecimen: boolean;
+  onInspectSpecimen: () => void;
+}
+
+export default function PrivacyLedger({
+  title = "What stays vs. what travels",
+  caveat,
+  excluded,
+  included,
+  staysTitle = "Stays on this machine",
+  travelsTitle = "Travels in the bundle",
+  specimenLabel = "Inspect specimen",
+  specimenDescription = "Inspect the exact first session that will be exported.",
+  emptyDescription = "No sessions are available for export yet.",
+  hasSpecimen,
+  onInspectSpecimen,
+}: Props) {
+  return (
+    <section className="privacy-ledger" aria-labelledby="privacy-ledger-title">
+      <div className="privacy-ledger-head">
+        <h2 id="privacy-ledger-title">{title}</h2>
+        <p className="privacy-note privacy-warning" role="note">
+          <AlertTriangle size={14} aria-hidden="true" />
+          <span>{caveat}</span>
+        </p>
+      </div>
+
+      <div className="privacy-grid">
+        <section className="privacy-column stays" aria-labelledby="privacy-stays">
+          <h2 id="privacy-stays">
+            <Lock size={13} aria-hidden="true" /> {staysTitle}
+          </h2>
+          <ul>
+            {excluded.map((field) => (
+              <li key={field}>{field}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="privacy-column travels" aria-labelledby="privacy-travels">
+          <h2 id="privacy-travels">
+            <ArrowUpRight size={13} aria-hidden="true" /> {travelsTitle}
+          </h2>
+          <ul>
+            {included.map((field) => (
+              <li key={field}>{field}</li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <div className="ledger-foot">
+        {hasSpecimen ? (
+          <>
+            <span>{specimenDescription}</span>
+            <button type="button" className="specimen-trigger" onClick={onInspectSpecimen}>
+              <ScanSearch size={14} aria-hidden="true" /> {specimenLabel}
+            </button>
+          </>
+        ) : (
+          <span>{emptyDescription}</span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/contribute/SpecimenModal.tsx
+++ b/frontend/src/contribute/SpecimenModal.tsx
@@ -1,5 +1,6 @@
 import { type MouseEvent, useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
+import { Blurred } from "../shell/Blurred";
 import {
   type ContributionSession,
   compactInt,
@@ -14,12 +15,22 @@ interface Props {
   sample: ContributionSession;
   open: boolean;
   onClose: () => void;
+  title?: string;
+  description?: string;
+  blurRaw?: boolean;
 }
 
 // The literal first session that would be sent, shown in a modal: an annotated
 // reading by default and the raw JSON it is derived from on demand. Uses the
 // native <dialog> element (focus trap, Esc-to-close, backdrop) like the glossary.
-export default function SpecimenModal({ sample, open, onClose }: Props) {
+export default function SpecimenModal({
+  sample,
+  open,
+  onClose,
+  title = "First exported session",
+  description = "The exact first session in the bundle, shown as structured fields or raw JSON.",
+  blurRaw = false,
+}: Props) {
   const ref = useRef<HTMLDialogElement>(null);
   const [raw, setRaw] = useState(false);
 
@@ -80,8 +91,8 @@ export default function SpecimenModal({ sample, open, onClose }: Props) {
       <div className="specimen-panel">
         <div className="specimen-modal-head">
           <div className="specimen-title">
-            <h2 id="specimen-title">First exported session</h2>
-            <p>The exact first session in the bundle, shown as structured fields or raw JSON.</p>
+            <h2 id="specimen-title">{title}</h2>
+            <p>{description}</p>
           </div>
           <div className="specimen-modal-tools">
             <div className="seg" role="group" aria-label="Specimen view">
@@ -116,7 +127,7 @@ export default function SpecimenModal({ sample, open, onClose }: Props) {
         <div className="specimen-modal-body">
           {raw ? (
             <pre className="specimen-raw" aria-label="Raw specimen JSON">
-              {JSON.stringify(sample, null, 2)}
+              {blurRaw ? <Blurred>{JSON.stringify(sample, null, 2)}</Blurred> : JSON.stringify(sample, null, 2)}
             </pre>
           ) : (
             <>

--- a/frontend/src/discover/mindmap/UsageMindmap.tsx
+++ b/frontend/src/discover/mindmap/UsageMindmap.tsx
@@ -199,7 +199,7 @@ export default function UsageMindmap({ projects }: Props) {
               <MindmapCanvas
                 phases={displayedPhases}
                 totalUsd={displayedTotal}
-                costAvailable={meta.cost_available}
+                costAvailable={basis === "cost"}
                 selectedNodeId={activeNode?.id ?? null}
                 onSelectNode={setSelectedNode}
                 previousShares={origin === "all" ? previousShares : undefined}

--- a/frontend/src/discover/mindmap/forceModel.test.ts
+++ b/frontend/src/discover/mindmap/forceModel.test.ts
@@ -132,6 +132,20 @@ describe("buildForceModel", () => {
     expect(a.nodes.map((n) => [n.x, n.y])).toEqual(b.nodes.map((n) => [n.x, n.y]));
     expect(a.nodes[1].x !== 0 || a.nodes[1].y !== 0).toBe(true);
   });
+
+  it("keeps every leaf visible when cost is unavailable (token basis)", () => {
+    const tokenPhases = phases.map((p) => ({
+      ...p,
+      cost_usd: 0,
+      habits: p.habits.map((h) => ({ ...h, cost_usd: 0 })),
+      tools: p.tools.map((t) => ({ ...t, cost_usd: 0 })),
+    }));
+    // Regression: the page passes the TOKEN total here in token-basis mode.
+    const model = buildForceModel(tokenPhases, { totalUsd: 5_000_000, costAvailable: false });
+    const habitNodes = model.nodes.filter((n) => n.kind === "habit");
+    expect(habitNodes.length).toBeGreaterThan(0);
+    expect(habitNodes.every((n) => n.habitKey !== undefined)).toBe(true); // no "+N more" group node
+  });
 });
 
 describe("buildForceModel tool lens", () => {

--- a/frontend/src/discover/mindmap/forceModel.ts
+++ b/frontend/src/discover/mindmap/forceModel.ts
@@ -151,6 +151,10 @@ export function buildForceModel(
   opts: { totalUsd: number; costAvailable: boolean; leafMode?: LeafMode },
 ): ForceModel {
   const leafMode = opts.leafMode ?? "habits";
+  // Share-of-spend grouping only makes sense on a dollar basis. In token
+  // fallback the caller's total is a token count while leaf.cost_usd is 0,
+  // which would mark every leaf "too small" — keep everything within the cap.
+  const shareTotal = opts.costAvailable ? opts.totalUsd : 0;
   const active = phases.filter((p) =>
     p.share > 0 || (leafMode === "habits" ? p.habits.length > 0 : p.tools.length > 0));
   const nodes: MapNode[] = [{
@@ -191,11 +195,11 @@ export function buildForceModel(
     };
 
     if (leafMode === "habits") {
-      const { visible, grouped } = groupSmallLeaves(phase.habits, opts.totalUsd);
+      const { visible, grouped } = groupSmallLeaves(phase.habits, shareTotal);
       const leaves: (UsageHabit | null)[] =
         grouped.length > 0 ? [...visible, null] : visible;
       leaves.forEach((leaf, j) => {
-        const share = leaf && opts.totalUsd > 0 ? leaf.cost_usd / opts.totalUsd : 0;
+        const share = leaf && shareTotal > 0 ? leaf.cost_usd / shareTotal : 0;
         const r = leaf ? habitRadius(share) : 10;
         const habitNode: MapNode = leaf
           ? {
@@ -214,11 +218,11 @@ export function buildForceModel(
         pushLeaf(habitNode, leaf?.polarity ?? "structure");
       });
     } else {
-      const { visible, grouped } = groupSmallLeaves(phase.tools, opts.totalUsd);
+      const { visible, grouped } = groupSmallLeaves(phase.tools, shareTotal);
       const leaves: (UsageTool | null)[] =
         grouped.length > 0 ? [...visible, null] : visible;
       leaves.forEach((leaf, j) => {
-        const share = leaf && opts.totalUsd > 0 ? leaf.cost_usd / opts.totalUsd : 0;
+        const share = leaf && shareTotal > 0 ? leaf.cost_usd / shareTotal : 0;
         const r = leaf ? habitRadius(share) : 10;
         const toolNode: MapNode = leaf
           ? {

--- a/frontend/src/shell/Sidebar.test.tsx
+++ b/frontend/src/shell/Sidebar.test.tsx
@@ -63,6 +63,15 @@ describe("Sidebar", () => {
     expect(props.onSelectScope).toHaveBeenCalledWith("team");
   });
 
+  it("renders a collapsed icon toggle for scope switching", () => {
+    const props = setup({ scope: "team", collapsed: true });
+    const scopeToggle = screen.getByRole("button", { name: /data scope: team\. switch to this machine/i });
+    expect(scopeToggle).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(scopeToggle);
+    expect(props.onSelectScope).toHaveBeenCalledWith("local");
+  });
+
   it("marks the active view and routes nav clicks", () => {
     const props = setup({ view: "cost" });
     expect(screen.getByRole("button", { name: "Cost" })).toHaveClass("active");

--- a/frontend/src/shell/Sidebar.test.tsx
+++ b/frontend/src/shell/Sidebar.test.tsx
@@ -1,16 +1,18 @@
 // frontend/src/shell/Sidebar.test.tsx
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import Sidebar from "./Sidebar";
 
 function setup(overrides: Partial<React.ComponentProps<typeof Sidebar>> = {}) {
   const props = {
     view: "discover" as const,
+    scope: "local" as const,
     discoverTechnique: "subgroup",
     collapsed: false,
     theme: "dark" as const,
     onSelectView: vi.fn(),
+    onSelectScope: vi.fn(),
     onSelectTechnique: vi.fn(),
     onToggleCollapsed: vi.fn(),
     onToggleTheme: vi.fn(),
@@ -27,15 +29,38 @@ function setup(overrides: Partial<React.ComponentProps<typeof Sidebar>> = {}) {
 }
 
 describe("Sidebar", () => {
-  it("renders the brand and primary nav", () => {
+  it("renders the brand and the local-scope nav", () => {
     setup();
     expect(screen.getByText("Session Analytics")).toBeInTheDocument();
     expect(screen.getByText("local, read-only session data")).toBeInTheDocument();
-    for (const name of ["Import", "Overview", "Cost", "Explore"]) {
+    for (const name of ["Import", "Export", "Overview", "Cost", "Explore"]) {
       expect(screen.getByRole("button", { name })).toBeInTheDocument();
     }
     expect(screen.queryByRole("button", { name: "Data" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Session" })).not.toBeInTheDocument();
+  });
+
+  it("shows only the aggregate views in team scope", () => {
+    setup({ scope: "team", view: "map" });
+    for (const name of ["Import", "Overview", "Cost"]) {
+      expect(screen.getByRole("button", { name })).toBeInTheDocument();
+    }
+    // Export (share a local bundle) and Explore (subgroup drilldown) have no
+    // team-bundle equivalent.
+    expect(screen.queryByRole("button", { name: "Export" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Explore" })).not.toBeInTheDocument();
+  });
+
+  it("renders the data-scope switch and routes scope changes", () => {
+    const props = setup({ scope: "local" });
+    const scopeGroup = screen.getByRole("group", { name: "Data scope" });
+    const thisMachine = within(scopeGroup).getByRole("button", { name: "This machine" });
+    const team = within(scopeGroup).getByRole("button", { name: "Team" });
+    expect(thisMachine).toHaveAttribute("aria-pressed", "true");
+    expect(team).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(team);
+    expect(props.onSelectScope).toHaveBeenCalledWith("team");
   });
 
   it("marks the active view and routes nav clicks", () => {
@@ -106,10 +131,12 @@ describe("Sidebar historical-pricing toggle", () => {
     render(
       <Sidebar
         view="map"
+        scope="local"
         discoverTechnique="subgroup"
         collapsed={false}
         theme="dark"
         onSelectView={vi.fn()}
+        onSelectScope={vi.fn()}
         onSelectTechnique={vi.fn()}
         onToggleCollapsed={vi.fn()}
         onToggleTheme={vi.fn()}
@@ -129,10 +156,12 @@ describe("Sidebar historical-pricing toggle", () => {
   it("reflects on/off state on the toggle button", () => {
     const base = {
       view: "map" as const,
+      scope: "local" as const,
       discoverTechnique: "subgroup",
       collapsed: false,
       theme: "dark" as const,
       onSelectView: vi.fn(),
+      onSelectScope: vi.fn(),
       onSelectTechnique: vi.fn(),
       onToggleCollapsed: vi.fn(),
       onToggleTheme: vi.fn(),

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -1,5 +1,5 @@
 // frontend/src/shell/Sidebar.tsx
-import { Eye, EyeOff, History, HelpCircle, Moon, PanelLeft, PanelLeftClose, Sun } from "lucide-react";
+import { Eye, EyeOff, History, HelpCircle, Monitor, Moon, PanelLeft, PanelLeftClose, Sun, Users } from "lucide-react";
 import { NAV_ITEMS, type View } from "./navConfig";
 import type { DataScope } from "./useDataScope";
 import { TECHNIQUES } from "../discover/techniques";
@@ -52,6 +52,10 @@ export default function Sidebar({
 }: Props) {
   const readyTechniques = TECHNIQUES.filter((tech) => tech.status === "ready");
   const navItems = NAV_ITEMS.filter((item) => item.scopes.includes(scope));
+  const scopeLabel = scope === "team" ? "Team" : "This machine";
+  const ScopeIcon = scope === "team" ? Users : Monitor;
+  const nextScope: DataScope = scope === "team" ? "local" : "team";
+  const nextScopeLabel = nextScope === "team" ? "Team" : "This machine";
 
   return (
     <aside className={`app-sidebar ${collapsed ? "is-collapsed" : ""}`} aria-label="Primary">
@@ -61,21 +65,6 @@ export default function Sidebar({
           <span className="sb-tagline">local, read-only session data</span>
         </div>
         <strong className="sb-monogram" aria-hidden="true">SA</strong>
-      </div>
-
-      <div className="sb-scope segmented-control" role="group" aria-label="Data scope">
-        {SCOPE_OPTIONS.map((option) => (
-          <button
-            key={option.key}
-            type="button"
-            className={scope === option.key ? "active" : ""}
-            aria-pressed={scope === option.key}
-            onClick={() => onSelectScope(option.key)}
-            title={option.key === "team" ? "Aggregated team bundles" : "This machine's local sessions"}
-          >
-            <span className="sb-label">{option.label}</span>
-          </button>
-        ))}
       </div>
 
       <nav className="sb-nav">
@@ -114,69 +103,98 @@ export default function Sidebar({
         })}
       </nav>
 
-      <div className="sb-foot">
-        <button
-          className={`sb-action ${privacyMode ? "is-active" : ""}`}
-          onClick={onTogglePrivacyMode}
-          aria-pressed={privacyMode}
-          aria-label="Privacy mode"
-          title={privacyMode ? "Privacy mode on — sensitive data is blurred" : "Privacy mode off — click to blur sensitive data"}
-        >
-          {privacyMode ? <EyeOff size={16} /> : <Eye size={16} />}
-        </button>
-        <button
-          className={`sb-action ${historicalPricing ? "is-active" : ""}`}
-          onClick={onToggleHistoricalPricing}
-          aria-pressed={historicalPricing}
-          aria-label="Historical pricing"
-          title={
-            historicalPricing
-              ? "Historical pricing on — spend uses rates effective on each session's date"
-              : "Historical pricing off — spend uses current rates for all sessions"
-          }
-        >
-          <History size={16} />
-        </button>
-        <div className="sb-glossary">
-          <button
-            className={`sb-action ${glossaryHint ? "is-hinted" : ""}`}
-            onClick={onOpenGlossary}
-            aria-label="Open glossary"
-            title="Open glossary"
-          >
-            <HelpCircle size={16} />
-          </button>
-          {glossaryHint && (
-            <div className="glossary-hint" role="note" aria-labelledby="glossary-hint-title">
-              <h4 id="glossary-hint-title">Not sure what a term means?</h4>
-              <p>Open the glossary any time for plain-English definitions — and how each score is computed.</p>
-              <div className="glossary-hint-actions">
-                <button type="button" className="ghint-primary" onClick={onOpenGlossary}>
-                  Browse glossary
-                </button>
-                <button type="button" className="ghint-secondary" onClick={() => onDismissGlossaryHint?.()}>
-                  Got it
-                </button>
-              </div>
-            </div>
-          )}
+      <div className="sb-bottom">
+        <div className="sb-scope-row">
+          <div className="sb-scope segmented-control" role="group" aria-label="Data scope">
+            {SCOPE_OPTIONS.map((option) => (
+              <button
+                key={option.key}
+                type="button"
+                className={scope === option.key ? "active" : ""}
+                aria-pressed={scope === option.key}
+                onClick={() => onSelectScope(option.key)}
+                title={option.key === "team" ? "Aggregated team bundles" : "This machine's local sessions"}
+              >
+                <span className="sb-label">{option.label}</span>
+              </button>
+            ))}
+          </div>
         </div>
-        <button
-          className="sb-action"
-          onClick={onToggleTheme}
-          aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
-          title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
-        >
-          {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
-        </button>
-        <button
-          className="sb-action sb-collapse"
-          onClick={onToggleCollapsed}
-          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-        >
-          {collapsed ? <PanelLeft size={16} /> : <PanelLeftClose size={16} />}
-        </button>
+
+        <div className="sb-foot">
+          <button
+            className={`sb-action sb-scope-action ${scope === "team" ? "is-active" : ""}`}
+            type="button"
+            aria-pressed={scope === "team"}
+            aria-label={`Data scope: ${scopeLabel}. Switch to ${nextScopeLabel}.`}
+            title={scope === "team" ? "Aggregated team bundles" : "This machine's local sessions"}
+            onClick={() => onSelectScope(nextScope)}
+          >
+            <ScopeIcon size={16} />
+          </button>
+          <button
+            className={`sb-action ${privacyMode ? "is-active" : ""}`}
+            onClick={onTogglePrivacyMode}
+            aria-pressed={privacyMode}
+            aria-label="Privacy mode"
+            title={privacyMode ? "Privacy mode on — sensitive data is blurred" : "Privacy mode off — click to blur sensitive data"}
+          >
+            {privacyMode ? <EyeOff size={16} /> : <Eye size={16} />}
+          </button>
+          <button
+            className={`sb-action ${historicalPricing ? "is-active" : ""}`}
+            onClick={onToggleHistoricalPricing}
+            aria-pressed={historicalPricing}
+            aria-label="Historical pricing"
+            title={
+              historicalPricing
+                ? "Historical pricing on — spend uses rates effective on each session's date"
+                : "Historical pricing off — spend uses current rates for all sessions"
+            }
+          >
+            <History size={16} />
+          </button>
+          <div className="sb-glossary">
+            <button
+              className={`sb-action ${glossaryHint ? "is-hinted" : ""}`}
+              onClick={onOpenGlossary}
+              aria-label="Open glossary"
+              title="Open glossary"
+            >
+              <HelpCircle size={16} />
+            </button>
+            {glossaryHint && (
+              <div className="glossary-hint" role="note" aria-labelledby="glossary-hint-title">
+                <h4 id="glossary-hint-title">Not sure what a term means?</h4>
+                <p>Open the glossary any time for plain-English definitions — and how each score is computed.</p>
+                <div className="glossary-hint-actions">
+                  <button type="button" className="ghint-primary" onClick={onOpenGlossary}>
+                    Browse glossary
+                  </button>
+                  <button type="button" className="ghint-secondary" onClick={() => onDismissGlossaryHint?.()}>
+                    Got it
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+          <button
+            className="sb-action"
+            onClick={onToggleTheme}
+            aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+            title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+          >
+            {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+          </button>
+          <button
+            className="sb-action sb-collapse"
+            onClick={onToggleCollapsed}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            {collapsed ? <PanelLeft size={16} /> : <PanelLeftClose size={16} />}
+          </button>
+        </div>
       </div>
     </aside>
   );

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -1,14 +1,22 @@
 // frontend/src/shell/Sidebar.tsx
 import { Eye, EyeOff, History, HelpCircle, Moon, PanelLeft, PanelLeftClose, Sun } from "lucide-react";
 import { NAV_ITEMS, type View } from "./navConfig";
+import type { DataScope } from "./useDataScope";
 import { TECHNIQUES } from "../discover/techniques";
+
+const SCOPE_OPTIONS: { key: DataScope; label: string }[] = [
+  { key: "local", label: "This machine" },
+  { key: "team", label: "Team" },
+];
 
 interface Props {
   view: View;
+  scope: DataScope;
   discoverTechnique: string;
   collapsed: boolean;
   theme: "dark" | "light";
   onSelectView: (view: View) => void;
+  onSelectScope: (scope: DataScope) => void;
   onSelectTechnique: (key: string) => void;
   onToggleCollapsed: () => void;
   onToggleTheme: () => void;
@@ -25,10 +33,12 @@ interface Props {
 
 export default function Sidebar({
   view,
+  scope,
   discoverTechnique,
   collapsed,
   theme,
   onSelectView,
+  onSelectScope,
   onSelectTechnique,
   onToggleCollapsed,
   onToggleTheme,
@@ -41,6 +51,7 @@ export default function Sidebar({
   onTogglePrivacyMode,
 }: Props) {
   const readyTechniques = TECHNIQUES.filter((tech) => tech.status === "ready");
+  const navItems = NAV_ITEMS.filter((item) => item.scopes.includes(scope));
 
   return (
     <aside className={`app-sidebar ${collapsed ? "is-collapsed" : ""}`} aria-label="Primary">
@@ -52,8 +63,23 @@ export default function Sidebar({
         <strong className="sb-monogram" aria-hidden="true">SA</strong>
       </div>
 
+      <div className="sb-scope segmented-control" role="group" aria-label="Data scope">
+        {SCOPE_OPTIONS.map((option) => (
+          <button
+            key={option.key}
+            type="button"
+            className={scope === option.key ? "active" : ""}
+            aria-pressed={scope === option.key}
+            onClick={() => onSelectScope(option.key)}
+            title={option.key === "team" ? "Aggregated team bundles" : "This machine's local sessions"}
+          >
+            <span className="sb-label">{option.label}</span>
+          </button>
+        ))}
+      </div>
+
       <nav className="sb-nav">
-        {NAV_ITEMS.map((item) => {
+        {navItems.map((item) => {
           const Icon = item.icon;
           const active = view === item.key;
           return (

--- a/frontend/src/shell/navConfig.ts
+++ b/frontend/src/shell/navConfig.ts
@@ -1,18 +1,26 @@
 import type { LucideIcon } from "lucide-react";
-import { DollarSign, LayoutDashboard, Sparkles, Upload } from "lucide-react";
+import { DollarSign, Download, LayoutDashboard, Sparkles, Upload } from "lucide-react";
+import type { DataScope } from "./useDataScope";
 
-export type View = "import" | "map" | "session" | "cost" | "discover";
+export type View = "import" | "export" | "map" | "session" | "cost" | "discover";
 
 export interface NavItem {
   key: View;
   label: string;
   icon: LucideIcon;
+  // Which data scopes expose this view. Team scope only surfaces the aggregate
+  // views; per-session drilldowns have no team equivalent by design.
+  scopes: DataScope[];
 }
 
 // Order matters: this is the visible top-to-bottom order in the sidebar.
+// "Import" is scope-aware in content: local imports source projects, team imports
+// shared bundles. "Export" (share a local bundle) is local-only — a team user has
+// nothing of their own to export from aggregated bundles.
 export const NAV_ITEMS: NavItem[] = [
-  { key: "import", label: "Import", icon: Upload },
-  { key: "map", label: "Overview", icon: LayoutDashboard },
-  { key: "cost", label: "Cost", icon: DollarSign },
-  { key: "discover", label: "Explore", icon: Sparkles },
+  { key: "import", label: "Import", icon: Upload, scopes: ["local", "team"] },
+  { key: "export", label: "Export", icon: Download, scopes: ["local"] },
+  { key: "map", label: "Overview", icon: LayoutDashboard, scopes: ["local", "team"] },
+  { key: "cost", label: "Cost", icon: DollarSign, scopes: ["local", "team"] },
+  { key: "discover", label: "Explore", icon: Sparkles, scopes: ["local"] },
 ];

--- a/frontend/src/shell/useDataScope.test.tsx
+++ b/frontend/src/shell/useDataScope.test.tsx
@@ -1,0 +1,29 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useDataScope } from "./useDataScope";
+
+describe("useDataScope", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("defaults to local when nothing is stored", () => {
+    const { result } = renderHook(() => useDataScope());
+    expect(result.current.scope).toBe("local");
+  });
+
+  it("persists the scope and rehydrates it on a fresh mount", () => {
+    const first = renderHook(() => useDataScope());
+    act(() => first.result.current.setScope("team"));
+    expect(first.result.current.scope).toBe("team");
+    expect(localStorage.getItem("ccfr.dataScope")).toBe("team");
+
+    const second = renderHook(() => useDataScope());
+    expect(second.result.current.scope).toBe("team");
+  });
+
+  it("ignores an unrecognized stored value", () => {
+    localStorage.setItem("ccfr.dataScope", "bogus");
+    const { result } = renderHook(() => useDataScope());
+    expect(result.current.scope).toBe("local");
+  });
+});

--- a/frontend/src/shell/useDataScope.ts
+++ b/frontend/src/shell/useDataScope.ts
@@ -1,0 +1,32 @@
+import React from "react";
+
+// Which dataset the app is looking at: the single-user local index on this
+// machine, or the aggregated team bundles. A pure client-side UI lens
+// (persisted to localStorage), not server state.
+export type DataScope = "local" | "team";
+
+const STORAGE_KEY = "ccfr.dataScope";
+
+function getInitial(): DataScope {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "team" ? "team" : "local";
+  } catch {
+    return "local";
+  }
+}
+
+export function useDataScope() {
+  const [scope, setScopeState] = React.useState<DataScope>(getInitial);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, scope);
+    } catch {
+      /* ignore */
+    }
+  }, [scope]);
+
+  const setScope = React.useCallback((next: DataScope) => setScopeState(next), []);
+
+  return { scope, setScope };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1475,6 +1475,7 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
   .app-sidebar .sb-tag,
   .app-sidebar .sb-brand-text,
   .app-sidebar .sb-subnav { display: none; }
+  .app-sidebar .sb-scope.segmented-control { display: none; }
   .app-sidebar .sb-brand { justify-content: center; }
   .app-sidebar .sb-monogram { display: block; }
   .app-sidebar .sb-item { justify-content: center; padding: 9px 0; }
@@ -3250,6 +3251,130 @@ html:has(.specimen-dialog[open]) {
   overflow-y: auto;
 }
 
+.team-overview-page {
+  min-height: 0;
+}
+
+.team-flow-page {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.team-flow-header {
+  flex: none;
+}
+
+.team-flow-metrics .contribute-metric strong.team-metric-text {
+  font-family: inherit;
+  letter-spacing: 0;
+}
+
+.team-flow-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: 14px;
+  overflow: hidden;
+}
+
+.team-export-layout {
+  grid-template-columns: minmax(320px, 0.92fr) minmax(0, 1.28fr);
+}
+
+.team-import-layout {
+  grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.3fr);
+}
+
+.team-flow-column {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: hidden;
+}
+
+.team-flow-column-wide {
+  min-width: 0;
+}
+
+.team-flow-card {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.team-flow-card-body {
+  min-height: 0;
+  padding: 14px 16px;
+}
+
+.team-flow-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.team-flow-copy {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.team-flow-errors {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.team-scroll-card {
+  flex: 1;
+}
+
+.team-flow-scroll-body {
+  min-height: 0;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.team-ledger-card {
+  flex: 1;
+}
+
+.team-ledger-card .privacy-ledger {
+  border-radius: inherit;
+}
+
+.team-overview-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: hidden;
+}
+
+.team-overview-board {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+  padding-bottom: 6px;
+}
+
 .team-titleblock {
   gap: 12px;
 }
@@ -3349,14 +3474,31 @@ html:has(.specimen-dialog[open]) {
 
 .team-import-controls {
   width: 100%;
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 10px;
+}
+
+.team-path-field,
+.team-import-controls input {
+  min-width: 0;
+}
+
+.team-path-field {
+  display: grid;
+  gap: 5px;
+}
+
+.team-path-field span {
+  color: var(--muted);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: .05em;
+  text-transform: uppercase;
 }
 
 .team-import-controls input {
-  min-width: 0;
-  flex: 1 1 auto;
   height: 36px;
   border: 1px solid var(--border-2);
   border-radius: 9px;
@@ -3379,7 +3521,6 @@ html:has(.specimen-dialog[open]) {
 
 .team-file-picker {
   min-width: 0;
-  flex: 1.1 1 240px;
   display: grid;
   gap: 5px;
 }
@@ -3415,6 +3556,7 @@ html:has(.specimen-dialog[open]) {
 
 .team-symbols {
   padding: 14px 16px;
+  flex: none;
 }
 
 .team-symbols-head,
@@ -3458,6 +3600,10 @@ html:has(.specimen-dialog[open]) {
   list-style: none;
   margin: 0;
   padding: 0;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .team-import-list li {
@@ -3479,6 +3625,14 @@ html:has(.specimen-dialog[open]) {
   display: flex;
   flex-direction: column;
   gap: 3px;
+}
+
+.team-import-member-head {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
 }
 
 .team-import-list li strong {
@@ -3523,6 +3677,15 @@ html:has(.specimen-dialog[open]) {
 @media (max-width: 960px) {
   .contribute-header,
   .contribute-flow {
+    grid-template-columns: 1fr;
+  }
+
+  .team-export-layout,
+  .team-import-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .team-import-controls {
     grid-template-columns: 1fr;
   }
 
@@ -3675,6 +3838,7 @@ html:has(.specimen-dialog[open]) {
 
 .team-activity {
   padding: 14px 16px;
+  flex: none;
 }
 
 .team-activity-svg {
@@ -3696,6 +3860,7 @@ html:has(.specimen-dialog[open]) {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
+  flex: none;
 }
 
 .team-bars {
@@ -3840,8 +4005,8 @@ html:has(.specimen-dialog[open]) {
 
 .team-level-selector {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
-  margin-top: 12px;
 }
 .team-level {
   display: inline-flex;
@@ -3865,62 +4030,143 @@ html:has(.specimen-dialog[open]) {
   cursor: not-allowed;
 }
 .team-level-hint {
-  margin: 6px 0 0;
+  margin: 0;
   font-size: 12.5px;
-  opacity: 0.75;
+  color: var(--muted);
 }
 .team-member-name {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 12px;
-  font-size: 13px;
-}
-.team-member-name input {
-  flex: 1;
-  max-width: 340px;
-}
-.team-project-picker {
-  margin-top: 14px;
-}
-.team-picker-note {
-  margin: 6px 0 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
   font-size: 12px;
   color: var(--muted);
 }
+.team-member-name input {
+  width: min(100%, 360px);
+  height: 34px;
+  border: 1px solid var(--border-2);
+  border-radius: 9px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  outline: 0;
+  padding: 0 10px;
+}
+.team-member-name input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+.team-project-picker {
+  min-height: 0;
+}
+.team-picker-note {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
 .team-project-picker ul {
   list-style: none;
-  margin: 8px 0 0;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  max-height: 200px;
+  gap: 8px;
+  min-height: 0;
+  flex: 1;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .team-project-picker li {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+}
+.team-project-picker li.is-disabled {
+  opacity: 0.72;
+}
+.team-project-picker li input[type="checkbox"] {
+  flex: none;
+  margin: 0;
+  accent-color: var(--accent);
+}
+.team-project-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }
 .team-project-label {
-  flex: 1;
-  max-width: 340px;
+  width: 100%;
+  max-width: none;
+  height: 32px;
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  outline: 0;
+  padding: 0 9px;
+}
+.team-project-label:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+.team-project-label:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 .team-project-label-static {
-  flex: 1;
+  min-width: 0;
+  color: var(--text-strong);
+  font-size: 12.5px;
+  overflow-wrap: anywhere;
+}
+.team-project-export-id {
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  overflow-wrap: anywhere;
 }
 .team-project-meta {
+  text-align: right;
   font-size: 12px;
-  opacity: 0.7;
-  white-space: nowrap;
+  color: var(--muted);
 }
 .team-level-tag {
-  display: inline-block;
-  margin-left: 8px;
-  padding: 1px 7px;
-  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  max-width: 100%;
+  padding: 1px 6px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
   border-radius: 999px;
-  font-size: 11px;
-  opacity: 0.75;
+  background: color-mix(in srgb, var(--bg) 74%, var(--surface));
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1.35;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.team-level-tag[data-level="team"] {
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+  color: color-mix(in srgb, var(--accent) 72%, var(--text));
+}
+
+.team-level-tag[data-level="structural"] {
+  border-color: color-mix(in srgb, var(--success) 18%, var(--border));
+  background: color-mix(in srgb, var(--success) 8%, var(--surface));
+  color: color-mix(in srgb, var(--success) 55%, var(--text));
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3837,3 +3837,76 @@ html:has(.specimen-dialog[open]) {
     grid-template-columns: 1fr;
   }
 }
+
+.team-level-selector {
+  display: flex;
+  gap: 6px;
+  margin-top: 12px;
+}
+.team-level {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+.team-level.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.team-level.planned {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.team-level-hint {
+  margin: 6px 0 0;
+  font-size: 12.5px;
+  opacity: 0.75;
+}
+.team-member-name {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  font-size: 13px;
+}
+.team-member-name input {
+  flex: 1;
+  max-width: 340px;
+}
+.team-project-picker {
+  margin-top: 14px;
+}
+.team-project-picker ul {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.team-project-picker li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.team-project-label {
+  flex: 1;
+  max-width: 340px;
+}
+.team-project-label-static {
+  flex: 1;
+}
+.team-project-meta {
+  font-size: 12px;
+  opacity: 0.7;
+  white-space: nowrap;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3883,6 +3883,11 @@ html:has(.specimen-dialog[open]) {
 .team-project-picker {
   margin-top: 14px;
 }
+.team-picker-note {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+}
 .team-project-picker ul {
   list-style: none;
   margin: 8px 0 0;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3463,7 +3463,8 @@ html:has(.specimen-dialog[open]) {
 .team-import-list li {
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(180px, .7fr);
+  grid-template-columns: minmax(0, 1fr) minmax(180px, .7fr) auto;
+  align-items: center;
   gap: 12px;
   padding: 12px 16px;
   border-top: 1px solid var(--border);
@@ -3499,6 +3500,23 @@ html:has(.specimen-dialog[open]) {
 
 .team-import-list > p {
   padding: 14px 16px;
+}
+
+.team-remove-member {
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--err);
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.team-remove-member:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--err) 45%, var(--border-2));
+  background: color-mix(in srgb, var(--err) 8%, var(--bg));
 }
 
 /* ---- Responsive ---- */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -115,7 +115,32 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .sb-tag { margin-left: auto; font-style: normal; font-size: 8.5px; letter-spacing: .5px;
   color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 1px 6px; }
 
-.sb-foot { margin-top: auto; display: flex; gap: 8px; padding-top: 8px; }
+.sb-bottom {
+  margin-top: auto;
+}
+
+.sb-scope-row {
+  padding-top: 8px;
+}
+
+.sb-scope-row .sb-scope.segmented-control {
+  display: flex;
+  align-self: stretch;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.sb-scope-row .sb-scope.segmented-control button {
+  flex: 1 1 0;
+  justify-content: center;
+  text-align: center;
+}
+
+.sb-foot .sb-scope-action {
+  display: none;
+}
+
+.sb-foot { display: flex; gap: 8px; padding-top: 8px; }
 .sb-action {
   width: 34px; height: 34px; display: grid; place-items: center;
   border: 1px solid var(--border); background: var(--bg); color: var(--muted); border-radius: 9px;
@@ -139,6 +164,9 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .app-sidebar.is-collapsed .sb-brand { justify-content: center; }
 .app-sidebar.is-collapsed .sb-monogram { display: block; }
 .app-sidebar.is-collapsed .sb-item { justify-content: center; padding: 9px 0; }
+.app-sidebar.is-collapsed .sb-bottom { margin-top: auto; }
+.app-sidebar.is-collapsed .sb-scope-row { display: none; }
+.app-sidebar.is-collapsed .sb-foot .sb-scope-action { display: grid; }
 .app-sidebar.is-collapsed .sb-foot { flex-direction: column; align-items: center; }
 .app-sidebar.is-collapsed .sb-collapse { margin-left: 0; }
 
@@ -1475,7 +1503,8 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
   .app-sidebar .sb-tag,
   .app-sidebar .sb-brand-text,
   .app-sidebar .sb-subnav { display: none; }
-  .app-sidebar .sb-scope.segmented-control { display: none; }
+  .app-sidebar .sb-scope-row { display: none; }
+  .app-sidebar .sb-scope-action { display: grid; }
   .app-sidebar .sb-brand { justify-content: center; }
   .app-sidebar .sb-monogram { display: block; }
   .app-sidebar .sb-item { justify-content: center; padding: 9px 0; }
@@ -2867,6 +2896,9 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
 
 .privacy-column {
   min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
   padding: 14px 16px;
 }
 
@@ -2899,6 +2931,10 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
   padding: 0;
   display: grid;
   gap: 9px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .privacy-column li {
@@ -3535,7 +3571,53 @@ html:has(.specimen-dialog[open]) {
 
 .team-file-picker input[type="file"] {
   width: 100%;
-  padding-top: 7px;
+  height: 36px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border-2);
+  border-radius: 9px;
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 11.5px;
+  padding: 0 8px;
+}
+
+.team-file-picker input[type="file"]::file-selector-button {
+  margin-right: 10px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-2);
+  border-radius: 7px;
+  background: var(--track);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.team-file-picker input[type="file"]::file-selector-button:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-2));
+  color: var(--accent);
+}
+
+/* Selection count + batch progress sit on their own line below the row. */
+.team-file-count,
+.team-import-progress {
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+}
+
+.team-import-results {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.team-import-results .flow-result.flow-error {
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
 }
 
 .team-mini-summary {
@@ -3801,21 +3883,6 @@ html:has(.specimen-dialog[open]) {
 }
 
 /* ---- Team context (data-scope switch + team overview) -------------------- */
-.sb-scope.segmented-control {
-  display: flex;
-  align-self: stretch;
-  margin-bottom: 8px;
-}
-
-.sb-scope.segmented-control button {
-  flex: 1 1 0;
-  justify-content: center;
-  text-align: center;
-}
-
-.app-sidebar.is-collapsed .sb-scope {
-  display: none;
-}
 
 .team-empty {
   display: flex;
@@ -4130,11 +4197,39 @@ html:has(.specimen-dialog[open]) {
   font-size: 12.5px;
   overflow-wrap: anywhere;
 }
-.team-project-export-id {
+.team-project-label-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.team-project-label-row .team-project-label-static {
+  flex: 1;
+}
+.team-project-edit {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  /* Negative block margin keeps a 20px hit target without letting the icon
+     grow the row past the name text, so structural and team rows match height. */
+  margin-block: -5px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
   color: var(--faint);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  overflow-wrap: anywhere;
+  cursor: pointer;
+  transition: color .12s ease, background .12s ease;
+}
+.team-project-edit:hover {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.team-project-edit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 .team-project-meta {
   text-align: right;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3910,3 +3910,12 @@ html:has(.specimen-dialog[open]) {
   opacity: 0.7;
   white-space: nowrap;
 }
+.team-level-tag {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 11px;
+  opacity: 0.75;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -327,7 +327,9 @@ html:has(.glossary-dialog[open]) { overflow: hidden; }
 }
 
 .page { flex: 1; width: 100%; max-width: var(--page-max-width); margin: 0 auto; padding: 22px var(--page-gutter); }
-.import-page { overflow: auto; width: 100%; }
+.import-page,
+.team-export-page,
+.team-import-page { overflow: auto; width: 100%; }
 
 /* Source console — the scan / import / cache control surface. */
 .source-console {
@@ -3243,6 +3245,262 @@ html:has(.specimen-dialog[open]) {
   white-space: pre;
 }
 
+/* ---- Team bundle sharing -------------------------------------------------- */
+.team-page {
+  overflow-y: auto;
+}
+
+.team-titleblock {
+  gap: 12px;
+}
+
+.team-root-row {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.team-root-row span {
+  flex: none;
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.team-root-row code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-strong);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.team-tabs {
+  flex: none;
+}
+
+.team-metrics {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.team-metrics .contribute-metric + .contribute-metric {
+  border-top: 0;
+}
+
+.team-metrics .contribute-metric:nth-child(even) {
+  border-left: 1px solid var(--border);
+}
+
+.team-metrics .contribute-metric:nth-child(n + 3) {
+  border-top: 1px solid var(--border);
+}
+
+.team-dashboard-strip,
+.team-symbols,
+.team-import-list {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.team-dashboard-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.team-dashboard-strip > div {
+  min-width: 0;
+  padding: 13px 16px;
+}
+
+.team-dashboard-strip > div + div {
+  border-left: 1px solid var(--border);
+}
+
+.team-dashboard-strip span,
+.team-symbols-head span,
+.team-import-list p,
+.team-import-list li span {
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.team-dashboard-strip span {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.team-dashboard-strip strong {
+  color: var(--text-strong);
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+
+.team-member-flow,
+.team-manager-flow {
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.team-import-controls {
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.team-import-controls input {
+  min-width: 0;
+  flex: 1 1 auto;
+  height: 36px;
+  border: 1px solid var(--border-2);
+  border-radius: 9px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  outline: 0;
+  padding: 0 10px;
+}
+
+.team-import-controls > input {
+  flex: 1 1 220px;
+}
+
+.team-import-controls input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.team-file-picker {
+  min-width: 0;
+  flex: 1.1 1 240px;
+  display: grid;
+  gap: 5px;
+}
+
+.team-file-picker span {
+  color: var(--muted);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.team-file-picker input[type="file"] {
+  width: 100%;
+  padding-top: 7px;
+}
+
+.team-mini-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.team-mini-summary span {
+  padding: 3px 8px;
+  border: 1px solid var(--border-2);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.team-symbols {
+  padding: 14px 16px;
+}
+
+.team-symbols-head,
+.team-import-list-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.team-symbols h2,
+.team-import-list h2 {
+  color: var(--text-strong);
+  font-size: 15.5px;
+}
+
+.team-symbols p,
+.team-import-list p {
+  margin: 0;
+}
+
+.team-symbols .seq-chip em {
+  margin-left: 4px;
+  color: var(--text-strong);
+  font-style: normal;
+}
+
+.team-import-list-head {
+  margin: 0;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.team-import-list-head strong {
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+
+.team-import-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.team-import-list li {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, .7fr);
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.team-import-list li:first-child {
+  border-top: 0;
+}
+
+.team-import-list li > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.team-import-list li strong {
+  min-width: 0;
+  color: var(--text-strong);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.team-import-list code {
+  min-width: 0;
+  align-self: center;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  overflow-wrap: anywhere;
+}
+
+.team-import-list > p {
+  padding: 14px 16px;
+}
+
 /* ---- Responsive ---- */
 @media (max-width: 960px) {
   .contribute-header,
@@ -3261,6 +3519,22 @@ html:has(.specimen-dialog[open]) {
 
   .flow-arrow {
     display: none;
+  }
+
+  .team-dashboard-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .team-dashboard-strip > div + div {
+    border-left: 0;
+  }
+
+  .team-dashboard-strip > div:nth-child(even) {
+    border-left: 1px solid var(--border);
+  }
+
+  .team-dashboard-strip > div:nth-child(n + 3) {
+    border-top: 1px solid var(--border);
   }
 }
 
@@ -3298,6 +3572,35 @@ html:has(.specimen-dialog[open]) {
     align-items: flex-start;
     gap: 8px;
   }
+
+  .team-dashboard-strip,
+  .team-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .team-dashboard-strip > div:nth-child(even),
+  .team-metrics .contribute-metric:nth-child(even) {
+    border-left: 0;
+  }
+
+  .team-dashboard-strip > div + div,
+  .team-metrics .contribute-metric + .contribute-metric {
+    border-top: 1px solid var(--border);
+  }
+
+  .team-import-controls,
+  .team-import-list li {
+    grid-template-columns: 1fr;
+  }
+
+  .team-import-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .team-import-list code {
+    align-self: start;
+  }
 }
 
 @media (max-width: 560px) {
@@ -3313,5 +3616,206 @@ html:has(.specimen-dialog[open]) {
   .specimen-facts > div {
     grid-template-columns: 1fr;
     gap: 3px;
+  }
+}
+
+/* ---- Team context (data-scope switch + team overview) -------------------- */
+.sb-scope.segmented-control {
+  display: flex;
+  align-self: stretch;
+  margin-bottom: 8px;
+}
+
+.sb-scope.segmented-control button {
+  flex: 1 1 0;
+  justify-content: center;
+  text-align: center;
+}
+
+.app-sidebar.is-collapsed .sb-scope {
+  display: none;
+}
+
+.team-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 22px;
+}
+
+.team-empty strong {
+  color: var(--text-strong);
+  font-size: 15px;
+}
+
+.team-empty p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.team-activity {
+  padding: 14px 16px;
+}
+
+.team-activity-svg {
+  width: 100%;
+  height: 130px;
+  display: block;
+}
+
+.team-activity-area {
+  fill: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.team-activity-line {
+  stroke: var(--accent);
+  stroke-width: 2;
+}
+
+.team-breakdowns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.team-bars {
+  padding: 14px 16px;
+}
+
+.team-bars h2,
+.team-activity h2 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 14px;
+}
+
+.team-bar-rows {
+  display: grid;
+  gap: 9px;
+}
+
+.team-bar-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 140px) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.team-bar-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 11.5px;
+  text-transform: capitalize;
+}
+
+.team-bar-track {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.team-bar-track i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.team-bar-val {
+  color: var(--text-strong);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.team-data-sources {
+  margin-top: 4px;
+}
+
+.team-ds-root {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 12px 16px 0;
+}
+
+.team-ds-root span {
+  flex: none;
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.team-ds-root code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-strong);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.team-ds-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  padding: 14px 16px;
+}
+
+.team-ds-col {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.team-ds-col h3 {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-strong);
+  font-size: 13px;
+}
+
+.team-ds-col p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* Single-column body for the split export / import views (each is its own page
+   now, so there's no side-by-side grid). */
+.team-ds-single {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 14px 16px;
+}
+
+.team-ds-single p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.team-import-list-head h3 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 13px;
+}
+
+@media (max-width: 720px) {
+  .team-breakdowns,
+  .team-ds-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/team/TeamBundleExport.test.tsx
+++ b/frontend/src/team/TeamBundleExport.test.tsx
@@ -68,6 +68,11 @@ describe("TeamBundleExport", () => {
     expect(screen.getByRole("button", { name: /Raw/ })).toBeDisabled();
   });
 
+  it("documents the snapshot-replace and deselection behavior in the project picker", async () => {
+    renderExport();
+    expect(await screen.findByText(/replaces your entire previous bundle/i)).toBeInTheDocument();
+  });
+
   it("defaults every project to selected and exports a structural bundle without a name", async () => {
     renderExport();
     const exportBtn = await screen.findByRole("button", { name: /Export bundle/i });

--- a/frontend/src/team/TeamBundleExport.test.tsx
+++ b/frontend/src/team/TeamBundleExport.test.tsx
@@ -6,20 +6,30 @@ import TeamBundleExport from "./TeamBundleExport";
 vi.mock("../api/client", () => ({
   getRuntimeConfig: vi.fn(),
   getTeamPreview: vi.fn(),
+  getTeamProjects: vi.fn(),
   exportTeamBundle: vi.fn(),
 }));
 
-import { exportTeamBundle, getRuntimeConfig, getTeamPreview } from "../api/client";
+import { exportTeamBundle, getRuntimeConfig, getTeamPreview, getTeamProjects } from "../api/client";
 
 const previewPayload = {
   manifest: {
-    session_count: 2,
+    privacy_level: "structural",
+    session_count: 3,
     sequence_step_count: 3,
     included_fields: ["Token counts + cache breakdown"],
     excluded: ["Prompts and your messages", "File paths"],
     fingerprint_caveat: "Local team bundles are structural fingerprints.",
   },
   bundle: { sessions: [{ sid: "s-a", models: ["claude-opus-4-8"], sequence: [] }] },
+};
+
+const projectsPayload = {
+  projects: [
+    { export_name: "d--Alpha", default_label: "alpha", session_count: 2, tokens: 1200 },
+    { export_name: "d--Beta", default_label: "beta", session_count: 1, tokens: 300 },
+  ],
+  prefs: {},
 };
 
 function renderExport() {
@@ -40,47 +50,100 @@ describe("TeamBundleExport", () => {
       database_path: "D:\\Data\\ccfr.sqlite3",
       is_docker: false,
     } as never);
+    vi.mocked(getTeamProjects).mockResolvedValue(projectsPayload as never);
     vi.mocked(getTeamPreview).mockResolvedValue(previewPayload as never);
     vi.mocked(exportTeamBundle).mockResolvedValue({
       path: "D:\\TeamBundles\\team-bundle-a.json",
       bundle_id: "bundle-a",
-      session_count: 2,
+      session_count: 3,
     } as never);
   });
 
-  it("renders the export control, the root, and the privacy ledger — but no import controls", async () => {
+  it("renders the level ladder with structural active and future rungs disabled", async () => {
     renderExport();
-
-    expect(await screen.findByRole("heading", { name: /Export a team bundle/i })).toBeInTheDocument();
-    expect(await screen.findByText("D:\\TeamBundles")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Export bundle/i })).toBeInTheDocument();
-    expect(await screen.findByText(/What stays vs. what goes into the team bundle/i)).toBeInTheDocument();
-
-    // Import lives on its own view now — nothing to import from here.
-    expect(screen.queryByLabelText("Choose local team bundle file")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Import bundle" })).not.toBeInTheDocument();
+    const structural = await screen.findByRole("radio", { name: "Structural" });
+    expect(structural).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: "Team" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("button", { name: /Sessions/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Raw/ })).toBeDisabled();
   });
 
-  it("exports a team bundle and shows the written path", async () => {
+  it("defaults every project to selected and exports a structural bundle without a name", async () => {
     renderExport();
-
     const exportBtn = await screen.findByRole("button", { name: /Export bundle/i });
     await waitFor(() => expect(exportBtn).toBeEnabled());
     fireEvent.click(exportBtn);
 
     await waitFor(() => expect(exportTeamBundle).toHaveBeenCalledTimes(1));
+    const body = vi.mocked(exportTeamBundle).mock.calls[0][0];
+    expect(body.privacy_level).toBe("structural");
+    expect(body.member_name).toBeNull();
+    expect(body.projects.map((p) => p.export_name)).toEqual(["d--Alpha", "d--Beta"]);
     expect(await screen.findByText(/team-bundle-a\.json/)).toBeInTheDocument();
   });
 
-  it("disables export when the local machine has no sessions", async () => {
+  it("requires a member name at the team level", async () => {
+    renderExport();
+    fireEvent.click(await screen.findByRole("radio", { name: "Team" }));
+    const exportBtn = screen.getByRole("button", { name: /Export bundle/i });
+    await waitFor(() => expect(exportBtn).toBeDisabled());
+    expect(screen.getByText(/Enter your name to export a team-level bundle/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Team member name"), { target: { value: "Avery" } });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+    await waitFor(() => expect(exportTeamBundle).toHaveBeenCalled());
+    const body = vi.mocked(exportTeamBundle).mock.calls[0][0];
+    expect(body.privacy_level).toBe("team");
+    expect(body.member_name).toBe("Avery");
+  });
+
+  it("drops deselected projects from the export body", async () => {
+    renderExport();
+    fireEvent.click(await screen.findByLabelText("Include beta"));
+    const exportBtn = screen.getByRole("button", { name: /Export bundle/i });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+    await waitFor(() => expect(exportTeamBundle).toHaveBeenCalled());
+    const body = vi.mocked(exportTeamBundle).mock.calls[0][0];
+    expect(body.projects.map((p) => p.export_name)).toEqual(["d--Alpha"]);
+  });
+
+  it("sends edited labels committed on blur", async () => {
+    renderExport();
+    fireEvent.click(await screen.findByRole("radio", { name: "Team" }));
+    const label = await screen.findByLabelText("Label for alpha");
+    fireEvent.change(label, { target: { value: "Payments API" } });
+    fireEvent.blur(label);
+    fireEvent.change(screen.getByLabelText("Team member name"), { target: { value: "Avery" } });
+
+    const exportBtn = screen.getByRole("button", { name: /Export bundle/i });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+    await waitFor(() => expect(exportTeamBundle).toHaveBeenCalled());
+    const body = vi.mocked(exportTeamBundle).mock.calls[0][0];
+    expect(body.projects.find((p) => p.export_name === "d--Alpha")?.label).toBe("Payments API");
+  });
+
+  it("prefills level, name, and deselection from persisted prefs", async () => {
+    vi.mocked(getTeamProjects).mockResolvedValue({
+      ...projectsPayload,
+      prefs: { member_name: "Avery", privacy_level: "team", deselected: ["d--Beta"], project_labels: {} },
+    } as never);
+    renderExport();
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Team" })).toHaveAttribute("aria-checked", "true"));
+    expect(screen.getByLabelText("Team member name")).toHaveValue("Avery");
+    expect(screen.getByLabelText("Include beta")).not.toBeChecked();
+  });
+
+  it("disables export when the selection has no sessions", async () => {
     vi.mocked(getTeamPreview).mockResolvedValue({
       manifest: { ...previewPayload.manifest, session_count: 0 },
       bundle: { sessions: [] },
     } as never);
     renderExport();
-
     const exportBtn = await screen.findByRole("button", { name: /Export bundle/i });
     await waitFor(() => expect(exportBtn).toBeDisabled());
-    expect(screen.getByText(/No local sessions are available for export/i)).toBeInTheDocument();
+    expect(screen.getByText(/No sessions in the current selection/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/team/TeamBundleExport.test.tsx
+++ b/frontend/src/team/TeamBundleExport.test.tsx
@@ -114,12 +114,17 @@ describe("TeamBundleExport", () => {
     expect(body.projects.map((p) => p.export_name)).toEqual(["d--Alpha"]);
   });
 
-  it("sends edited labels committed on blur", async () => {
+  it("reveals the label input only after clicking rename, then commits on blur", async () => {
     renderExport();
     fireEvent.click(await screen.findByRole("radio", { name: "Team" }));
+    // Names render read-only until the per-project edit button is used.
+    expect(screen.queryByLabelText("Label for alpha")).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: "Rename alpha" }));
     const label = await screen.findByLabelText("Label for alpha");
     fireEvent.change(label, { target: { value: "Payments API" } });
     fireEvent.blur(label);
+    // Committing hides the input again.
+    expect(screen.queryByLabelText("Label for alpha")).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Team member name"), { target: { value: "Avery" } });
 
     const exportBtn = screen.getByRole("button", { name: /Export bundle/i });

--- a/frontend/src/team/TeamBundleExport.test.tsx
+++ b/frontend/src/team/TeamBundleExport.test.tsx
@@ -136,6 +136,33 @@ describe("TeamBundleExport", () => {
     expect(screen.getByLabelText("Include beta")).not.toBeChecked();
   });
 
+  it("never sends a member name in a structural export after a team prefill", async () => {
+    // A returning user whose last export was team-level has a persisted name in prefs.
+    vi.mocked(getTeamProjects).mockResolvedValue({
+      ...projectsPayload,
+      prefs: { member_name: "Avery", privacy_level: "team", deselected: [], project_labels: {} },
+    } as never);
+    renderExport();
+    // Prefilled to team; the name field is visible and holds "Avery"...
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Team" })).toHaveAttribute("aria-checked", "true"));
+    // ...then they drop back to Structural, where the name field is no longer rendered.
+    fireEvent.click(screen.getByRole("radio", { name: "Structural" }));
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: "Structural" })).toHaveAttribute("aria-checked", "true"),
+    );
+    expect(screen.queryByLabelText("Team member name")).not.toBeInTheDocument();
+
+    const exportBtn = screen.getByRole("button", { name: /Export bundle/i });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+
+    await waitFor(() => expect(exportTeamBundle).toHaveBeenCalled());
+    const body = vi.mocked(exportTeamBundle).mock.calls[0][0];
+    // A structural bundle must never carry a name, even one left over from prefs.
+    expect(body.privacy_level).toBe("structural");
+    expect(body.member_name).toBeNull();
+  });
+
   it("disables export when the selection has no sessions", async () => {
     vi.mocked(getTeamPreview).mockResolvedValue({
       manifest: { ...previewPayload.manifest, session_count: 0 },

--- a/frontend/src/team/TeamBundleExport.test.tsx
+++ b/frontend/src/team/TeamBundleExport.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TeamBundleExport from "./TeamBundleExport";
+
+vi.mock("../api/client", () => ({
+  getRuntimeConfig: vi.fn(),
+  getTeamPreview: vi.fn(),
+  exportTeamBundle: vi.fn(),
+}));
+
+import { exportTeamBundle, getRuntimeConfig, getTeamPreview } from "../api/client";
+
+const previewPayload = {
+  manifest: {
+    session_count: 2,
+    sequence_step_count: 3,
+    included_fields: ["Token counts + cache breakdown"],
+    excluded: ["Prompts and your messages", "File paths"],
+    fingerprint_caveat: "Local team bundles are structural fingerprints.",
+  },
+  bundle: { sessions: [{ sid: "s-a", models: ["claude-opus-4-8"], sequence: [] }] },
+};
+
+function renderExport() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <TeamBundleExport />
+    </QueryClientProvider>,
+  );
+}
+
+describe("TeamBundleExport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRuntimeConfig).mockResolvedValue({
+      import_root: "D:\\Data",
+      team_bundle_root: "D:\\TeamBundles",
+      database_path: "D:\\Data\\ccfr.sqlite3",
+      is_docker: false,
+    } as never);
+    vi.mocked(getTeamPreview).mockResolvedValue(previewPayload as never);
+    vi.mocked(exportTeamBundle).mockResolvedValue({
+      path: "D:\\TeamBundles\\team-bundle-a.json",
+      bundle_id: "bundle-a",
+      session_count: 2,
+    } as never);
+  });
+
+  it("renders the export control, the root, and the privacy ledger — but no import controls", async () => {
+    renderExport();
+
+    expect(await screen.findByRole("heading", { name: /Export a team bundle/i })).toBeInTheDocument();
+    expect(await screen.findByText("D:\\TeamBundles")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Export bundle/i })).toBeInTheDocument();
+    expect(await screen.findByText(/What stays vs. what goes into the team bundle/i)).toBeInTheDocument();
+
+    // Import lives on its own view now — nothing to import from here.
+    expect(screen.queryByLabelText("Choose local team bundle file")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Import bundle" })).not.toBeInTheDocument();
+  });
+
+  it("exports a team bundle and shows the written path", async () => {
+    renderExport();
+
+    const exportBtn = await screen.findByRole("button", { name: /Export bundle/i });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
+
+    await waitFor(() => expect(exportTeamBundle).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/team-bundle-a\.json/)).toBeInTheDocument();
+  });
+
+  it("disables export when the local machine has no sessions", async () => {
+    vi.mocked(getTeamPreview).mockResolvedValue({
+      manifest: { ...previewPayload.manifest, session_count: 0 },
+      bundle: { sessions: [] },
+    } as never);
+    renderExport();
+
+    const exportBtn = await screen.findByRole("button", { name: /Export bundle/i });
+    await waitFor(() => expect(exportBtn).toBeDisabled());
+    expect(screen.getByText(/No local sessions are available for export/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/team/TeamBundleExport.tsx
+++ b/frontend/src/team/TeamBundleExport.tsx
@@ -1,39 +1,108 @@
-import { useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { Check, Download, FileJson } from "lucide-react";
-import { exportTeamBundle, getRuntimeConfig, getTeamPreview } from "../api/client";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Download, FileJson, Lock } from "lucide-react";
+import { exportTeamBundle, getRuntimeConfig, getTeamPreview, getTeamProjects } from "../api/client";
+import type { TeamExportRequestBody, TeamPrivacyLevel } from "../api/types";
 import type { ContributionSession } from "../contribute/specimen";
+import { compactInt } from "../contribute/specimen";
 import { Blurred } from "../shell/Blurred";
 import PrivacyLedger from "../contribute/PrivacyLedger";
 import SpecimenModal from "../contribute/SpecimenModal";
+
+const LEVELS: { id: TeamPrivacyLevel; label: string; hint: string }[] = [
+  {
+    id: "structural",
+    label: "Structural",
+    hint: "Fully pseudonymous: hashed ids, bucketed names, zero free text.",
+  },
+  {
+    id: "team",
+    label: "Team",
+    hint: "Adds your name, project names, tool names, and file types — still no conversation content.",
+  },
+];
+// Reserved ladder rungs (raw session sharing) — visible so the ladder reads as one axis.
+const PLANNED_LEVELS = ["Sessions", "Raw"];
 
 function sessionsFromBundle(value: unknown): ContributionSession[] {
   return Array.isArray(value) ? (value as ContributionSession[]) : [];
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown export error";
+}
+
 // Local-scope "Export": write a content-free team bundle from this machine's
-// sessions and share it through a team-approved channel. The privacy ledger
-// spells out exactly what leaves the machine; nothing is ever uploaded.
+// sessions and share it through a team-approved channel. The exporter picks a
+// privacy level: structural (anonymous) or team (named, for per-user/per-project
+// dashboards). The privacy ledger spells out exactly what leaves the machine.
 export default function TeamBundleExport() {
+  const queryClient = useQueryClient();
   const config = useQuery({ queryKey: ["config"], queryFn: getRuntimeConfig });
-  const preview = useQuery({ queryKey: ["team-preview"], queryFn: getTeamPreview });
+  const projectsQuery = useQuery({ queryKey: ["team-projects"], queryFn: getTeamProjects });
   const [specimenOpen, setSpecimenOpen] = useState(false);
 
-  const exporter = useMutation({ mutationFn: exportTeamBundle });
+  // null = untouched; fall back to persisted prefs until the user edits a control.
+  const [levelState, setLevelState] = useState<TeamPrivacyLevel | null>(null);
+  const [nameState, setNameState] = useState<string | null>(null);
+  const [deselectedState, setDeselectedState] = useState<Set<string> | null>(null);
+  const [labelsState, setLabelsState] = useState<Record<string, string> | null>(null);
+
+  const prefs = projectsQuery.data?.prefs;
+  const entries = projectsQuery.data?.projects ?? [];
+  const level: TeamPrivacyLevel = levelState ?? (prefs?.privacy_level === "team" ? "team" : "structural");
+  const memberName = nameState ?? prefs?.member_name ?? "";
+  const deselected = deselectedState ?? new Set(prefs?.deselected ?? []);
+  const labels = labelsState ?? prefs?.project_labels ?? {};
+
+  const selected = entries.filter((entry) => !deselected.has(entry.export_name));
+  const previewBody: TeamExportRequestBody = useMemo(
+    () => ({
+      privacy_level: level,
+      projects: selected.map((entry) => ({
+        export_name: entry.export_name,
+        label: labels[entry.export_name]?.trim() || null,
+      })),
+    }),
+    [level, selected, labels],
+  );
+
+  const preview = useQuery({
+    queryKey: ["team-preview", previewBody],
+    queryFn: () => getTeamPreview(previewBody),
+    enabled: selected.length > 0,
+  });
+
+  const exporter = useMutation({
+    mutationFn: () => exportTeamBundle({ ...previewBody, member_name: memberName.trim() || null }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["team-projects"] }),
+  });
 
   const manifest = preview.data?.manifest;
   const sessions = sessionsFromBundle(preview.data?.bundle.sessions);
   const sample = sessions[0];
-  const hasLocalSessions = (manifest?.session_count ?? sessions.length) > 0;
+  const sessionCount = manifest?.session_count ?? sessions.length;
+  const needsName = level === "team" && memberName.trim().length === 0;
   const exportedPath = exporter.data?.path ?? null;
   const bundleRoot = config.data?.team_bundle_root ?? null;
+
+  const toggleProject = (exportName: string) => {
+    const next = new Set(deselected);
+    if (next.has(exportName)) next.delete(exportName);
+    else next.add(exportName);
+    setDeselectedState(next);
+  };
+
+  const commitLabel = (exportName: string, value: string) => {
+    setLabelsState({ ...labels, [exportName]: value.trim() });
+  };
 
   return (
     <main className="page team-export-page">
       <section className="card team-data-sources" aria-labelledby="team-export-title">
         <div className="card-head">
           <h2 id="team-export-title">Export a team bundle</h2>
-          <span className="card-count">Local JSON only — no uploads, no content</span>
+          <span className="card-count">Local JSON only — no uploads{level === "team" ? ", names visible to your team" : ", no names"}</span>
         </div>
 
         <div className="team-ds-root">
@@ -43,18 +112,104 @@ export default function TeamBundleExport() {
           </code>
         </div>
 
+        <div className="team-level-selector" role="radiogroup" aria-label="Export privacy level">
+          {LEVELS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={level === option.id}
+              className={level === option.id ? "team-level active" : "team-level"}
+              onClick={() => setLevelState(option.id)}
+              title={option.hint}
+            >
+              {option.label}
+            </button>
+          ))}
+          {PLANNED_LEVELS.map((label) => (
+            <button key={label} type="button" className="team-level planned" disabled title="Planned: raw session sharing">
+              <Lock size={12} aria-hidden="true" /> {label}
+            </button>
+          ))}
+        </div>
+        <p className="team-level-hint">{LEVELS.find((option) => option.id === level)?.hint}</p>
+
+        {level === "team" ? (
+          <label className="team-member-name">
+            <span>Your name</span>
+            <input
+              aria-label="Team member name"
+              value={memberName}
+              maxLength={80}
+              placeholder="Shown to everyone who imports this bundle"
+              onChange={(event) => setNameState(event.target.value)}
+            />
+          </label>
+        ) : null}
+
+        <section className="team-project-picker" aria-label="Projects to export">
+          <div className="team-import-list-head">
+            <h3>Projects in this bundle</h3>
+            <strong>
+              {selected.length}/{entries.length}
+            </strong>
+          </div>
+          {projectsQuery.isError ? (
+            <p className="flow-error">Could not read the local project list.</p>
+          ) : (
+            <ul>
+              {entries.map((entry) => {
+                const checked = !deselected.has(entry.export_name);
+                const committed = labels[entry.export_name];
+                return (
+                  <li key={entry.export_name}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      aria-label={`Include ${entry.default_label}`}
+                      onChange={() => toggleProject(entry.export_name)}
+                    />
+                    {level === "team" ? (
+                      <input
+                        className="team-project-label"
+                        aria-label={`Label for ${entry.default_label}`}
+                        key={`${entry.export_name}:${committed ?? ""}`}
+                        defaultValue={committed || entry.default_label}
+                        maxLength={120}
+                        disabled={!checked}
+                        onBlur={(event) => commitLabel(entry.export_name, event.target.value)}
+                      />
+                    ) : (
+                      <span className="team-project-label-static">
+                        <Blurred>{entry.default_label}</Blurred>
+                      </span>
+                    )}
+                    <span className="team-project-meta">
+                      {compactInt(entry.session_count)} sessions · {compactInt(entry.tokens)} tok
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
         <div className="team-ds-single">
           <p>Writes a local JSON bundle under team_bundle_root. Share it through your team-approved channel.</p>
           <button
             type="button"
             className="contribute-primary-button"
             onClick={() => exporter.mutate()}
-            disabled={exporter.isPending || !hasLocalSessions}
+            disabled={exporter.isPending || selected.length === 0 || sessionCount === 0 || needsName}
           >
             {exporter.isSuccess ? <Check size={15} strokeWidth={3} aria-hidden="true" /> : <Download size={15} aria-hidden="true" />}
             {exporter.isPending ? "Exporting…" : "Export bundle"}
           </button>
-          {!hasLocalSessions && <span className="flow-error">No local sessions are available for export.</span>}
+          {needsName && <span className="flow-error">Enter your name to export a team-level bundle.</span>}
+          {selected.length === 0 && <span className="flow-error">Select at least one project.</span>}
+          {selected.length > 0 && sessionCount === 0 && (
+            <span className="flow-error">No sessions in the current selection.</span>
+          )}
           {exportedPath ? (
             <div className="flow-result">
               <FileJson size={14} aria-hidden="true" />
@@ -63,7 +218,9 @@ export default function TeamBundleExport() {
               </code>
             </div>
           ) : null}
-          {exporter.isError && <span className="flow-error">Export failed; no local team bundle was written.</span>}
+          {exporter.isError && (
+            <span className="flow-error">Export failed: {errorMessage(exporter.error)}. No local team bundle was written.</span>
+          )}
         </div>
 
         {manifest ? (

--- a/frontend/src/team/TeamBundleExport.tsx
+++ b/frontend/src/team/TeamBundleExport.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Download, FileJson, Lock } from "lucide-react";
+import { Check, Download, FileJson, Lock, Pencil } from "lucide-react";
 import { exportTeamBundle, getRuntimeConfig, getTeamPreview, getTeamProjects } from "../api/client";
 import type { TeamExportRequestBody, TeamPrivacyLevel } from "../api/types";
 import type { ContributionSession } from "../contribute/specimen";
@@ -41,6 +41,8 @@ export default function TeamBundleExport() {
   const config = useQuery({ queryKey: ["config"], queryFn: getRuntimeConfig });
   const projectsQuery = useQuery({ queryKey: ["team-projects"], queryFn: getTeamProjects });
   const [specimenOpen, setSpecimenOpen] = useState(false);
+  // Which project's name is currently being renamed inline (team level only).
+  const [editingProject, setEditingProject] = useState<string | null>(null);
 
   // null = untouched; fall back to persisted prefs until the user edits a control.
   const [levelState, setLevelState] = useState<TeamPrivacyLevel | null>(null);
@@ -241,24 +243,42 @@ export default function TeamBundleExport() {
                           onChange={() => toggleProject(entry.export_name)}
                         />
                         <div className="team-project-copy">
-                          {level === "team" ? (
+                          {level === "team" && editingProject === entry.export_name ? (
                             <input
                               className="team-project-label"
                               aria-label={`Label for ${entry.default_label}`}
-                              key={`${entry.export_name}:${committed ?? ""}`}
+                              autoFocus
                               defaultValue={committed || entry.default_label}
                               maxLength={120}
                               disabled={!checked}
-                              onBlur={(event) => commitLabel(entry.export_name, event.target.value)}
+                              onBlur={(event) => {
+                                commitLabel(entry.export_name, event.target.value);
+                                setEditingProject(null);
+                              }}
+                              onKeyDown={(event) => {
+                                if (event.key === "Enter") event.currentTarget.blur();
+                              }}
                             />
+                          ) : level === "team" ? (
+                            <div className="team-project-label-row">
+                              <span className="team-project-label-static">
+                                <Blurred>{committed || entry.default_label}</Blurred>
+                              </span>
+                              <button
+                                type="button"
+                                className="team-project-edit"
+                                aria-label={`Rename ${entry.default_label}`}
+                                disabled={!checked}
+                                onClick={() => setEditingProject(entry.export_name)}
+                              >
+                                <Pencil size={12} aria-hidden="true" />
+                              </button>
+                            </div>
                           ) : (
                             <span className="team-project-label-static">
                               <Blurred>{entry.default_label}</Blurred>
                             </span>
                           )}
-                          <span className="team-project-export-id">
-                            <Blurred>{entry.export_name}</Blurred>
-                          </span>
                         </div>
                         <span className="team-project-meta">
                           {compactInt(entry.session_count)} sessions · {compactInt(entry.tokens)} tok

--- a/frontend/src/team/TeamBundleExport.tsx
+++ b/frontend/src/team/TeamBundleExport.tsx
@@ -157,6 +157,10 @@ export default function TeamBundleExport() {
               {selected.length}/{entries.length}
             </strong>
           </div>
+          <p className="team-picker-note">
+            Each export replaces your entire previous bundle for teammates who import it. Unchecked
+            projects are removed from their dashboards — deselection is remembered for next time.
+          </p>
           {projectsQuery.isError ? (
             <p className="flow-error">Could not read the local project list.</p>
           ) : (

--- a/frontend/src/team/TeamBundleExport.tsx
+++ b/frontend/src/team/TeamBundleExport.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Check, Download, FileJson } from "lucide-react";
+import { exportTeamBundle, getRuntimeConfig, getTeamPreview } from "../api/client";
+import type { ContributionSession } from "../contribute/specimen";
+import { Blurred } from "../shell/Blurred";
+import PrivacyLedger from "../contribute/PrivacyLedger";
+import SpecimenModal from "../contribute/SpecimenModal";
+
+function sessionsFromBundle(value: unknown): ContributionSession[] {
+  return Array.isArray(value) ? (value as ContributionSession[]) : [];
+}
+
+// Local-scope "Export": write a content-free team bundle from this machine's
+// sessions and share it through a team-approved channel. The privacy ledger
+// spells out exactly what leaves the machine; nothing is ever uploaded.
+export default function TeamBundleExport() {
+  const config = useQuery({ queryKey: ["config"], queryFn: getRuntimeConfig });
+  const preview = useQuery({ queryKey: ["team-preview"], queryFn: getTeamPreview });
+  const [specimenOpen, setSpecimenOpen] = useState(false);
+
+  const exporter = useMutation({ mutationFn: exportTeamBundle });
+
+  const manifest = preview.data?.manifest;
+  const sessions = sessionsFromBundle(preview.data?.bundle.sessions);
+  const sample = sessions[0];
+  const hasLocalSessions = (manifest?.session_count ?? sessions.length) > 0;
+  const exportedPath = exporter.data?.path ?? null;
+  const bundleRoot = config.data?.team_bundle_root ?? null;
+
+  return (
+    <main className="page team-export-page">
+      <section className="card team-data-sources" aria-labelledby="team-export-title">
+        <div className="card-head">
+          <h2 id="team-export-title">Export a team bundle</h2>
+          <span className="card-count">Local JSON only — no uploads, no content</span>
+        </div>
+
+        <div className="team-ds-root">
+          <span>team_bundle_root</span>
+          <code>
+            <Blurred>{bundleRoot || "Not configured"}</Blurred>
+          </code>
+        </div>
+
+        <div className="team-ds-single">
+          <p>Writes a local JSON bundle under team_bundle_root. Share it through your team-approved channel.</p>
+          <button
+            type="button"
+            className="contribute-primary-button"
+            onClick={() => exporter.mutate()}
+            disabled={exporter.isPending || !hasLocalSessions}
+          >
+            {exporter.isSuccess ? <Check size={15} strokeWidth={3} aria-hidden="true" /> : <Download size={15} aria-hidden="true" />}
+            {exporter.isPending ? "Exporting…" : "Export bundle"}
+          </button>
+          {!hasLocalSessions && <span className="flow-error">No local sessions are available for export.</span>}
+          {exportedPath ? (
+            <div className="flow-result">
+              <FileJson size={14} aria-hidden="true" />
+              <code>
+                <Blurred>{exportedPath}</Blurred>
+              </code>
+            </div>
+          ) : null}
+          {exporter.isError && <span className="flow-error">Export failed; no local team bundle was written.</span>}
+        </div>
+
+        {manifest ? (
+          <PrivacyLedger
+            title="What stays vs. what goes into the team bundle"
+            caveat={manifest.fingerprint_caveat}
+            excluded={manifest.excluded}
+            included={manifest.included_fields}
+            staysTitle="Stays on this machine"
+            travelsTitle="Goes into the team bundle"
+            specimenDescription="Inspect the exact first session in the team bundle."
+            emptyDescription="No sessions are available for a team bundle yet."
+            hasSpecimen={Boolean(sample)}
+            onInspectSpecimen={() => setSpecimenOpen(true)}
+          />
+        ) : null}
+      </section>
+
+      {sample ? (
+        <SpecimenModal
+          sample={sample}
+          open={specimenOpen}
+          onClose={() => setSpecimenOpen(false)}
+          title="First team bundle session"
+          description="The exact first session in the team bundle, shown as structured fields or raw JSON."
+          blurRaw
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/frontend/src/team/TeamBundleExport.tsx
+++ b/frontend/src/team/TeamBundleExport.tsx
@@ -85,6 +85,7 @@ export default function TeamBundleExport() {
   const sessions = sessionsFromBundle(preview.data?.bundle.sessions);
   const sample = sessions[0];
   const sessionCount = manifest?.session_count ?? sessions.length;
+  const selectedTokens = selected.reduce((total, entry) => total + entry.tokens, 0);
   const needsName = level === "team" && memberName.trim().length === 0;
   const exportedPath = exporter.data?.path ?? null;
   const bundleRoot = config.data?.team_bundle_root ?? null;
@@ -101,149 +102,192 @@ export default function TeamBundleExport() {
   };
 
   return (
-    <main className="page team-export-page">
-      <section className="card team-data-sources" aria-labelledby="team-export-title">
-        <div className="card-head">
-          <h2 id="team-export-title">Export a team bundle</h2>
-          <span className="card-count">Local JSON only — no uploads{level === "team" ? ", names visible to your team" : ", no names"}</span>
-        </div>
-
-        <div className="team-ds-root">
-          <span>team_bundle_root</span>
-          <code>
-            <Blurred>{bundleRoot || "Not configured"}</Blurred>
-          </code>
-        </div>
-
-        <div className="team-level-selector" role="radiogroup" aria-label="Export privacy level">
-          {LEVELS.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              role="radio"
-              aria-checked={level === option.id}
-              className={level === option.id ? "team-level active" : "team-level"}
-              onClick={() => setLevelState(option.id)}
-              title={option.hint}
-            >
-              {option.label}
-            </button>
-          ))}
-          {PLANNED_LEVELS.map((label) => (
-            <button key={label} type="button" className="team-level planned" disabled title="Planned: raw session sharing">
-              <Lock size={12} aria-hidden="true" /> {label}
-            </button>
-          ))}
-        </div>
-        <p className="team-level-hint">{LEVELS.find((option) => option.id === level)?.hint}</p>
-
-        {level === "team" ? (
-          <label className="team-member-name">
-            <span>Your name</span>
-            <input
-              aria-label="Team member name"
-              value={memberName}
-              maxLength={80}
-              placeholder="Shown to everyone who imports this bundle"
-              onChange={(event) => setNameState(event.target.value)}
-            />
-          </label>
-        ) : null}
-
-        <section className="team-project-picker" aria-label="Projects to export">
-          <div className="team-import-list-head">
-            <h3>Projects in this bundle</h3>
-            <strong>
-              {selected.length}/{entries.length}
-            </strong>
-          </div>
-          <p className="team-picker-note">
-            Each export replaces your entire previous bundle for teammates who import it. Unchecked
-            projects are removed from their dashboards — deselection is remembered for next time.
+    <main className="page team-flow-page team-export-page">
+      <section className="contribute-header team-flow-header" aria-labelledby="team-export-title">
+        <div className="contribute-titleblock team-titleblock">
+          <h1 id="team-export-title">Export a team bundle</h1>
+          <p>
+            Package local session structure into a content-free JSON bundle for teammates. The app
+            writes locally only, and the privacy level controls whether names travel with it.
           </p>
-          {projectsQuery.isError ? (
-            <p className="flow-error">Could not read the local project list.</p>
-          ) : (
-            <ul>
-              {entries.map((entry) => {
-                const checked = !deselected.has(entry.export_name);
-                const committed = labels[entry.export_name];
-                return (
-                  <li key={entry.export_name}>
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      aria-label={`Include ${entry.default_label}`}
-                      onChange={() => toggleProject(entry.export_name)}
-                    />
-                    {level === "team" ? (
-                      <input
-                        className="team-project-label"
-                        aria-label={`Label for ${entry.default_label}`}
-                        key={`${entry.export_name}:${committed ?? ""}`}
-                        defaultValue={committed || entry.default_label}
-                        maxLength={120}
-                        disabled={!checked}
-                        onBlur={(event) => commitLabel(entry.export_name, event.target.value)}
-                      />
-                    ) : (
-                      <span className="team-project-label-static">
-                        <Blurred>{entry.default_label}</Blurred>
-                      </span>
-                    )}
-                    <span className="team-project-meta">
-                      {compactInt(entry.session_count)} sessions · {compactInt(entry.tokens)} tok
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </section>
-
-        <div className="team-ds-single">
-          <p>Writes a local JSON bundle under team_bundle_root. Share it through your team-approved channel.</p>
-          <button
-            type="button"
-            className="contribute-primary-button"
-            onClick={() => exporter.mutate()}
-            disabled={exporter.isPending || selected.length === 0 || sessionCount === 0 || needsName}
-          >
-            {exporter.isSuccess ? <Check size={15} strokeWidth={3} aria-hidden="true" /> : <Download size={15} aria-hidden="true" />}
-            {exporter.isPending ? "Exporting…" : "Export bundle"}
-          </button>
-          {needsName && <span className="flow-error">Enter your name to export a team-level bundle.</span>}
-          {selected.length === 0 && <span className="flow-error">Select at least one project.</span>}
-          {selected.length > 0 && sessionCount === 0 && (
-            <span className="flow-error">No sessions in the current selection.</span>
-          )}
-          {exportedPath ? (
-            <div className="flow-result">
-              <FileJson size={14} aria-hidden="true" />
-              <code>
-                <Blurred>{exportedPath}</Blurred>
-              </code>
-            </div>
-          ) : null}
-          {exporter.isError && (
-            <span className="flow-error">Export failed: {errorMessage(exporter.error)}. No local team bundle was written.</span>
-          )}
+          <div className="team-root-row">
+            <span>team_bundle_root</span>
+            <code>
+              <Blurred>{bundleRoot || "Not configured"}</Blurred>
+            </code>
+          </div>
         </div>
 
-        {manifest ? (
-          <PrivacyLedger
-            title="What stays vs. what goes into the team bundle"
-            caveat={manifest.fingerprint_caveat}
-            excluded={manifest.excluded}
-            included={manifest.included_fields}
-            staysTitle="Stays on this machine"
-            travelsTitle="Goes into the team bundle"
-            specimenDescription="Inspect the exact first session in the team bundle."
-            emptyDescription="No sessions are available for a team bundle yet."
-            hasSpecimen={Boolean(sample)}
-            onInspectSpecimen={() => setSpecimenOpen(true)}
-          />
-        ) : null}
+        <div className="contribute-metrics team-metrics team-flow-metrics" aria-label="Team export summary">
+          <Metric value={`${selected.length}/${entries.length || 0}`} label="Projects" />
+          <Metric value={sessionCount} label="Sessions" />
+          <Metric value={selectedTokens} label="Tokens" />
+          <Metric value={level === "team" ? "Named" : "Anonymous"} label="Privacy" mono={false} />
+        </div>
+      </section>
+
+      <section className="team-flow-body team-export-layout" aria-label="Team export workspace">
+        <div className="team-flow-column">
+          <section className="card team-flow-card">
+            <div className="card-head">
+              <h2>Privacy level</h2>
+              <span className="card-count">Local JSON only</span>
+            </div>
+            <div className="team-flow-card-body team-flow-stack">
+              <div className="team-level-selector" role="radiogroup" aria-label="Export privacy level">
+                {LEVELS.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    role="radio"
+                    aria-checked={level === option.id}
+                    className={level === option.id ? "team-level active" : "team-level"}
+                    onClick={() => setLevelState(option.id)}
+                    title={option.hint}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+                {PLANNED_LEVELS.map((label) => (
+                  <button key={label} type="button" className="team-level planned" disabled title="Planned: raw session sharing">
+                    <Lock size={12} aria-hidden="true" /> {label}
+                  </button>
+                ))}
+              </div>
+              <p className="team-level-hint">{LEVELS.find((option) => option.id === level)?.hint}</p>
+
+              {level === "team" ? (
+                <label className="team-member-name">
+                  <span>Your name</span>
+                  <input
+                    aria-label="Team member name"
+                    value={memberName}
+                    maxLength={80}
+                    placeholder="Shown to everyone who imports this bundle"
+                    onChange={(event) => setNameState(event.target.value)}
+                  />
+                </label>
+              ) : null}
+            </div>
+          </section>
+
+          <section className="card team-flow-card">
+            <div className="card-head">
+              <h2>Export workflow</h2>
+              <span className="card-count">Share through your approved channel</span>
+            </div>
+            <div className="team-flow-card-body team-flow-stack">
+              <p className="team-flow-copy">
+                Writes a local JSON bundle under team_bundle_root. Each export replaces your previous
+                bundle for teammates who import it.
+              </p>
+              <button
+                type="button"
+                className="contribute-primary-button"
+                onClick={() => exporter.mutate()}
+                disabled={exporter.isPending || selected.length === 0 || sessionCount === 0 || needsName}
+              >
+                {exporter.isSuccess ? <Check size={15} strokeWidth={3} aria-hidden="true" /> : <Download size={15} aria-hidden="true" />}
+                {exporter.isPending ? "Exporting…" : "Export bundle"}
+              </button>
+              <div className="team-flow-errors" aria-live="polite">
+                {needsName && <span className="flow-error">Enter your name to export a team-level bundle.</span>}
+                {selected.length === 0 && <span className="flow-error">Select at least one project.</span>}
+                {selected.length > 0 && sessionCount === 0 && (
+                  <span className="flow-error">No sessions in the current selection.</span>
+                )}
+                {exporter.isError && (
+                  <span className="flow-error">Export failed: {errorMessage(exporter.error)}. No local team bundle was written.</span>
+                )}
+              </div>
+              {exportedPath ? (
+                <div className="flow-result">
+                  <FileJson size={14} aria-hidden="true" />
+                  <code>
+                    <Blurred>{exportedPath}</Blurred>
+                  </code>
+                </div>
+              ) : null}
+            </div>
+          </section>
+        </div>
+
+        <div className="team-flow-column team-flow-column-wide">
+          <section className="card team-flow-card team-scroll-card team-project-picker" aria-label="Projects to export">
+            <div className="card-head">
+              <h2>Projects in this bundle</h2>
+              <span className="card-count">
+                <b>{selected.length}</b> of {entries.length}
+              </span>
+            </div>
+            <div className="team-flow-card-body team-flow-scroll-body">
+              <p className="team-picker-note">
+                Each export replaces your entire previous bundle for teammates who import it. Unchecked
+                projects are removed from their dashboards, and deselection is remembered for next time.
+              </p>
+              {projectsQuery.isError ? (
+                <p className="flow-error">Could not read the local project list.</p>
+              ) : (
+                <ul>
+                  {entries.map((entry) => {
+                    const checked = !deselected.has(entry.export_name);
+                    const committed = labels[entry.export_name];
+                    return (
+                      <li key={entry.export_name} className={checked ? undefined : "is-disabled"}>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          aria-label={`Include ${entry.default_label}`}
+                          onChange={() => toggleProject(entry.export_name)}
+                        />
+                        <div className="team-project-copy">
+                          {level === "team" ? (
+                            <input
+                              className="team-project-label"
+                              aria-label={`Label for ${entry.default_label}`}
+                              key={`${entry.export_name}:${committed ?? ""}`}
+                              defaultValue={committed || entry.default_label}
+                              maxLength={120}
+                              disabled={!checked}
+                              onBlur={(event) => commitLabel(entry.export_name, event.target.value)}
+                            />
+                          ) : (
+                            <span className="team-project-label-static">
+                              <Blurred>{entry.default_label}</Blurred>
+                            </span>
+                          )}
+                          <span className="team-project-export-id">
+                            <Blurred>{entry.export_name}</Blurred>
+                          </span>
+                        </div>
+                        <span className="team-project-meta">
+                          {compactInt(entry.session_count)} sessions · {compactInt(entry.tokens)} tok
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </section>
+
+          {manifest ? (
+            <section className="card team-flow-card team-ledger-card">
+              <PrivacyLedger
+                title="What stays vs. what goes into the team bundle"
+                caveat={manifest.fingerprint_caveat}
+                excluded={manifest.excluded}
+                included={manifest.included_fields}
+                staysTitle="Stays on this machine"
+                travelsTitle="Goes into the team bundle"
+                specimenDescription="Inspect the exact first session in the team bundle."
+                emptyDescription="No sessions are available for a team bundle yet."
+                hasSpecimen={Boolean(sample)}
+                onInspectSpecimen={() => setSpecimenOpen(true)}
+              />
+            </section>
+          ) : null}
+        </div>
       </section>
 
       {sample ? (
@@ -257,5 +301,24 @@ export default function TeamBundleExport() {
         />
       ) : null}
     </main>
+  );
+}
+
+function Metric({
+  value,
+  label,
+  mono = true,
+}: {
+  value: number | string;
+  label: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="contribute-metric">
+      <strong className={mono ? undefined : "team-metric-text"}>
+        {typeof value === "number" ? compactInt(value) : value}
+      </strong>
+      <span>{label}</span>
+    </div>
   );
 }

--- a/frontend/src/team/TeamBundleExport.tsx
+++ b/frontend/src/team/TeamBundleExport.tsx
@@ -74,7 +74,10 @@ export default function TeamBundleExport() {
   });
 
   const exporter = useMutation({
-    mutationFn: () => exportTeamBundle({ ...previewBody, member_name: memberName.trim() || null }),
+    // Structural bundles never carry a name — even a stale one still resolved from
+    // prefs after switching down from team level (the name field is hidden there).
+    mutationFn: () =>
+      exportTeamBundle({ ...previewBody, member_name: level === "team" ? memberName.trim() || null : null }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["team-projects"] }),
   });
 

--- a/frontend/src/team/TeamBundleImport.test.tsx
+++ b/frontend/src/team/TeamBundleImport.test.tsx
@@ -15,6 +15,7 @@ import {
   deleteTeamMember,
   getRuntimeConfig,
   importTeamBundle,
+  importTeamBundleFile,
   listTeamImports,
 } from "../api/client";
 
@@ -44,6 +45,13 @@ describe("TeamBundleImport", () => {
       imported: true,
       status: "imported",
     });
+    vi.mocked(importTeamBundleFile).mockImplementation(async (filename: string) => ({
+      bundle_id: `bundle-${filename}`,
+      member_id: filename,
+      session_count: 2,
+      imported: true,
+      status: "imported",
+    }));
     vi.mocked(deleteTeamMember).mockResolvedValue({
       member_id: "alice",
       bundles_removed: 1,
@@ -55,7 +63,7 @@ describe("TeamBundleImport", () => {
 
     expect(await screen.findByRole("heading", { name: /Import a team bundle/i })).toBeInTheDocument();
     expect(await screen.findByText("D:\\TeamBundles")).toBeInTheDocument();
-    expect(screen.getByLabelText("Choose local team bundle file")).toBeInTheDocument();
+    expect(screen.getByLabelText("Choose local team bundle files")).toBeInTheDocument();
     expect(screen.getByLabelText("Optional server-visible team bundle path")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Import bundle" })).toBeInTheDocument();
     expect(screen.getByText(/No team bundles have been imported yet/i)).toBeInTheDocument();
@@ -74,6 +82,82 @@ describe("TeamBundleImport", () => {
 
     await waitFor(() => expect(importTeamBundle).toHaveBeenCalledWith("D:\\TeamBundles\\shared.json"));
     expect(await screen.findByText(/shared\.json/)).toBeInTheDocument();
+  });
+
+  it("imports multiple selected files, calling importTeamBundleFile once per file in order", async () => {
+    renderImport();
+
+    const bundleA = { bundle_id: "alice-bundle" };
+    const bundleB = { bundle_id: "bob-bundle" };
+    const files = [
+      new File([JSON.stringify(bundleA)], "alice.json", { type: "application/json" }),
+      new File([JSON.stringify(bundleB)], "bob.json", { type: "application/json" }),
+    ];
+
+    const input = await screen.findByLabelText(/Choose local team bundle file/i);
+    fireEvent.change(input, { target: { files } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Import/i }));
+
+    await waitFor(() => expect(importTeamBundleFile).toHaveBeenCalledTimes(2));
+    const calls = vi.mocked(importTeamBundleFile).mock.calls;
+    expect(calls[0][0]).toBe("alice.json");
+    expect(calls[0][1]).toEqual(bundleA);
+    expect(calls[1][0]).toBe("bob.json");
+    expect(calls[1][1]).toEqual(bundleB);
+
+    // Both files show up in the per-file result list.
+    expect(await screen.findByText("alice.json")).toBeInTheDocument();
+    expect(await screen.findByText("bob.json")).toBeInTheDocument();
+  });
+
+  it("reports a per-file failure without blocking the other files in the batch", async () => {
+    vi.mocked(importTeamBundleFile).mockImplementation(async (filename: string) => {
+      if (filename === "bob.json") throw new Error("boom");
+      return {
+        bundle_id: `bundle-${filename}`,
+        member_id: filename,
+        session_count: 2,
+        imported: true,
+        status: "imported",
+      };
+    });
+    renderImport();
+
+    const files = [
+      new File([JSON.stringify({ bundle_id: "a" })], "alice.json", { type: "application/json" }),
+      new File([JSON.stringify({ bundle_id: "b" })], "bob.json", { type: "application/json" }),
+    ];
+    const input = await screen.findByLabelText(/Choose local team bundle file/i);
+    fireEvent.change(input, { target: { files } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Import/i }));
+
+    // Every file is still attempted even though one throws.
+    await waitFor(() => expect(importTeamBundleFile).toHaveBeenCalledTimes(2));
+    // The successful file's outcome is reported alongside the failed one.
+    expect(await screen.findByText("alice.json")).toBeInTheDocument();
+    expect(await screen.findByText("bob.json")).toBeInTheDocument();
+    expect(await screen.findByText(/boom/)).toBeInTheDocument();
+  });
+
+  it("records a failure for a file with invalid JSON and still imports the valid ones", async () => {
+    renderImport();
+
+    const files = [
+      new File(["this is not json"], "broken.json", { type: "application/json" }),
+      new File([JSON.stringify({ bundle_id: "ok" })], "good.json", { type: "application/json" }),
+    ];
+    const input = await screen.findByLabelText(/Choose local team bundle file/i);
+    fireEvent.change(input, { target: { files } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Import/i }));
+
+    // Only the parseable file reaches the API.
+    await waitFor(() => expect(importTeamBundleFile).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(importTeamBundleFile).mock.calls[0][0]).toBe("good.json");
+    expect(await screen.findByText("broken.json")).toBeInTheDocument();
+    expect(await screen.findByText("good.json")).toBeInTheDocument();
   });
 
   it("shows the replaced-bundle message when the import supersedes a previous one", async () => {

--- a/frontend/src/team/TeamBundleImport.test.tsx
+++ b/frontend/src/team/TeamBundleImport.test.tsx
@@ -42,7 +42,8 @@ describe("TeamBundleImport", () => {
       member_id: "m",
       session_count: 2,
       imported: true,
-    } as never);
+      status: "imported",
+    });
     vi.mocked(deleteTeamMember).mockResolvedValue({
       member_id: "alice",
       bundles_removed: 1,
@@ -73,6 +74,25 @@ describe("TeamBundleImport", () => {
 
     await waitFor(() => expect(importTeamBundle).toHaveBeenCalledWith("D:\\TeamBundles\\shared.json"));
     expect(await screen.findByText(/shared\.json/)).toBeInTheDocument();
+  });
+
+  it("shows the replaced-bundle message when the import supersedes a previous one", async () => {
+    vi.mocked(importTeamBundle).mockResolvedValue({
+      bundle_id: "b",
+      member_id: "m",
+      session_count: 2,
+      imported: true,
+      status: "replaced",
+    });
+    renderImport();
+
+    const pathInput = await screen.findByLabelText("Optional server-visible team bundle path");
+    fireEvent.change(pathInput, { target: { value: "D:\\TeamBundles\\shared.json" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Import bundle" }));
+
+    await waitFor(() => expect(importTeamBundle).toHaveBeenCalledWith("D:\\TeamBundles\\shared.json"));
+    expect(await screen.findByText("Replaced this member's previous bundle.")).toBeInTheDocument();
   });
 
   it("lists imported team bundles", async () => {
@@ -140,6 +160,7 @@ describe("TeamBundleImport", () => {
     const button = await screen.findByRole("button", { name: /remove alice/i });
     fireEvent.click(button);
 
+    await Promise.resolve();
     expect(deleteTeamMember).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/team/TeamBundleImport.test.tsx
+++ b/frontend/src/team/TeamBundleImport.test.tsx
@@ -8,9 +8,11 @@ vi.mock("../api/client", () => ({
   listTeamImports: vi.fn(),
   importTeamBundle: vi.fn(),
   importTeamBundleFile: vi.fn(),
+  deleteTeamMember: vi.fn(),
 }));
 
 import {
+  deleteTeamMember,
   getRuntimeConfig,
   importTeamBundle,
   listTeamImports,
@@ -40,6 +42,10 @@ describe("TeamBundleImport", () => {
       member_id: "m",
       session_count: 2,
       imported: true,
+    } as never);
+    vi.mocked(deleteTeamMember).mockResolvedValue({
+      member_id: "alice",
+      bundles_removed: 1,
     } as never);
   });
 
@@ -87,5 +93,28 @@ describe("TeamBundleImport", () => {
 
     expect(await screen.findByText("alice")).toBeInTheDocument();
     expect(screen.getByText(/9 sessions/)).toBeInTheDocument();
+  });
+
+  it("removes a member's bundles via the row button", async () => {
+    vi.mocked(listTeamImports).mockResolvedValue([
+      {
+        id: 1,
+        bundle_id: "b".repeat(64),
+        profile: "team_strict",
+        schema_version: 1,
+        member_id: "alice",
+        generated_at: "2026-06-18",
+        app_version: "0.1.0",
+        imported_at: "2026-06-19T00:00:00Z",
+        source_path: "a.json",
+        session_count: 3,
+      },
+    ] as never);
+    renderImport();
+
+    const button = await screen.findByRole("button", { name: /remove alice/i });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(deleteTeamMember).toHaveBeenCalledWith("alice"));
   });
 });

--- a/frontend/src/team/TeamBundleImport.test.tsx
+++ b/frontend/src/team/TeamBundleImport.test.tsx
@@ -115,6 +115,29 @@ describe("TeamBundleImport", () => {
     expect(screen.getByText(/9 sessions/)).toBeInTheDocument();
   });
 
+  it("shows the member name and privacy level for imported bundles", async () => {
+    vi.mocked(listTeamImports).mockResolvedValue([
+      {
+        id: 1,
+        bundle_id: "b-1",
+        profile: "team",
+        schema_version: 2,
+        member_id: "1111",
+        member_name: "Avery",
+        privacy_level: "team",
+        generated_at: "2026-07-03",
+        imported_at: "2026-07-03T10:00:00Z",
+        source_path: "D:\\TeamBundles\\a.json",
+        session_count: 3,
+      },
+    ] as never);
+    renderImport();
+
+    expect(await screen.findByText("Avery")).toBeInTheDocument();
+    expect(screen.getByText("team")).toBeInTheDocument(); // level tag
+    expect(screen.getByRole("button", { name: "Remove Avery" })).toBeInTheDocument();
+  });
+
   it("removes a member's bundles via the row button after confirming", async () => {
     vi.spyOn(window, "confirm").mockReturnValue(true);
     vi.mocked(listTeamImports).mockResolvedValue([

--- a/frontend/src/team/TeamBundleImport.test.tsx
+++ b/frontend/src/team/TeamBundleImport.test.tsx
@@ -95,7 +95,8 @@ describe("TeamBundleImport", () => {
     expect(screen.getByText(/9 sessions/)).toBeInTheDocument();
   });
 
-  it("removes a member's bundles via the row button", async () => {
+  it("removes a member's bundles via the row button after confirming", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
     vi.mocked(listTeamImports).mockResolvedValue([
       {
         id: 1,
@@ -116,5 +117,29 @@ describe("TeamBundleImport", () => {
     fireEvent.click(button);
 
     await waitFor(() => expect(deleteTeamMember).toHaveBeenCalledWith("alice"));
+  });
+
+  it("does not remove bundles if user declines the confirmation", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    vi.mocked(listTeamImports).mockResolvedValue([
+      {
+        id: 1,
+        bundle_id: "b".repeat(64),
+        profile: "team_strict",
+        schema_version: 1,
+        member_id: "alice",
+        generated_at: "2026-06-18",
+        app_version: "0.1.0",
+        imported_at: "2026-06-19T00:00:00Z",
+        source_path: "a.json",
+        session_count: 3,
+      },
+    ] as never);
+    renderImport();
+
+    const button = await screen.findByRole("button", { name: /remove alice/i });
+    fireEvent.click(button);
+
+    expect(deleteTeamMember).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/team/TeamBundleImport.test.tsx
+++ b/frontend/src/team/TeamBundleImport.test.tsx
@@ -1,0 +1,91 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TeamBundleImport from "./TeamBundleImport";
+
+vi.mock("../api/client", () => ({
+  getRuntimeConfig: vi.fn(),
+  listTeamImports: vi.fn(),
+  importTeamBundle: vi.fn(),
+  importTeamBundleFile: vi.fn(),
+}));
+
+import {
+  getRuntimeConfig,
+  importTeamBundle,
+  listTeamImports,
+} from "../api/client";
+
+function renderImport() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <TeamBundleImport />
+    </QueryClientProvider>,
+  );
+}
+
+describe("TeamBundleImport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRuntimeConfig).mockResolvedValue({
+      import_root: "D:\\Data",
+      team_bundle_root: "D:\\TeamBundles",
+      database_path: "D:\\Data\\ccfr.sqlite3",
+      is_docker: false,
+    } as never);
+    vi.mocked(listTeamImports).mockResolvedValue([] as never);
+    vi.mocked(importTeamBundle).mockResolvedValue({
+      bundle_id: "b",
+      member_id: "m",
+      session_count: 2,
+      imported: true,
+    } as never);
+  });
+
+  it("renders import controls, the root, and the imported list — but no export control", async () => {
+    renderImport();
+
+    expect(await screen.findByRole("heading", { name: /Import a team bundle/i })).toBeInTheDocument();
+    expect(await screen.findByText("D:\\TeamBundles")).toBeInTheDocument();
+    expect(screen.getByLabelText("Choose local team bundle file")).toBeInTheDocument();
+    expect(screen.getByLabelText("Optional server-visible team bundle path")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import bundle" })).toBeInTheDocument();
+    expect(screen.getByText(/No team bundles have been imported yet/i)).toBeInTheDocument();
+
+    // Export lives on its own local-scope view now.
+    expect(screen.queryByRole("button", { name: /Export bundle/i })).not.toBeInTheDocument();
+  });
+
+  it("imports from a server-visible path and shows the result", async () => {
+    renderImport();
+
+    const pathInput = await screen.findByLabelText("Optional server-visible team bundle path");
+    fireEvent.change(pathInput, { target: { value: "D:\\TeamBundles\\shared.json" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Import bundle" }));
+
+    await waitFor(() => expect(importTeamBundle).toHaveBeenCalledWith("D:\\TeamBundles\\shared.json"));
+    expect(await screen.findByText(/shared\.json/)).toBeInTheDocument();
+  });
+
+  it("lists imported team bundles", async () => {
+    vi.mocked(listTeamImports).mockResolvedValue([
+      {
+        id: 1,
+        bundle_id: "bundle-x",
+        profile: "team_strict",
+        schema_version: 1,
+        member_id: "alice",
+        generated_at: "2026-06-30T00:00:00Z",
+        imported_at: "2026-06-30T01:00:00Z",
+        source_path: "D:\\TeamBundles\\alice.json",
+        session_count: 9,
+      },
+    ] as never);
+    renderImport();
+
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(screen.getByText(/9 sessions/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -141,8 +141,9 @@ export default function TeamBundleImport() {
                 <li key={importRecordId(record, index)}>
                   <div>
                     <strong>
-                      <Blurred>{record.member_id ?? record.bundle_id ?? "team bundle"}</Blurred>
+                      <Blurred>{record.member_name ?? record.member_id ?? record.bundle_id ?? "team bundle"}</Blurred>
                     </strong>
+                    <span className="team-level-tag">{record.privacy_level ?? "structural"}</span>
                     <span>
                       {compactInt(record.session_count)} sessions
                       {record.generated_at ? ` · generated ${record.generated_at}` : ""}
@@ -156,10 +157,11 @@ export default function TeamBundleImport() {
                   <button
                     type="button"
                     className="team-remove-member"
-                    aria-label={`Remove ${record.member_id ?? "member"}`}
+                    aria-label={`Remove ${record.member_name ?? record.member_id ?? "member"}`}
                     disabled={removeMember.isPending}
                     onClick={() => {
-                      if (record.member_id && window.confirm(`Remove all imported bundles from ${record.member_id}?`)) {
+                      const display = record.member_name ?? record.member_id;
+                      if (record.member_id && window.confirm(`Remove all imported bundles from ${display}?`)) {
                         removeMember.mutate(record.member_id);
                       }
                     }}

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { FileJson, FolderInput } from "lucide-react";
-import { getRuntimeConfig, importTeamBundle, importTeamBundleFile, listTeamImports } from "../api/client";
+import {
+  deleteTeamMember,
+  getRuntimeConfig,
+  importTeamBundle,
+  importTeamBundleFile,
+  listTeamImports,
+} from "../api/client";
 import type { TeamImportRecord } from "../api/types";
 import { Blurred } from "../shell/Blurred";
 import { compactInt } from "../contribute/specimen";
@@ -42,6 +48,14 @@ export default function TeamBundleImport() {
       }
       return importTeamBundle(importPath.trim() || null);
     },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["team-import-list"] });
+      queryClient.invalidateQueries({ queryKey: ["team-dashboard"] });
+    },
+  });
+
+  const removeMember = useMutation({
+    mutationFn: (memberId: string) => deleteTeamMember(memberId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["team-import-list"] });
       queryClient.invalidateQueries({ queryKey: ["team-dashboard"] });
@@ -139,6 +153,15 @@ export default function TeamBundleImport() {
                       <Blurred>{record.source_path}</Blurred>
                     </code>
                   ) : null}
+                  <button
+                    type="button"
+                    className="team-remove-member"
+                    aria-label={`Remove ${record.member_id ?? "member"}`}
+                    disabled={removeMember.isPending}
+                    onClick={() => record.member_id && removeMember.mutate(record.member_id)}
+                  >
+                    Remove
+                  </button>
                 </li>
               ))}
             </ul>

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -95,12 +95,18 @@ export default function TeamBundleImport() {
               {importer.isPending ? "Importing…" : "Import bundle"}
             </button>
           </div>
-          {importer.isSuccess ? (
+          {importer.isSuccess && importer.data ? (
             <div className="flow-result">
               <FileJson size={14} aria-hidden="true" />
               <code>
                 <Blurred>{importTarget}</Blurred>
               </code>
+              <span>
+                {importer.data.status === "replaced" && "Replaced this member's previous bundle."}
+                {importer.data.status === "duplicate" && "Already imported — nothing changed."}
+                {importer.data.status === "stale" && "Older than this member's current bundle — nothing changed."}
+                {importer.data.status === "imported" && `Imported ${importer.data.session_count} sessions.`}
+              </span>
             </div>
           ) : null}
           {importer.isError && (

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -63,122 +63,199 @@ export default function TeamBundleImport() {
   });
 
   const importedRecords = imports.data ?? [];
+  const importedSessionCount = importedRecords.reduce((total, record) => total + (record.session_count ?? 0), 0);
+  const importedMemberCount = new Set(
+    importedRecords.map((record, index) => record.member_id ?? record.member_name ?? importRecordId(record, index)),
+  ).size;
   const importTarget = selectedFile?.name || importPath.trim() || "";
   const bundleRoot = config.data?.team_bundle_root ?? null;
+  const sourceMode = selectedFile ? "File" : importPath.trim() ? "Path" : "Idle";
 
   return (
-    <main className="page team-import-page">
-      <section className="card team-data-sources" aria-labelledby="team-import-title">
-        <div className="card-head">
-          <h2 id="team-import-title">Import a team bundle</h2>
-          <span className="card-count">Local JSON only — no uploads, no content</span>
-        </div>
-
-        <div className="team-ds-root">
-          <span>team_bundle_root</span>
-          <code>
-            <Blurred>{bundleRoot || "Not configured"}</Blurred>
-          </code>
-        </div>
-
-        <div className="team-ds-single">
-          <p>Choose a bundle JSON from this browser, or enter a server-visible path.</p>
-          <div className="team-import-controls">
-            <label className="team-file-picker">
-              <span>Bundle file</span>
-              <input
-                aria-label="Choose local team bundle file"
-                type="file"
-                accept=".json,application/json"
-                onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
-              />
-            </label>
-            <input
-              aria-label="Optional server-visible team bundle path"
-              value={importPath}
-              onChange={(event) => setImportPath(event.target.value)}
-              placeholder="Optional server-visible JSON path"
-            />
-            <button
-              type="button"
-              className="contribute-primary-button"
-              onClick={() => importer.mutate()}
-              disabled={importer.isPending || !importTarget}
-            >
-              <FolderInput size={15} aria-hidden="true" />
-              {importer.isPending ? "Importing…" : "Import bundle"}
-            </button>
+    <main className="page team-flow-page team-import-page">
+      <section className="contribute-header team-flow-header" aria-labelledby="team-import-title">
+        <div className="contribute-titleblock team-titleblock">
+          <h1 id="team-import-title">Import a team bundle</h1>
+          <p>
+            Bring in content-free bundles your teammates shared. You can import from a local JSON
+            file in the browser or from a server-visible path without uploading conversation data.
+          </p>
+          <div className="team-root-row">
+            <span>team_bundle_root</span>
+            <code>
+              <Blurred>{bundleRoot || "Not configured"}</Blurred>
+            </code>
           </div>
-          {importer.isSuccess && importer.data ? (
-            <div className="flow-result">
-              <FileJson size={14} aria-hidden="true" />
-              <code>
-                <Blurred>{importTarget}</Blurred>
-              </code>
-              <span>
-                {importer.data.status === "replaced" && "Replaced this member's previous bundle."}
-                {importer.data.status === "duplicate" && "Already imported — nothing changed."}
-                {importer.data.status === "stale" && "Older than this member's current bundle — nothing changed."}
-                {importer.data.status === "imported" && `Imported ${importer.data.session_count} sessions.`}
-              </span>
+        </div>
+
+        <div className="contribute-metrics team-metrics team-flow-metrics" aria-label="Team import summary">
+          <Metric value={importedRecords.length} label="Bundles" />
+          <Metric value={importedMemberCount} label="Members" />
+          <Metric value={importedSessionCount} label="Sessions" />
+          <Metric value={sourceMode} label="Source" mono={false} />
+        </div>
+      </section>
+
+      <section className="team-flow-body team-import-layout" aria-label="Team import workspace">
+        <div className="team-flow-column">
+          <section className="card team-flow-card">
+            <div className="card-head">
+              <h2>Import sources</h2>
+              <span className="card-count">Local JSON only</span>
             </div>
-          ) : null}
-          {importer.isError && (
-            <span className="flow-error">Import failed: {errorMessage(importer.error)}. The team dashboard was not changed.</span>
-          )}
+            <div className="team-flow-card-body team-flow-stack">
+              <p className="team-flow-copy">
+                Choose a bundle JSON from this browser, or point to a server-visible file when the
+                backend can already read that location.
+              </p>
+              <div className="team-mini-summary" aria-label="Supported import sources">
+                <span>Browser file</span>
+                <span>Server path</span>
+                <span>No prompts or content</span>
+              </div>
+            </div>
+          </section>
+
+          <section className="card team-flow-card">
+            <div className="card-head">
+              <h2>Import workflow</h2>
+              <span className="card-count">Replaces stale bundles automatically</span>
+            </div>
+            <div className="team-flow-card-body team-flow-stack">
+              <div className="team-import-controls">
+                <label className="team-file-picker">
+                  <span>Bundle file</span>
+                  <input
+                    aria-label="Choose local team bundle file"
+                    type="file"
+                    accept=".json,application/json"
+                    onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+                  />
+                </label>
+                <label className="team-path-field">
+                  <span>Server-visible path</span>
+                  <input
+                    aria-label="Optional server-visible team bundle path"
+                    value={importPath}
+                    onChange={(event) => setImportPath(event.target.value)}
+                    placeholder="Optional server-visible JSON path"
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="contribute-primary-button"
+                  onClick={() => importer.mutate()}
+                  disabled={importer.isPending || !importTarget}
+                >
+                  <FolderInput size={15} aria-hidden="true" />
+                  {importer.isPending ? "Importing…" : "Import bundle"}
+                </button>
+              </div>
+
+              {importer.isSuccess && importer.data ? (
+                <div className="flow-result">
+                  <FileJson size={14} aria-hidden="true" />
+                  <code>
+                    <Blurred>{importTarget}</Blurred>
+                  </code>
+                  <span>
+                    {importer.data.status === "replaced" && "Replaced this member's previous bundle."}
+                    {importer.data.status === "duplicate" && "Already imported — nothing changed."}
+                    {importer.data.status === "stale" && "Older than this member's current bundle — nothing changed."}
+                    {importer.data.status === "imported" && `Imported ${importer.data.session_count} sessions.`}
+                  </span>
+                </div>
+              ) : null}
+
+              {importer.isError && (
+                <span className="flow-error">Import failed: {errorMessage(importer.error)}. The team dashboard was not changed.</span>
+              )}
+            </div>
+          </section>
         </div>
 
-        <section className="team-import-list" aria-label="Imported team bundles">
-          <div className="team-import-list-head">
-            <h3>Imported team bundles</h3>
-            <strong>{compactInt(importedRecords.length)}</strong>
+        <section className="team-import-list team-flow-card team-scroll-card" aria-label="Imported team bundles">
+          <div className="card-head">
+            <h2>Imported team bundles</h2>
+            <span className="card-count">
+              <b>{compactInt(importedRecords.length)}</b> active
+            </span>
           </div>
-          {imports.isError ? (
-            <p className="flow-error">Could not read the team bundle import list.</p>
-          ) : importedRecords.length > 0 ? (
-            <ul>
-              {importedRecords.map((record, index) => (
-                <li key={importRecordId(record, index)}>
-                  <div>
-                    <strong>
-                      <Blurred>{record.member_name ?? record.member_id ?? record.bundle_id ?? "team bundle"}</Blurred>
-                    </strong>
-                    <span className="team-level-tag">{record.privacy_level ?? "structural"}</span>
-                    <span>
-                      {compactInt(record.session_count)} sessions
-                      {record.generated_at ? ` · generated ${record.generated_at}` : ""}
-                    </span>
-                  </div>
-                  {record.source_path ? (
-                    <code>
-                      <Blurred>{record.source_path}</Blurred>
-                    </code>
-                  ) : null}
-                  <button
-                    type="button"
-                    className="team-remove-member"
-                    aria-label={`Remove ${record.member_name ?? record.member_id ?? "member"}`}
-                    disabled={removeMember.isPending}
-                    onClick={() => {
-                      const display = record.member_name ?? record.member_id;
-                      if (record.member_id && window.confirm(`Remove all imported bundles from ${display}?`)) {
-                        removeMember.mutate(record.member_id);
-                      }
-                    }}
-                  >
-                    Remove
-                  </button>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p>No team bundles have been imported yet.</p>
-          )}
-          {removeMember.isError && (
-            <span className="flow-error">Remove failed: {errorMessage(removeMember.error)}. The team dashboard was not changed.</span>
-          )}
+          <div className="team-flow-card-body team-flow-scroll-body">
+            <p className="team-flow-copy">
+              Newer imports replace older bundles from the same member. Remove a member to drop all
+              of their imported bundles from the team dashboard.
+            </p>
+            {imports.isError ? (
+              <p className="flow-error">Could not read the team bundle import list.</p>
+            ) : importedRecords.length > 0 ? (
+              <ul>
+                {importedRecords.map((record, index) => (
+                  <li key={importRecordId(record, index)}>
+                    <div>
+                      <div className="team-import-member-head">
+                        <strong>
+                          <Blurred>{record.member_name ?? record.member_id ?? record.bundle_id ?? "team bundle"}</Blurred>
+                        </strong>
+                        <span className="team-level-tag" data-level={record.privacy_level ?? "structural"}>
+                          {record.privacy_level ?? "structural"}
+                        </span>
+                      </div>
+                      <span>
+                        {compactInt(record.session_count)} sessions
+                        {record.generated_at ? ` · generated ${record.generated_at}` : ""}
+                      </span>
+                    </div>
+                    {record.source_path ? (
+                      <code>
+                        <Blurred>{record.source_path}</Blurred>
+                      </code>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="team-remove-member"
+                      aria-label={`Remove ${record.member_name ?? record.member_id ?? "member"}`}
+                      disabled={removeMember.isPending}
+                      onClick={() => {
+                        const display = record.member_name ?? record.member_id;
+                        if (record.member_id && window.confirm(`Remove all imported bundles from ${display}?`)) {
+                          removeMember.mutate(record.member_id);
+                        }
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No team bundles have been imported yet.</p>
+            )}
+            {removeMember.isError && (
+              <span className="flow-error">Remove failed: {errorMessage(removeMember.error)}. The team dashboard was not changed.</span>
+            )}
+          </div>
         </section>
       </section>
     </main>
+  );
+}
+
+function Metric({
+  value,
+  label,
+  mono = true,
+}: {
+  value: number | string;
+  label: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="contribute-metric">
+      <strong className={mono ? undefined : "team-metric-text"}>
+        {typeof value === "number" ? compactInt(value) : value}
+      </strong>
+      <span>{label}</span>
+    </div>
   );
 }

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FileJson, FolderInput } from "lucide-react";
+import { getRuntimeConfig, importTeamBundle, importTeamBundleFile, listTeamImports } from "../api/client";
+import type { TeamImportRecord } from "../api/types";
+import { Blurred } from "../shell/Blurred";
+import { compactInt } from "../contribute/specimen";
+
+function importRecordId(record: TeamImportRecord, index: number): string {
+  return record.bundle_id ?? record.member_id ?? record.source_path ?? `team-import-${index}`;
+}
+
+function readLocalFile(file: File): Promise<string> {
+  if (typeof file.text === "function") return file.text();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read selected team bundle."));
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.readAsText(file);
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown import error";
+}
+
+// Team-scope "Import": bring in content-free bundles other members shared. Local
+// JSON files only — pick one from this browser or point at a server-visible path.
+// The app never uploads, and bundles carry no prompts/paths/commands/content.
+export default function TeamBundleImport() {
+  const queryClient = useQueryClient();
+  const config = useQuery({ queryKey: ["config"], queryFn: getRuntimeConfig });
+  const imports = useQuery({ queryKey: ["team-import-list"], queryFn: listTeamImports });
+  const [importPath, setImportPath] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const importer = useMutation({
+    mutationFn: async () => {
+      if (selectedFile) {
+        const text = await readLocalFile(selectedFile);
+        return importTeamBundleFile(selectedFile.name, JSON.parse(text) as unknown);
+      }
+      return importTeamBundle(importPath.trim() || null);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["team-import-list"] });
+      queryClient.invalidateQueries({ queryKey: ["team-dashboard"] });
+    },
+  });
+
+  const importedRecords = imports.data ?? [];
+  const importTarget = selectedFile?.name || importPath.trim() || "";
+  const bundleRoot = config.data?.team_bundle_root ?? null;
+
+  return (
+    <main className="page team-import-page">
+      <section className="card team-data-sources" aria-labelledby="team-import-title">
+        <div className="card-head">
+          <h2 id="team-import-title">Import a team bundle</h2>
+          <span className="card-count">Local JSON only — no uploads, no content</span>
+        </div>
+
+        <div className="team-ds-root">
+          <span>team_bundle_root</span>
+          <code>
+            <Blurred>{bundleRoot || "Not configured"}</Blurred>
+          </code>
+        </div>
+
+        <div className="team-ds-single">
+          <p>Choose a bundle JSON from this browser, or enter a server-visible path.</p>
+          <div className="team-import-controls">
+            <label className="team-file-picker">
+              <span>Bundle file</span>
+              <input
+                aria-label="Choose local team bundle file"
+                type="file"
+                accept=".json,application/json"
+                onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+              />
+            </label>
+            <input
+              aria-label="Optional server-visible team bundle path"
+              value={importPath}
+              onChange={(event) => setImportPath(event.target.value)}
+              placeholder="Optional server-visible JSON path"
+            />
+            <button
+              type="button"
+              className="contribute-primary-button"
+              onClick={() => importer.mutate()}
+              disabled={importer.isPending || !importTarget}
+            >
+              <FolderInput size={15} aria-hidden="true" />
+              {importer.isPending ? "Importing…" : "Import bundle"}
+            </button>
+          </div>
+          {importer.isSuccess ? (
+            <div className="flow-result">
+              <FileJson size={14} aria-hidden="true" />
+              <code>
+                <Blurred>{importTarget}</Blurred>
+              </code>
+            </div>
+          ) : null}
+          {importer.isError && (
+            <span className="flow-error">Import failed: {errorMessage(importer.error)}. The team dashboard was not changed.</span>
+          )}
+        </div>
+
+        <section className="team-import-list" aria-label="Imported team bundles">
+          <div className="team-import-list-head">
+            <h3>Imported team bundles</h3>
+            <strong>{compactInt(importedRecords.length)}</strong>
+          </div>
+          {imports.isError ? (
+            <p className="flow-error">Could not read the team bundle import list.</p>
+          ) : importedRecords.length > 0 ? (
+            <ul>
+              {importedRecords.map((record, index) => (
+                <li key={importRecordId(record, index)}>
+                  <div>
+                    <strong>
+                      <Blurred>{record.member_id ?? record.bundle_id ?? "team bundle"}</Blurred>
+                    </strong>
+                    <span>
+                      {compactInt(record.session_count)} sessions
+                      {record.generated_at ? ` · generated ${record.generated_at}` : ""}
+                    </span>
+                  </div>
+                  {record.source_path ? (
+                    <code>
+                      <Blurred>{record.source_path}</Blurred>
+                    </code>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No team bundles have been imported yet.</p>
+          )}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -16,6 +16,33 @@ function importRecordId(record: TeamImportRecord, index: number): string {
   return record.bundle_id ?? record.member_id ?? record.source_path ?? `team-import-${index}`;
 }
 
+type FileImportStatus = "imported" | "replaced" | "duplicate" | "stale" | "failed";
+
+interface FileImportResult {
+  filename: string;
+  status: FileImportStatus;
+  session_count?: number;
+  error?: string;
+}
+
+// Human-readable outcome for one bundle in a batch — mirrors the backend's
+// import status vocabulary so single- and multi-file imports read the same.
+function resultMessage(result: FileImportResult): string {
+  switch (result.status) {
+    case "replaced":
+      return "Replaced this member's previous bundle.";
+    case "duplicate":
+      return "Already imported — nothing changed.";
+    case "stale":
+      return "Older than this member's current bundle — nothing changed.";
+    case "failed":
+      return `Import failed: ${result.error ?? "unknown error"}.`;
+    case "imported":
+    default:
+      return `Imported ${result.session_count ?? 0} sessions.`;
+  }
+}
+
 function readLocalFile(file: File): Promise<string> {
   if (typeof file.text === "function") return file.text();
   return new Promise((resolve, reject) => {
@@ -31,22 +58,51 @@ function errorMessage(error: unknown): string {
 }
 
 // Team-scope "Import": bring in content-free bundles other members shared. Local
-// JSON files only — pick one from this browser or point at a server-visible path.
-// The app never uploads, and bundles carry no prompts/paths/commands/content.
+// JSON files only — pick one or more from this browser or point at a server-visible
+// path. The app never uploads, and bundles carry no prompts/paths/commands/content.
 export default function TeamBundleImport() {
   const queryClient = useQueryClient();
   const config = useQuery({ queryKey: ["config"], queryFn: getRuntimeConfig });
   const imports = useQuery({ queryKey: ["team-import-list"], queryFn: listTeamImports });
   const [importPath, setImportPath] = useState("");
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [fileResults, setFileResults] = useState<FileImportResult[] | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
 
   const importer = useMutation({
     mutationFn: async () => {
-      if (selectedFile) {
-        const text = await readLocalFile(selectedFile);
-        return importTeamBundleFile(selectedFile.name, JSON.parse(text) as unknown);
+      // Browser files take precedence over the server path. Each file is
+      // imported sequentially — the backend resolves replace/duplicate/stale
+      // from stored state, so order does not matter and sequential writes keep
+      // SQLite from contending with itself.
+      if (selectedFiles.length) {
+        const results: FileImportResult[] = [];
+        setProgress({ done: 0, total: selectedFiles.length });
+        for (const file of selectedFiles) {
+          try {
+            const text = await readLocalFile(file);
+            const parsed = JSON.parse(text) as unknown;
+            const res = await importTeamBundleFile(file.name, parsed);
+            results.push({ filename: file.name, status: res.status as FileImportStatus, session_count: res.session_count });
+          } catch (error) {
+            // One bad file (unreadable, invalid JSON, rejected import) is
+            // recorded and skipped so the rest of the batch still imports.
+            results.push({ filename: file.name, status: "failed", error: errorMessage(error) });
+          }
+          setProgress((prev) => (prev ? { ...prev, done: prev.done + 1 } : prev));
+          setFileResults([...results]);
+        }
+        setProgress(null);
+        return results;
       }
-      return importTeamBundle(importPath.trim() || null);
+      const res = await importTeamBundle(importPath.trim() || null);
+      const single: FileImportResult = {
+        filename: importPath.trim(),
+        status: res.status as FileImportStatus,
+        session_count: res.session_count,
+      };
+      setFileResults([single]);
+      return [single];
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["team-import-list"] });
@@ -67,9 +123,11 @@ export default function TeamBundleImport() {
   const importedMemberCount = new Set(
     importedRecords.map((record, index) => record.member_id ?? record.member_name ?? importRecordId(record, index)),
   ).size;
-  const importTarget = selectedFile?.name || importPath.trim() || "";
+  const hasFiles = selectedFiles.length > 0;
+  const canImport = hasFiles || importPath.trim().length > 0;
   const bundleRoot = config.data?.team_bundle_root ?? null;
-  const sourceMode = selectedFile ? "File" : importPath.trim() ? "Path" : "Idle";
+  const sourceMode = hasFiles ? (selectedFiles.length > 1 ? "Files" : "File") : importPath.trim() ? "Path" : "Idle";
+  const importButtonLabel = selectedFiles.length > 1 ? `Import ${selectedFiles.length} bundles` : "Import bundle";
 
   return (
     <main className="page team-flow-page team-import-page">
@@ -77,8 +135,8 @@ export default function TeamBundleImport() {
         <div className="contribute-titleblock team-titleblock">
           <h1 id="team-import-title">Import a team bundle</h1>
           <p>
-            Bring in content-free bundles your teammates shared. You can import from a local JSON
-            file in the browser or from a server-visible path without uploading conversation data.
+            Bring in content-free bundles your teammates shared. You can import one or more local
+            JSON files in the browser or a server-visible path without uploading conversation data.
           </p>
           <div className="team-root-row">
             <span>team_bundle_root</span>
@@ -105,8 +163,8 @@ export default function TeamBundleImport() {
             </div>
             <div className="team-flow-card-body team-flow-stack">
               <p className="team-flow-copy">
-                Choose a bundle JSON from this browser, or point to a server-visible file when the
-                backend can already read that location.
+                Choose one or more bundle JSONs from this browser, or point to a server-visible file
+                when the backend can already read that location.
               </p>
               <div className="team-mini-summary" aria-label="Supported import sources">
                 <span>Browser file</span>
@@ -124,12 +182,16 @@ export default function TeamBundleImport() {
             <div className="team-flow-card-body team-flow-stack">
               <div className="team-import-controls">
                 <label className="team-file-picker">
-                  <span>Bundle file</span>
+                  <span>Bundle files</span>
                   <input
-                    aria-label="Choose local team bundle file"
+                    aria-label="Choose local team bundle files"
                     type="file"
+                    multiple
                     accept=".json,application/json"
-                    onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+                    onChange={(event) => {
+                      setSelectedFiles(Array.from(event.target.files ?? []));
+                      setFileResults(null);
+                    }}
                   />
                 </label>
                 <label className="team-path-field">
@@ -145,25 +207,39 @@ export default function TeamBundleImport() {
                   type="button"
                   className="contribute-primary-button"
                   onClick={() => importer.mutate()}
-                  disabled={importer.isPending || !importTarget}
+                  disabled={importer.isPending || !canImport}
                 >
                   <FolderInput size={15} aria-hidden="true" />
-                  {importer.isPending ? "Importing…" : "Import bundle"}
+                  {importer.isPending ? "Importing…" : importButtonLabel}
                 </button>
               </div>
 
-              {importer.isSuccess && importer.data ? (
-                <div className="flow-result">
-                  <FileJson size={14} aria-hidden="true" />
-                  <code>
-                    <Blurred>{importTarget}</Blurred>
-                  </code>
-                  <span>
-                    {importer.data.status === "replaced" && "Replaced this member's previous bundle."}
-                    {importer.data.status === "duplicate" && "Already imported — nothing changed."}
-                    {importer.data.status === "stale" && "Older than this member's current bundle — nothing changed."}
-                    {importer.data.status === "imported" && `Imported ${importer.data.session_count} sessions.`}
-                  </span>
+              {hasFiles && !importer.isPending ? (
+                <span className="team-file-count">
+                  {selectedFiles.length} file{selectedFiles.length === 1 ? "" : "s"} selected
+                </span>
+              ) : null}
+
+              {importer.isPending && progress ? (
+                <span className="team-import-progress" role="status">
+                  Importing {Math.min(progress.done + 1, progress.total)} of {progress.total}…
+                </span>
+              ) : null}
+
+              {fileResults && fileResults.length > 0 ? (
+                <div className="team-import-results" aria-label="Import results">
+                  {fileResults.map((result, index) => (
+                    <div
+                      key={`${result.filename}-${index}`}
+                      className={result.status === "failed" ? "flow-result flow-error" : "flow-result"}
+                    >
+                      <FileJson size={14} aria-hidden="true" />
+                      <code>
+                        <Blurred>{result.filename}</Blurred>
+                      </code>
+                      <span>{resultMessage(result)}</span>
+                    </div>
+                  ))}
                 </div>
               ) : null}
 

--- a/frontend/src/team/TeamBundleImport.tsx
+++ b/frontend/src/team/TeamBundleImport.tsx
@@ -158,7 +158,11 @@ export default function TeamBundleImport() {
                     className="team-remove-member"
                     aria-label={`Remove ${record.member_id ?? "member"}`}
                     disabled={removeMember.isPending}
-                    onClick={() => record.member_id && removeMember.mutate(record.member_id)}
+                    onClick={() => {
+                      if (record.member_id && window.confirm(`Remove all imported bundles from ${record.member_id}?`)) {
+                        removeMember.mutate(record.member_id);
+                      }
+                    }}
                   >
                     Remove
                   </button>
@@ -167,6 +171,9 @@ export default function TeamBundleImport() {
             </ul>
           ) : (
             <p>No team bundles have been imported yet.</p>
+          )}
+          {removeMember.isError && (
+            <span className="flow-error">Remove failed: {errorMessage(removeMember.error)}. The team dashboard was not changed.</span>
           )}
         </section>
       </section>

--- a/frontend/src/team/TeamOverview.test.tsx
+++ b/frontend/src/team/TeamOverview.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TeamOverview from "./TeamOverview";
+
+vi.mock("../api/client", () => ({ getTeamDashboard: vi.fn() }));
+
+import { getTeamDashboard } from "../api/client";
+
+const dashboard = {
+  meta: { bundle_count: 2, member_count: 3, project_count: 4, session_count: 9, date_from: "2026-06-01", date_to: "2026-06-05" },
+  tokens: { input: 12_000, output: 5_000, base: 0, cache_5m: 0, cache_1h: 0, cache_read: 0, total: 27_000 },
+  stats: { errors: 7, loops: 2 },
+  providers: [{ provider: "claude", session_count: 9 }],
+  models: [
+    { model: "opus", session_count: 6 },
+    { model: "sonnet", session_count: 3 },
+  ],
+  stop_reasons: [],
+  risk_categories: [
+    { category: "cost_context_blowup", session_count: 5 },
+    { category: "permission_friction", session_count: 3 },
+  ],
+  subagents: [],
+  sequence: [{ sym: "CALL:inspect:Read", count: 4 }],
+  members: [],
+  over_time: [
+    { date: "2026-06-01", session_count: 4, tokens: 12_000 },
+    { date: "2026-06-05", session_count: 5, tokens: 15_000 },
+  ],
+};
+
+function renderOverview(onGoToImport = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <TeamOverview onGoToImport={onGoToImport} />
+    </QueryClientProvider>,
+  );
+  return onGoToImport;
+}
+
+describe("TeamOverview", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows a loading state while the dashboard loads", () => {
+    vi.mocked(getTeamDashboard).mockReturnValue(new Promise(() => undefined) as never);
+    renderOverview();
+    expect(screen.getByText(/Loading team overview/i)).toBeInTheDocument();
+  });
+
+  it("shows an error state when the dashboard fails", async () => {
+    vi.mocked(getTeamDashboard).mockRejectedValue(new Error("boom") as never);
+    renderOverview();
+    expect(await screen.findByText(/Team overview unavailable/i)).toBeInTheDocument();
+  });
+
+  it("prompts for an import when there are no team bundles", async () => {
+    vi.mocked(getTeamDashboard).mockResolvedValue({
+      ...dashboard,
+      meta: { ...dashboard.meta, session_count: 0, bundle_count: 0 },
+    } as never);
+    const onGoToImport = renderOverview();
+
+    expect(await screen.findByText(/No team bundles imported yet/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Go to Import/i }));
+    expect(onGoToImport).toHaveBeenCalled();
+  });
+
+  it("renders totals, activity, risk, model mix, and symbols", async () => {
+    vi.mocked(getTeamDashboard).mockResolvedValue(dashboard as never);
+    renderOverview();
+
+    const totals = await screen.findByLabelText("Team totals");
+    expect(within(totals).getByText("Members").closest(".contribute-metric")).toHaveTextContent("3");
+    expect(within(totals).getByText("Projects").closest(".contribute-metric")).toHaveTextContent("4");
+    expect(within(totals).getByText("Sessions").closest(".contribute-metric")).toHaveTextContent("9");
+    expect(within(totals).getByText("Tokens").closest(".contribute-metric")).toHaveTextContent("27k");
+
+    expect(screen.getByRole("img", { name: "Activity over time" })).toBeInTheDocument();
+
+    const risk = screen.getByLabelText("Team risk patterns");
+    expect(within(risk).getByText(/cost context blowup/i)).toBeInTheDocument();
+    expect(within(risk).getByText(/permission friction/i)).toBeInTheDocument();
+
+    const modelMix = screen.getByLabelText("Team model mix");
+    expect(within(modelMix).getByText("opus")).toBeInTheDocument();
+    expect(within(modelMix).getByText("sonnet")).toBeInTheDocument();
+
+    expect(screen.getByText(/Read/)).toHaveTextContent("x4");
+  });
+});

--- a/frontend/src/team/TeamOverview.test.tsx
+++ b/frontend/src/team/TeamOverview.test.tsx
@@ -24,6 +24,9 @@ const dashboard = {
   subagents: [],
   sequence: [{ sym: "CALL:inspect:Read", count: 4 }],
   members: [],
+  projects: [],
+  tools: [],
+  file_types: [],
   over_time: [
     { date: "2026-06-01", session_count: 4, tokens: 12_000 },
     { date: "2026-06-05", session_count: 5, tokens: 15_000 },
@@ -88,5 +91,43 @@ describe("TeamOverview", () => {
     expect(within(modelMix).getByText("sonnet")).toBeInTheDocument();
 
     expect(screen.getByText(/Read/)).toHaveTextContent("x4");
+  });
+
+  it("renders member, project, toolchain, and file-type breakdowns", async () => {
+    vi.mocked(getTeamDashboard).mockResolvedValue({
+      ...dashboard,
+      members: [
+        { member_name: "Avery", member_ids: ["1111"], bundle_count: 1, project_count: 1, session_count: 3, tokens: 900 },
+        { member_name: "member-2222abcd", member_ids: ["2222abcd"], bundle_count: 1, project_count: 1, session_count: 1, tokens: 100 },
+      ],
+      projects: [
+        { project_key: "alpha", project_name: "alpha", member_count: 2, session_count: 4, tokens: 1000 },
+      ],
+      tools: [{ name: "Read", call_count: 12, session_count: 3 }],
+      file_types: [{ ext: "py", count: 9, session_count: 3 }],
+    } as never);
+    renderOverview();
+
+    expect(await screen.findByText("Tokens by member")).toBeInTheDocument();
+    expect(screen.getByText("Avery")).toBeInTheDocument();
+    expect(screen.getByText("Tokens by project")).toBeInTheDocument();
+    expect(screen.getByText("Toolchain")).toBeInTheDocument();
+    expect(screen.getByText(".py")).toBeInTheDocument();
+  });
+
+  it("hides the toolchain row when no team-level bundles exist", async () => {
+    vi.mocked(getTeamDashboard).mockResolvedValue({
+      ...dashboard,
+      members: [
+        { member_name: "member-1111abcd", member_ids: ["1111abcd"], bundle_count: 1, project_count: 1, session_count: 3, tokens: 900 },
+      ],
+      projects: [{ project_key: "a1b2c3d4", project_name: "a1b2c3d4", member_count: 1, session_count: 3, tokens: 900 }],
+      tools: [],
+      file_types: [],
+    } as never);
+    renderOverview();
+
+    expect(await screen.findByText("Tokens by member")).toBeInTheDocument();
+    expect(screen.queryByText("Toolchain")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/team/TeamOverview.tsx
+++ b/frontend/src/team/TeamOverview.tsx
@@ -23,7 +23,7 @@ export default function TeamOverview({ onGoToImport }: Props) {
 
   if (dashboard.isLoading) {
     return (
-      <main className="page contribute-page team-page">
+      <main className="page team-flow-page team-overview-page">
         <div className="contribute-state">Loading team overview…</div>
       </main>
     );
@@ -31,7 +31,7 @@ export default function TeamOverview({ onGoToImport }: Props) {
 
   if (dashboard.isError || !dashboard.data) {
     return (
-      <main className="page contribute-page team-page">
+      <main className="page team-flow-page team-overview-page">
         <div className="contribute-state panel-error">
           <strong>Team overview unavailable.</strong>
           <span>Could not load the aggregated team dashboard.</span>
@@ -46,7 +46,7 @@ export default function TeamOverview({ onGoToImport }: Props) {
 
   if (sessionCount === 0) {
     return (
-      <main className="page contribute-page team-page">
+      <main className="page team-flow-page team-overview-page">
         <Header />
         <div className="team-empty card">
           <strong>No team bundles imported yet.</strong>
@@ -80,9 +80,9 @@ export default function TeamOverview({ onGoToImport }: Props) {
   const modelMax = Math.max(...models.map((m) => m.session_count), 1);
 
   return (
-    <main className="page contribute-page team-page">
+    <main className="page team-flow-page team-overview-page">
       <Header>
-        <div className="contribute-metrics team-metrics" aria-label="Team totals">
+        <div className="contribute-metrics team-metrics team-flow-metrics" aria-label="Team totals">
           <Metric value={meta?.member_count ?? 0} label="Members" />
           <Metric value={meta?.project_count ?? 0} label="Projects" />
           <Metric value={sessionCount} label="Sessions" />
@@ -90,119 +90,123 @@ export default function TeamOverview({ onGoToImport }: Props) {
         </div>
       </Header>
 
-      <section className="team-dashboard-strip" aria-label="Team totals detail">
-        <div>
-          <span>Token totals</span>
-          <strong>{compactInt(tokens?.input ?? 0)} in / {compactInt(tokens?.output ?? 0)} out</strong>
-        </div>
-        <div>
-          <span>Errors</span>
-          <strong>{compactInt(stats?.errors ?? 0)}</strong>
-        </div>
-        <div>
-          <span>Loops</span>
-          <strong>{compactInt(stats?.loops ?? 0)}</strong>
-        </div>
-        <div>
-          <span>Bundles</span>
-          <strong>{compactInt(meta?.bundle_count ?? 0)}</strong>
-        </div>
-      </section>
-
-      {overTime.length > 0 ? (
-        <section className="team-activity card" aria-labelledby="team-activity-title">
-          <div className="team-symbols-head">
-            <h2 id="team-activity-title">Activity over time</h2>
-            <span>
-              {meta?.date_from} → {meta?.date_to}
-            </span>
+      <section className="team-overview-body" aria-label="Team overview workspace">
+        <section className="team-dashboard-strip" aria-label="Team totals detail">
+          <div>
+            <span>Token totals</span>
+            <strong>{compactInt(tokens?.input ?? 0)} in / {compactInt(tokens?.output ?? 0)} out</strong>
           </div>
-          <svg
-            className="team-activity-svg"
-            viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-            preserveAspectRatio="none"
-            role="img"
-            aria-label="Activity over time"
-          >
-            <path d={activity.areaPath} className="team-activity-area" />
-            <path d={activity.linePath} className="team-activity-line" fill="none" vectorEffect="non-scaling-stroke" />
-          </svg>
+          <div>
+            <span>Errors</span>
+            <strong>{compactInt(stats?.errors ?? 0)}</strong>
+          </div>
+          <div>
+            <span>Loops</span>
+            <strong>{compactInt(stats?.loops ?? 0)}</strong>
+          </div>
+          <div>
+            <span>Bundles</span>
+            <strong>{compactInt(meta?.bundle_count ?? 0)}</strong>
+          </div>
         </section>
-      ) : null}
 
-      <div className="team-breakdowns">
-        <TeamBars
-          title="Risk patterns"
-          ariaLabel="Team risk patterns"
-          rows={risks.map((r) => ({ label: prettyRisk(r.category), value: r.session_count }))}
-          max={riskMax}
-          empty="No risk findings across team bundles."
-        />
-        <TeamBars
-          title="Model mix"
-          ariaLabel="Team model mix"
-          rows={models.map((m) => ({ label: m.model, value: m.session_count }))}
-          max={modelMax}
-          empty="No models recorded."
-        />
-      </div>
+        <div className="team-overview-board">
+          {overTime.length > 0 ? (
+            <section className="team-activity card" aria-labelledby="team-activity-title">
+              <div className="team-symbols-head">
+                <h2 id="team-activity-title">Activity over time</h2>
+                <span>
+                  {meta?.date_from} → {meta?.date_to}
+                </span>
+              </div>
+              <svg
+                className="team-activity-svg"
+                viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+                preserveAspectRatio="none"
+                role="img"
+                aria-label="Activity over time"
+              >
+                <path d={activity.areaPath} className="team-activity-area" />
+                <path d={activity.linePath} className="team-activity-line" fill="none" vectorEffect="non-scaling-stroke" />
+              </svg>
+            </section>
+          ) : null}
 
-      {(members.length > 0 || projectRows.length > 0) && (
-        <div className="team-breakdowns">
-          <TeamBars
-            title="Tokens by member"
-            ariaLabel="Tokens by member"
-            rows={memberRows.map((m) => ({ label: m.member_name, value: m.tokens }))}
-            max={memberMax}
-            empty="No members yet."
-          />
-          <TeamBars
-            title="Tokens by project"
-            ariaLabel="Tokens by project"
-            rows={projectRows.map((p) => ({ label: p.project_name, value: p.tokens }))}
-            max={projectMax}
-            empty="No projects yet."
-          />
-        </div>
-      )}
-      {(tools.length > 0 || fileTypes.length > 0) && (
-        <div className="team-breakdowns">
-          <TeamBars
-            title="Toolchain"
-            ariaLabel="Team toolchain"
-            rows={tools.slice(0, 8).map((t) => ({ label: t.name, value: t.call_count }))}
-            max={toolMax}
-            empty="Tool names appear once team-level bundles are imported."
-          />
-          <TeamBars
-            title="File types"
-            ariaLabel="Team file types"
-            rows={fileTypes.slice(0, 8).map((f) => ({ label: `.${f.ext}`, value: f.count }))}
-            max={fileTypeMax}
-            empty="File types appear once team-level bundles are imported."
-          />
-        </div>
-      )}
+          <div className="team-breakdowns">
+            <TeamBars
+              title="Risk patterns"
+              ariaLabel="Team risk patterns"
+              rows={risks.map((r) => ({ label: prettyRisk(r.category), value: r.session_count }))}
+              max={riskMax}
+              empty="No risk findings across team bundles."
+            />
+            <TeamBars
+              title="Model mix"
+              ariaLabel="Team model mix"
+              rows={models.map((m) => ({ label: m.model, value: m.session_count }))}
+              max={modelMax}
+              empty="No models recorded."
+            />
+          </div>
 
-      <section className="team-symbols" aria-labelledby="team-symbols-title">
-        <div className="team-symbols-head">
-          <h2 id="team-symbols-title">Top sequence symbols</h2>
-          <span>{compactInt(meta?.bundle_count ?? 0)} imported bundles</span>
+          {(members.length > 0 || projectRows.length > 0) && (
+            <div className="team-breakdowns">
+              <TeamBars
+                title="Tokens by member"
+                ariaLabel="Tokens by member"
+                rows={memberRows.map((m) => ({ label: m.member_name, value: m.tokens }))}
+                max={memberMax}
+                empty="No members yet."
+              />
+              <TeamBars
+                title="Tokens by project"
+                ariaLabel="Tokens by project"
+                rows={projectRows.map((p) => ({ label: p.project_name, value: p.tokens }))}
+                max={projectMax}
+                empty="No projects yet."
+              />
+            </div>
+          )}
+          {(tools.length > 0 || fileTypes.length > 0) && (
+            <div className="team-breakdowns">
+              <TeamBars
+                title="Toolchain"
+                ariaLabel="Team toolchain"
+                rows={tools.slice(0, 8).map((t) => ({ label: t.name, value: t.call_count }))}
+                max={toolMax}
+                empty="Tool names appear once team-level bundles are imported."
+              />
+              <TeamBars
+                title="File types"
+                ariaLabel="Team file types"
+                rows={fileTypes.slice(0, 8).map((f) => ({ label: `.${f.ext}`, value: f.count }))}
+                max={fileTypeMax}
+                empty="File types appear once team-level bundles are imported."
+              />
+            </div>
+          )}
+
+          <section className="team-symbols" aria-labelledby="team-symbols-title">
+            <div className="team-symbols-head">
+              <h2 id="team-symbols-title">Top sequence symbols</h2>
+              <span>{compactInt(meta?.bundle_count ?? 0)} imported bundles</span>
+            </div>
+            {symbols.length > 0 ? (
+              <ol className="seq-strand">
+                {symbols.map(({ sym, count }) => {
+                  const { label, kind } = prettySymbol(sym);
+                  return (
+                    <li className={`seq-chip k-${kind}`} key={sym} title={sym}>
+                      {label} <em>x{compactInt(count)}</em>
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : (
+              <p>No sequence symbols yet.</p>
+            )}
+          </section>
         </div>
-        {symbols.length > 0 ? (
-          <ol className="seq-strand">
-            {symbols.map(({ sym, count }) => {
-              const { label, kind } = prettySymbol(sym);
-              return (
-                <li className={`seq-chip k-${kind}`} key={sym} title={sym}>
-                  {label} <em>x{compactInt(count)}</em>
-                </li>
-              );
-            })}
-          </ol>
-        ) : (
-          <p>No sequence symbols yet.</p>
-        )}
       </section>
     </main>
   );
@@ -210,7 +214,7 @@ export default function TeamOverview({ onGoToImport }: Props) {
 
 function Header({ children }: { children?: React.ReactNode }) {
   return (
-    <section className="contribute-header" aria-labelledby="team-title">
+    <section className="contribute-header team-flow-header" aria-labelledby="team-title">
       <div className="contribute-titleblock team-titleblock">
         <h1 id="team-title">Team overview</h1>
         <p>Aggregated usage across imported team bundles — no prompts, file contents, or commands.</p>

--- a/frontend/src/team/TeamOverview.tsx
+++ b/frontend/src/team/TeamOverview.tsx
@@ -63,6 +63,16 @@ export default function TeamOverview({ onGoToImport }: Props) {
   const stats = summary.stats;
   const risks = summary.risk_categories ?? [];
   const models = summary.models ?? [];
+  const members = summary.members ?? [];
+  const projects = summary.projects ?? [];
+  const tools = summary.tools ?? [];
+  const fileTypes = summary.file_types ?? [];
+  const memberRows = [...members].sort((a, b) => b.tokens - a.tokens).slice(0, 8);
+  const projectRows = [...projects].slice(0, 8); // backend already sorts by tokens desc
+  const memberMax = Math.max(...memberRows.map((m) => m.tokens), 1);
+  const projectMax = Math.max(...projectRows.map((p) => p.tokens), 1);
+  const toolMax = Math.max(...tools.slice(0, 8).map((t) => t.call_count), 1);
+  const fileTypeMax = Math.max(...fileTypes.slice(0, 8).map((f) => f.count), 1);
   const symbols = (summary.sequence ?? []).slice(0, 8);
   const overTime = summary.over_time ?? [];
   const activity = buildAreaChart(overTime.map((p) => ({ label: p.date, value: p.tokens })), CHART_W, CHART_H);
@@ -136,6 +146,43 @@ export default function TeamOverview({ onGoToImport }: Props) {
           empty="No models recorded."
         />
       </div>
+
+      {(members.length > 0 || projectRows.length > 0) && (
+        <div className="team-breakdowns">
+          <TeamBars
+            title="Tokens by member"
+            ariaLabel="Tokens by member"
+            rows={memberRows.map((m) => ({ label: m.member_name, value: m.tokens }))}
+            max={memberMax}
+            empty="No members yet."
+          />
+          <TeamBars
+            title="Tokens by project"
+            ariaLabel="Tokens by project"
+            rows={projectRows.map((p) => ({ label: p.project_name, value: p.tokens }))}
+            max={projectMax}
+            empty="No projects yet."
+          />
+        </div>
+      )}
+      {(tools.length > 0 || fileTypes.length > 0) && (
+        <div className="team-breakdowns">
+          <TeamBars
+            title="Toolchain"
+            ariaLabel="Team toolchain"
+            rows={tools.slice(0, 8).map((t) => ({ label: t.name, value: t.call_count }))}
+            max={toolMax}
+            empty="Tool names appear once team-level bundles are imported."
+          />
+          <TeamBars
+            title="File types"
+            ariaLabel="Team file types"
+            rows={fileTypes.slice(0, 8).map((f) => ({ label: `.${f.ext}`, value: f.count }))}
+            max={fileTypeMax}
+            empty="File types appear once team-level bundles are imported."
+          />
+        </div>
+      )}
 
       <section className="team-symbols" aria-labelledby="team-symbols-title">
         <div className="team-symbols-head">

--- a/frontend/src/team/TeamOverview.tsx
+++ b/frontend/src/team/TeamOverview.tsx
@@ -1,0 +1,222 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { getTeamDashboard } from "../api/client";
+import { compactInt, prettySymbol } from "../contribute/specimen";
+import { buildAreaChart } from "./teamCharts";
+
+const CHART_W = 600;
+const CHART_H = 130;
+
+function prettyRisk(category: string): string {
+  return category.replace(/_/g, " ");
+}
+
+interface Props {
+  onGoToImport: () => void;
+}
+
+// The team-scope "Overview": the same aggregate story the local Overview tells,
+// but computed on the backend from imported team bundles. No per-session detail
+// exists in a bundle, so there is nothing to drill into here by design.
+export default function TeamOverview({ onGoToImport }: Props) {
+  const dashboard = useQuery({ queryKey: ["team-dashboard"], queryFn: getTeamDashboard });
+
+  if (dashboard.isLoading) {
+    return (
+      <main className="page contribute-page team-page">
+        <div className="contribute-state">Loading team overview…</div>
+      </main>
+    );
+  }
+
+  if (dashboard.isError || !dashboard.data) {
+    return (
+      <main className="page contribute-page team-page">
+        <div className="contribute-state panel-error">
+          <strong>Team overview unavailable.</strong>
+          <span>Could not load the aggregated team dashboard.</span>
+        </div>
+      </main>
+    );
+  }
+
+  const summary = dashboard.data;
+  const meta = summary.meta;
+  const sessionCount = meta?.session_count ?? 0;
+
+  if (sessionCount === 0) {
+    return (
+      <main className="page contribute-page team-page">
+        <Header />
+        <div className="team-empty card">
+          <strong>No team bundles imported yet.</strong>
+          <p>Import a team bundle to see aggregated usage, risk patterns, and activity.</p>
+          <button type="button" className="contribute-primary-button" onClick={onGoToImport}>
+            <ArrowRight size={15} aria-hidden="true" /> Go to Import
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  const tokens = summary.tokens;
+  const stats = summary.stats;
+  const risks = summary.risk_categories ?? [];
+  const models = summary.models ?? [];
+  const symbols = (summary.sequence ?? []).slice(0, 8);
+  const overTime = summary.over_time ?? [];
+  const activity = buildAreaChart(overTime.map((p) => ({ label: p.date, value: p.tokens })), CHART_W, CHART_H);
+  const riskMax = Math.max(...risks.map((r) => r.session_count), 1);
+  const modelMax = Math.max(...models.map((m) => m.session_count), 1);
+
+  return (
+    <main className="page contribute-page team-page">
+      <Header>
+        <div className="contribute-metrics team-metrics" aria-label="Team totals">
+          <Metric value={meta?.member_count ?? 0} label="Members" />
+          <Metric value={meta?.project_count ?? 0} label="Projects" />
+          <Metric value={sessionCount} label="Sessions" />
+          <Metric value={tokens?.total ?? 0} label="Tokens" />
+        </div>
+      </Header>
+
+      <section className="team-dashboard-strip" aria-label="Team totals detail">
+        <div>
+          <span>Token totals</span>
+          <strong>{compactInt(tokens?.input ?? 0)} in / {compactInt(tokens?.output ?? 0)} out</strong>
+        </div>
+        <div>
+          <span>Errors</span>
+          <strong>{compactInt(stats?.errors ?? 0)}</strong>
+        </div>
+        <div>
+          <span>Loops</span>
+          <strong>{compactInt(stats?.loops ?? 0)}</strong>
+        </div>
+        <div>
+          <span>Bundles</span>
+          <strong>{compactInt(meta?.bundle_count ?? 0)}</strong>
+        </div>
+      </section>
+
+      {overTime.length > 0 ? (
+        <section className="team-activity card" aria-labelledby="team-activity-title">
+          <div className="team-symbols-head">
+            <h2 id="team-activity-title">Activity over time</h2>
+            <span>
+              {meta?.date_from} → {meta?.date_to}
+            </span>
+          </div>
+          <svg
+            className="team-activity-svg"
+            viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+            preserveAspectRatio="none"
+            role="img"
+            aria-label="Activity over time"
+          >
+            <path d={activity.areaPath} className="team-activity-area" />
+            <path d={activity.linePath} className="team-activity-line" fill="none" vectorEffect="non-scaling-stroke" />
+          </svg>
+        </section>
+      ) : null}
+
+      <div className="team-breakdowns">
+        <TeamBars
+          title="Risk patterns"
+          ariaLabel="Team risk patterns"
+          rows={risks.map((r) => ({ label: prettyRisk(r.category), value: r.session_count }))}
+          max={riskMax}
+          empty="No risk findings across team bundles."
+        />
+        <TeamBars
+          title="Model mix"
+          ariaLabel="Team model mix"
+          rows={models.map((m) => ({ label: m.model, value: m.session_count }))}
+          max={modelMax}
+          empty="No models recorded."
+        />
+      </div>
+
+      <section className="team-symbols" aria-labelledby="team-symbols-title">
+        <div className="team-symbols-head">
+          <h2 id="team-symbols-title">Top sequence symbols</h2>
+          <span>{compactInt(meta?.bundle_count ?? 0)} imported bundles</span>
+        </div>
+        {symbols.length > 0 ? (
+          <ol className="seq-strand">
+            {symbols.map(({ sym, count }) => {
+              const { label, kind } = prettySymbol(sym);
+              return (
+                <li className={`seq-chip k-${kind}`} key={sym} title={sym}>
+                  {label} <em>x{compactInt(count)}</em>
+                </li>
+              );
+            })}
+          </ol>
+        ) : (
+          <p>No sequence symbols yet.</p>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function Header({ children }: { children?: React.ReactNode }) {
+  return (
+    <section className="contribute-header" aria-labelledby="team-title">
+      <div className="contribute-titleblock team-titleblock">
+        <h1 id="team-title">Team overview</h1>
+        <p>Aggregated usage across imported team bundles — no prompts, file contents, or commands.</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Metric({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="contribute-metric">
+      <strong>{compactInt(value)}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function TeamBars({
+  title,
+  ariaLabel,
+  rows,
+  max,
+  empty,
+}: {
+  title: string;
+  ariaLabel: string;
+  rows: { label: string; value: number }[];
+  max: number;
+  empty: string;
+}) {
+  return (
+    <section className="team-bars card" aria-label={ariaLabel}>
+      <div className="team-symbols-head">
+        <h2>{title}</h2>
+      </div>
+      {rows.length > 0 ? (
+        <div className="team-bar-rows">
+          {rows.map((row) => (
+            <div className="team-bar-row" key={row.label}>
+              <span className="team-bar-label" title={row.label}>
+                {row.label}
+              </span>
+              <span className="team-bar-track">
+                <i style={{ width: `${(row.value / max) * 100}%` }} />
+              </span>
+              <span className="team-bar-val">{compactInt(row.value)}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>{empty}</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/team/teamCharts.test.ts
+++ b/frontend/src/team/teamCharts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildAreaChart } from "./teamCharts";
+
+describe("buildAreaChart", () => {
+  it("returns empty geometry for no data", () => {
+    const chart = buildAreaChart([], 100, 50);
+    expect(chart.linePath).toBe("");
+    expect(chart.areaPath).toBe("");
+    expect(chart.points).toEqual([]);
+    expect(chart.yMax).toBe(0);
+  });
+
+  it("maps values into an area + line path scaled to the max", () => {
+    const chart = buildAreaChart(
+      [
+        { label: "a", value: 10 },
+        { label: "b", value: 20 },
+      ],
+      100,
+      50,
+    );
+    expect(chart.yMax).toBe(20);
+    expect(chart.linePath).toBe("M0,25 L100,0");
+    expect(chart.areaPath).toBe("M0,25 L100,0 L100,50 L0,50 Z");
+    expect(chart.points).toEqual([
+      { x: 0, y: 25, label: "a", value: 10 },
+      { x: 100, y: 0, label: "b", value: 20 },
+    ]);
+  });
+
+  it("flattens to the baseline when every value is zero", () => {
+    const chart = buildAreaChart(
+      [
+        { label: "a", value: 0 },
+        { label: "b", value: 0 },
+      ],
+      100,
+      50,
+    );
+    expect(chart.yMax).toBe(0);
+    expect(chart.linePath).toBe("M0,50 L100,50");
+  });
+
+  it("places a single point on the left", () => {
+    const chart = buildAreaChart([{ label: "a", value: 5 }], 100, 50);
+    expect(chart.points).toEqual([{ x: 0, y: 0, label: "a", value: 5 }]);
+    expect(chart.linePath).toBe("M0,0");
+  });
+});

--- a/frontend/src/team/teamCharts.ts
+++ b/frontend/src/team/teamCharts.ts
@@ -1,0 +1,56 @@
+// Minimal hand-rolled area-chart geometry for the team activity strip. Kept
+// separate from the cost chartGeometry (which is spend/model-specific) and
+// deliberately dependency-free, matching the app's no-charting-library rule.
+
+export interface AreaPoint {
+  label: string;
+  value: number;
+}
+
+export interface AreaChartPoint {
+  x: number;
+  y: number;
+  label: string;
+  value: number;
+}
+
+export interface AreaChart {
+  areaPath: string;
+  linePath: string;
+  points: AreaChartPoint[];
+  yMax: number;
+}
+
+function coord(n: number): string {
+  return String(Number(n.toFixed(2)));
+}
+
+export function buildAreaChart(data: AreaPoint[], width: number, height: number): AreaChart {
+  if (data.length === 0) {
+    return { areaPath: "", linePath: "", points: [], yMax: 0 };
+  }
+
+  const yMax = data.reduce((max, point) => Math.max(max, point.value), 0);
+  const denom = yMax > 0 ? yMax : 1;
+  const lastIndex = data.length - 1;
+
+  const points: AreaChartPoint[] = data.map((point, index) => ({
+    x: lastIndex === 0 ? 0 : (index / lastIndex) * width,
+    y: height - (point.value / denom) * height,
+    label: point.label,
+    value: point.value,
+  }));
+
+  const linePath = points
+    .map((point, index) => `${index === 0 ? "M" : "L"}${coord(point.x)},${coord(point.y)}`)
+    .join(" ");
+
+  const first = points[0];
+  const last = points[lastIndex];
+  const areaPath =
+    lastIndex === 0
+      ? `${linePath} L${coord(first.x)},${coord(height)} Z`
+      : `${linePath} L${coord(last.x)},${coord(height)} L${coord(first.x)},${coord(height)} Z`;
+
+  return { areaPath, linePath, points, yMax };
+}


### PR DESCRIPTION
## Team bundle sharing & aggregate team analytics

Lets a team pool Claude Code usage without ever sharing raw conversation content. Each member exports a content-free **team bundle** from their local index; a manager imports the bundles and gets the app's Overview/Cost story computed in aggregate across the team.

### Privacy ladder

Bundles are built from a structural allowlist and reuse the contribution sanitizers — no previews, paths, commands, prompts, model aliases, or MCP names ever leave the machine. Two levels:

- **Structural** — fully pseudonymous: hashed ids, bucketed names, zero free text.
- **Team** — adds member name, project names, tool names, and file-type mix (extensions only); still no conversation content.

Two further rungs (`sessions`, `raw`) are reserved in the wire format for future raw-session sharing and shown as greyed-out "planned" rungs.

### Scope-aware UI

New client-side **data scope** lens (`local` / `team`), with scope-filtered navigation:

- **Export** (new, local-only) — write a bundle from this machine: pick a privacy level, pick/relabel projects, edit member name. A privacy ledger shows exactly what leaves before you export.
- **Import** — scope-aware; team imports accept a server path or a browser-picked JSON file, with batch outcomes (imported / replaced / duplicate / stale / failed) and single-member removal.
- **Overview** and **Cost** render team-aggregate data through the existing components. Drilldowns and Explore stay local-only — bundles carry no per-session detail by design.

### Backend

- `analysis/team_bundles.py` — build/import, canonicalization, level-aware allowlist, dashboard aggregation. Wire `SCHEMA_VERSION` 2 with v1 compatibility.
- `analysis/team_cost.py` — cost over imported bundles, mirroring the per-model math so Cost renders team data unchanged.
- `ingest/file_ext.py` — derive-then-drop: paths are parsed for their extension at ingest and discarded; only the extension is stored (`tool_calls.file_ext`).
- `/api/team/*` endpoints (projects, export-preview, export, import, import-bundle, imports, reset, members/{id} DELETE, dashboard, analytics/cost) + schemas.
- New `team_bundles` / `team_bundle_sessions` tables and migrations, plus `projects.source_signature` and `tool_calls.file_ext`.

### Supporting import hardening

Per-project transactional imports (clean rollback, truthful counts); malformed JSONL/meta recorded and skipped instead of aborting; re-import on changed export via `source_signature`; throttled progress queries; re-importing a member's bundle replaces rather than double-counts.

### Config & tests

- New `CCFR_TEAM_BUNDLE_ROOT` (path-confined); `docker-compose.yml`, `.gitignore`, `README.md`, `PRIVACY.md` updated.
- New backend suites (`test_team_bundles`, `_api`, `test_team_cost`, `test_file_ext`, `test_config`) and frontend suites for the team components, scope hook, and charts.

### Compatibility

Additive migrations only; with no bundle root the app behaves exactly as before, and v1 bundles remain importable.
