### PR TITLE
docs: cut the 0.1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,36 +6,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-- Privacy mode now blurs Context Economics "Heaviest contributors" labels, which
-  previously exposed raw file paths.
-- Installed wheels (`uvx` / `pipx` / `pip`) now bundle `pricing.csv` and the
-  demo dataset, default their data directory to `~/.checkyouragent`, and read
-  optional dated pricing snapshots from `~/.checkyouragent/pricing`, so cost
-  analytics and Load demo data work outside a source checkout. The server also
-  logs the resolved database path at startup.
+## [0.1.0] - 2026-07-11
 
-### Added
-- Synthetic demo dataset and a "Load demo data" action on the Import page, so the
-  product's value is visible before importing real logs.
-- The CLI now tips its hat on startup (CYA -- cover your assets).
-
-### Changed
-- Renamed the GitHub repository to `checkyouragent` (old
-  `authrty-claude-code-analytics` URLs redirect automatically).
-- Clarified licensing: the Business Source License 1.1 now carries an Additional
-  Use Grant permitting free personal and internal use.
-- Rewrote the README to lead with the avoidable-spend outcome and added a "How it
-  compares" section covering ccusage, token-dashboard, Sniffly, and Anthropic's
-  native analytics.
-
-### Removed
-- Hid the unfinished "soon" Explore technique tiles and the disabled team-export
-  rungs; removed the unmounted contribution page from the build.
-
-## [0.1.0] - 2026-07-05
-
-First tagged release. Local, privacy-strict forensic analytics for Claude Code
+First public release. Local, privacy-strict forensic analytics for Claude Code
 `~/.claude/projects` exports.
 
 ### Added
@@ -54,3 +27,33 @@ First tagged release. Local, privacy-strict forensic analytics for Claude Code
 - Content-free team bundles at structural and team privacy levels, with team
   aggregate Overview and Cost views.
 - Privacy mode that blurs sensitive UI text for safe screenshots.
+- Synthetic demo dataset and a "Load demo data" action on the Import page, so the
+  product's value is visible before importing real logs.
+- The CLI now tips its hat on startup (CYA -- cover your assets).
+
+### Fixed
+- Privacy mode now blurs Context Economics "Heaviest contributors" labels, which
+  previously exposed raw file paths.
+- Installed wheels (`uvx` / `pipx` / `pip`) now bundle `pricing.csv` and the
+  demo dataset, default their data directory to `~/.checkyouragent`, and read
+  optional dated pricing snapshots from `~/.checkyouragent/pricing`, so cost
+  analytics and Load demo data work outside a source checkout. The server also
+  logs the resolved database path at startup.
+
+### Security
+- The API now rejects requests whose `Host` header is not on a localhost
+  allow-list (`CCFR_ALLOWED_HOSTS`), protecting local instances from
+  DNS-rebinding attacks.
+
+### Changed
+- Renamed the GitHub repository to `checkyouragent` (old
+  `authrty-claude-code-analytics` URLs redirect automatically).
+- Clarified licensing: the Business Source License 1.1 now carries an Additional
+  Use Grant permitting free personal and internal use.
+- Rewrote the README to lead with the avoidable-spend outcome and added a "How it
+  compares" section covering ccusage, token-dashboard, Sniffly, and Anthropic's
+  native analytics.
+
+### Removed
+- Hid the unfinished "soon" Explore technique tiles and the disabled team-export
+  rungs; removed the unmounted contribution page from the build.


### PR DESCRIPTION
Folds [Unreleased] into a single [0.1.0] - 2026-07-11 section and adds the Security bullet for the Host-header guard. Last content gap before the v0.1.0 release.