### PR TITLE
feat: Limit Hits Explore page

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "pydantic>=2.8.0",
+    "tzdata>=2024.1",
 ]
 
 [project.urls]

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -103,3 +103,107 @@ def _parse_ts(ts: str | None) -> datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed
+
+
+@dataclass
+class LimitHit:
+    """One deduplicated cap hit (possibly seen as several retry events)."""
+
+    ts: datetime
+    kind: str  # session | weekly | org | unknown
+    reset_at: datetime | None
+    session_ids: list[int] = field(default_factory=list)
+    session_titles: list[str] = field(default_factory=list)
+    occurrence_count: int = 1
+    usage_at_hit: float | None = None  # filled by fold_windows
+    window_index: int | None = None  # filled by fold_windows
+
+    @property
+    def blocked_minutes(self) -> float | None:
+        if self.reset_at is None:
+            return None
+        return max(0.0, (self.reset_at - self.ts).total_seconds() / 60)
+
+
+def _hit_text(preview: str, raw: dict) -> str:
+    """The limit message text: text_preview when stored, else the raw block."""
+    if preview:
+        return preview
+    content = (raw.get("message") or {}).get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                return str(block.get("text") or "")
+    return ""
+
+
+def detect_limit_hits(
+    conn: sqlite3.Connection,
+    *,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[LimitHit]:
+    """All deduplicated limit hits in the corpus, sorted by time.
+
+    Detection is structured-first: '<synthetic>' messages whose event raw_json
+    carries error == "rate_limit" (or apiErrorStatus == 429 on older logs).
+    Events sharing (kind, reset stamp) are one hit; without a parsed stamp the
+    fallback key buckets timestamps into 5-minute slots.
+    """
+    where = ["m.model = ?"]
+    params: list[Any] = [SYNTHETIC_MODEL]
+    if date_from:
+        where.append("date(e.timestamp) >= date(?)")
+        params.append(date_from)
+    if date_to:
+        where.append("date(e.timestamp) <= date(?)")
+        params.append(date_to)
+    rows = conn.execute(
+        f"""
+        SELECT e.timestamp AS ts, e.raw_json AS raw_json,
+               COALESCE(m.text_preview, '') AS text,
+               s.id AS session_db_id, COALESCE(s.title, '') AS title
+        FROM messages m
+        JOIN events e ON e.id = m.event_id
+        JOIN sessions s ON s.id = e.session_id
+        WHERE {' AND '.join(where)}
+        ORDER BY e.timestamp, e.id
+        """,
+        params,
+    ).fetchall()
+
+    merged: dict[tuple[str, Any], LimitHit] = {}
+    for row in rows:
+        try:
+            raw = json.loads(row["raw_json"])
+        except (json.JSONDecodeError, TypeError):
+            raw = {}
+        if not isinstance(raw, dict):
+            raw = {}
+        if raw.get("error") != "rate_limit" and raw.get("apiErrorStatus") != 429:
+            continue
+        ts = _parse_ts(row["ts"])
+        if ts is None:
+            continue
+        text = _hit_text(row["text"], raw)
+        kind = classify_hit_text(text)
+        reset_at = parse_reset_at(text, ts)
+        key: tuple[str, Any]
+        if reset_at is not None:
+            key = (kind, reset_at.isoformat())
+        else:
+            key = (kind, int(ts.timestamp()) // _DEDUP_BUCKET_S)
+        hit = merged.get(key)
+        if hit is None:
+            merged[key] = LimitHit(
+                ts=ts, kind=kind, reset_at=reset_at,
+                session_ids=[row["session_db_id"]],
+                session_titles=[row["title"]],
+            )
+        else:
+            hit.occurrence_count += 1
+            hit.ts = min(hit.ts, ts)
+            if row["session_db_id"] not in hit.session_ids:
+                hit.session_ids.append(row["session_db_id"])
+                hit.session_titles.append(row["title"])
+    return sorted(merged.values(), key=lambda h: h.ts)

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -1,0 +1,105 @@
+"""Limit hits and 5-hour-window economics, computed on read.
+
+Subscription limit hits are already ingested: each one is an assistant event
+whose raw_json carries error == "rate_limit" (HTTP 429) and whose message row
+has model '<synthetic>' with the limit text in text_preview. This module
+detects those events, folds all assistant usage into 5-hour windows priced by
+the shared pricing timeline, and derives the measured cap zones.
+
+Corpus-wide by design: limits are account-level, so there is no project
+filter. Computation is on-demand from the rebuildable SQLite cache, like
+usage_characteristics.py.
+Design doc: docs/superpowers/specs/2026-07-12-limit-hits-explore-design.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from statistics import median
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from ccfr.analysis.pricing import load_price_timeline
+from ccfr.analysis.usage_map import load_events
+from ccfr.config import pricing_dir, pricing_path
+
+SYNTHETIC_MODEL = "<synthetic>"
+WINDOW_SPAN = timedelta(hours=5)
+# A parsed reset stamp may sit slightly past start+5h (stamps are rounded and
+# the window start is inferred from the first logged call). Snap within this.
+SNAP_TOLERANCE = timedelta(minutes=30)
+NEAR_MISS_RATIO = 0.6
+RECENT_DAYS = 28
+_DEDUP_BUCKET_S = 300  # fallback dedup bucket for hits without a reset stamp
+
+METHOD_NOTE = (
+    "Account-level view: 5-hour windows are shared across every project and "
+    "Claude surface, so this page always covers the whole corpus. Dollars are "
+    "API-equivalent value, not an invoice. Hit counts are a lower bound (only "
+    "hits recorded inside exported sessions are visible), and usage outside "
+    "Claude Code shares the same pool but is invisible here. Fable 5 usage "
+    "after 2026-07-12 bills as usage credits and no longer counts against "
+    "these caps."
+)
+
+
+def classify_hit_text(text: str) -> str:
+    """Bucket a rate-limit message by which cap it reports."""
+    lowered = (text or "").lower()
+    if "session limit" in lowered:
+        return "session"
+    if "weekly" in lowered:
+        return "weekly"
+    if "monthly" in lowered or "org" in lowered:
+        return "org"
+    return "unknown"
+
+
+_RESET_RE = re.compile(
+    r"resets\s+(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<ampm>am|pm)"
+    r"(?:\s*\((?P<tz>[^)]+)\))?",
+    re.IGNORECASE,
+)
+
+
+def parse_reset_at(text: str, hit_at: datetime) -> datetime | None:
+    """Absolute reset time from "resets 12:30pm (Europe/Paris)"-style text.
+
+    The wall-clock time is anchored in the named timezone; without one the
+    stamp is ambiguous and we return None (the hit still counts, its blocked
+    time is just unknown). Rolls to the next day when the parsed time is not
+    after the hit.
+    """
+    match = _RESET_RE.search(text or "")
+    if not match or not match.group("tz"):
+        return None
+    try:
+        tz = ZoneInfo(match.group("tz").strip())
+    except Exception:  # unknown/garbled zone name: treat as unparsed
+        return None
+    hour = int(match.group("hour")) % 12
+    if match.group("ampm").lower() == "pm":
+        hour += 12
+    minute = int(match.group("minute") or 0)
+    local_hit = hit_at.astimezone(tz)
+    candidate = local_hit.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= local_hit:
+        candidate += timedelta(days=1)
+    return candidate.astimezone(timezone.utc)
+
+
+def _parse_ts(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -80,10 +80,14 @@ def parse_reset_at(text: str, hit_at: datetime) -> datetime | None:
         tz = ZoneInfo(match.group("tz").strip())
     except Exception:  # unknown/garbled zone name: treat as unparsed
         return None
+    # hour is bounded by the % 12, but the minute group is \d{2}: "resets 5:99pm"
+    # is as garbled as an unknown zone, so it reads as unparsed rather than raising.
     hour = int(match.group("hour")) % 12
     if match.group("ampm").lower() == "pm":
         hour += 12
     minute = int(match.group("minute") or 0)
+    if minute > 59:
+        return None
     local_hit = hit_at.astimezone(tz)
     candidate = local_hit.replace(hour=hour, minute=minute, second=0, microsecond=0)
     if candidate <= local_hit:

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -287,3 +287,137 @@ def fold_windows(events: list[UsageEvent], hits: list[LimitHit]) -> list[UsageWi
     for window in windows:
         window.value_usd = round(window.value_usd, 6)
     return windows
+
+
+def _era_for(ts: datetime, history: list[dict[str, str]]) -> str:
+    """Label for the last plan whose start_date is on or before ts (else "")."""
+    day = ts.date().isoformat()
+    label = ""
+    for row in history:
+        if row["start_date"] <= day:
+            label = row["plan"]
+    return label
+
+
+def _hit_payload(hit: LimitHit) -> dict[str, Any]:
+    blocked = hit.blocked_minutes
+    return {
+        "ts": hit.ts.isoformat(),
+        "kind": hit.kind,
+        "reset_at": hit.reset_at.isoformat() if hit.reset_at else None,
+        "blocked_minutes": round(blocked, 1) if blocked is not None else None,
+        "usage_at_hit": round(hit.usage_at_hit, 4) if hit.usage_at_hit is not None else None,
+        "occurrence_count": hit.occurrence_count,
+        "window_index": hit.window_index,
+        "session_ids": list(hit.session_ids),
+        "session_titles": list(hit.session_titles),
+    }
+
+
+def limits_analytics(
+    conn: sqlite3.Connection,
+    *,
+    historical: bool = True,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    plan_history: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Limit hits, priced 5-hour windows, and per-era cap zones."""
+    history = sorted(
+        (
+            row for row in (plan_history or [])
+            if isinstance(row, dict) and row.get("plan") and row.get("start_date")
+        ),
+        key=lambda row: row["start_date"],
+    )
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    events = load_events(conn, timeline, historical=historical,
+                         date_from=date_from, date_to=date_to)
+    usage: list[UsageEvent] = []
+    costs_partial = False
+    for event in events:
+        ts = _parse_ts(event.ts)
+        if ts is None:
+            continue
+        if event.model != SYNTHETIC_MODEL and not event.priced:
+            costs_partial = True
+        usage.append(UsageEvent(ts=ts, cost=event.cost, tokens=event.tokens))
+    usage.sort(key=lambda u: u.ts)
+
+    hits = detect_limit_hits(conn, date_from=date_from, date_to=date_to)
+    windows = fold_windows(usage, hits)
+    for window in windows:
+        window.era = _era_for(window.start, history)
+
+    era_order: list[str] = []
+    for window in windows:
+        if window.era not in era_order:
+            era_order.append(window.era)
+    if not era_order:
+        era_order = [""]
+
+    eras_payload: list[dict[str, Any]] = []
+    for era in era_order:
+        era_indices = [i for i, w in enumerate(windows) if w.era == era]
+        era_windows = [windows[i] for i in era_indices]
+        era_hits = [h for h in hits
+                    if h.window_index is not None and windows[h.window_index].era == era]
+        session_hits = [h for h in era_hits if h.kind == "session"]
+        zone = sorted(h.usage_at_hit for h in session_hits if h.usage_at_hit is not None)
+        cap_median = round(median(zone), 4) if zone else None
+        near_miss = 0
+        percentile = None
+        if cap_median:
+            hit_window_indices = {h.window_index for h in session_hits}
+            near_miss = sum(
+                1 for i in era_indices
+                if i not in hit_window_indices
+                and windows[i].value_usd >= NEAR_MISS_RATIO * cap_median
+            )
+            below = sum(1 for w in era_windows if w.value_usd <= cap_median)
+            percentile = round(below / len(era_windows), 4)
+        blocked = sum(h.blocked_minutes or 0.0 for h in era_hits)
+        eras_payload.append({
+            "era": era,
+            "window_count": len(era_windows),
+            "session_hit_count": len(session_hits),
+            "blocked_minutes": round(blocked, 1),
+            "cap_median_usd": cap_median,
+            "cap_min_usd": round(zone[0], 4) if zone else None,
+            "cap_max_usd": round(zone[-1], 4) if zone else None,
+            "near_miss_count": near_miss,
+            "cap_percentile": percentile,
+            "usage_at_hit_usd": [round(v, 4) for v in zone],
+        })
+
+    blocked_total = sum(h.blocked_minutes or 0.0 for h in hits)
+    last_ts = usage[-1].ts if usage else None
+    recent = [h for h in hits
+              if last_ts is not None and h.ts >= last_ts - timedelta(days=RECENT_DAYS)]
+    return {
+        "meta": {
+            "window": {"date_from": date_from, "date_to": date_to},
+            "cost_available": timeline.has_prices,
+            "costs_partial": costs_partial,
+            "total_hits": len(hits),
+            "total_windows": len(windows),
+            "blocked_minutes": round(blocked_total, 1),
+            "hits_per_week_recent": round(len(recent) / (RECENT_DAYS / 7), 2),
+            "hit_counts": dict(Counter(h.kind for h in hits)),
+            "plan_history": history,
+            "method_note": METHOD_NOTE,
+        },
+        "hits": [_hit_payload(h) for h in hits],
+        "windows": [
+            {
+                "start": w.start.isoformat(),
+                "end": w.end.isoformat(),
+                "value_usd": round(w.value_usd, 4),
+                "tokens": w.tokens,
+                "era": w.era,
+                "hit_kinds": list(w.hit_kinds),
+            }
+            for w in windows
+        ],
+        "eras": eras_payload,
+    }

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -367,7 +367,10 @@ def limits_analytics(
         cap_median = round(median(zone), 4) if zone else None
         near_miss = 0
         percentile = None
-        if cap_median:
+        # A zero median cap means the measured hits carried no visible usage
+        # (the shared pool filled elsewhere); near-miss and percentile would
+        # be meaningless against a $0 threshold, so they stay unset.
+        if cap_median is not None and cap_median > 0:
             hit_window_indices = {h.window_index for h in session_hits}
             near_miss = sum(
                 1 for i in era_indices

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -207,3 +207,62 @@ def detect_limit_hits(
                 hit.session_ids.append(row["session_db_id"])
                 hit.session_titles.append(row["title"])
     return sorted(merged.values(), key=lambda h: h.ts)
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    """One assistant message reduced to what window folding needs."""
+
+    ts: datetime
+    cost: float
+    tokens: int
+
+
+@dataclass
+class UsageWindow:
+    """One reconstructed 5-hour rate-limit window."""
+
+    start: datetime
+    end: datetime
+    value_usd: float = 0.0
+    tokens: int = 0
+    era: str = ""
+    hit_kinds: list[str] = field(default_factory=list)
+
+
+def fold_windows(events: list[UsageEvent], hits: list[LimitHit]) -> list[UsageWindow]:
+    """Fold time-sorted events into non-overlapping 5-hour windows.
+
+    A window opens at its first message and ends 5 hours later, except when a
+    session hit inside it carries a parsed reset stamp within tolerance: then
+    the end snaps to the stamp (measured ground truth beats inference), and
+    later events open the next window. Fills usage_at_hit (window value up to
+    the hit, not the whole window) and window_index on the hits in place.
+    `hits` must be sorted by ts, as detect_limit_hits returns them.
+    """
+    windows: list[UsageWindow] = []
+    current: UsageWindow | None = None
+    hit_idx = 0
+    for event in events:
+        if current is None or event.ts >= current.end:
+            current = UsageWindow(start=event.ts, end=event.ts + WINDOW_SPAN)
+            windows.append(current)
+        current.value_usd += event.cost
+        current.tokens += event.tokens
+        while hit_idx < len(hits) and hits[hit_idx].ts <= event.ts:
+            hit = hits[hit_idx]
+            hit_idx += 1
+            if hit.ts < current.start:
+                continue  # hit fell in a gap with no matching usage row
+            hit.window_index = len(windows) - 1
+            hit.usage_at_hit = round(current.value_usd, 6)
+            current.hit_kinds.append(hit.kind)
+            if (
+                hit.kind == "session"
+                and hit.reset_at is not None
+                and current.start < hit.reset_at <= current.start + WINDOW_SPAN + SNAP_TOLERANCE
+            ):
+                current.end = hit.reset_at
+    for window in windows:
+        window.value_usd = round(window.value_usd, 6)
+    return windows

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -42,9 +42,7 @@ METHOD_NOTE = (
     "Claude surface, so this page always covers the whole corpus. Dollars are "
     "API-equivalent value, not an invoice. Hit counts are a lower bound (only "
     "hits recorded inside exported sessions are visible), and usage outside "
-    "Claude Code shares the same pool but is invisible here. Fable 5 usage "
-    "after 2026-07-12 bills as usage credits and no longer counts against "
-    "these caps."
+    "Claude Code shares the same pool but is invisible here."
 )
 
 

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -238,31 +238,52 @@ def fold_windows(events: list[UsageEvent], hits: list[LimitHit]) -> list[UsageWi
     the end snaps to the stamp (measured ground truth beats inference), and
     later events open the next window. Fills usage_at_hit (window value up to
     the hit, not the whole window) and window_index on the hits in place.
-    `hits` must be sorted by ts, as detect_limit_hits returns them.
+    Hits are merged into the event stream by timestamp, so a hit with no
+    matching event row still lands in the window that contains it; a hit in
+    an activity gap opens its own window (an attempted call is activity).
+    `events` and `hits` must both be sorted by ts.
     """
     windows: list[UsageWindow] = []
     current: UsageWindow | None = None
     hit_idx = 0
+
+    def open_window(ts: datetime) -> UsageWindow:
+        window = UsageWindow(start=ts, end=ts + WINDOW_SPAN)
+        windows.append(window)
+        return window
+
+    def attach(hit: LimitHit) -> None:
+        hit.window_index = len(windows) - 1
+        hit.usage_at_hit = round(current.value_usd, 6)
+        current.hit_kinds.append(hit.kind)
+        if (
+            hit.kind == "session"
+            and hit.reset_at is not None
+            and current.start < hit.reset_at <= current.start + WINDOW_SPAN + SNAP_TOLERANCE
+        ):
+            current.end = hit.reset_at
+
     for event in events:
+        while hit_idx < len(hits) and hits[hit_idx].ts < event.ts:
+            hit = hits[hit_idx]
+            hit_idx += 1
+            if current is None or hit.ts >= current.end:
+                current = open_window(hit.ts)
+            attach(hit)
         if current is None or event.ts >= current.end:
-            current = UsageWindow(start=event.ts, end=event.ts + WINDOW_SPAN)
-            windows.append(current)
+            current = open_window(event.ts)
         current.value_usd += event.cost
         current.tokens += event.tokens
         while hit_idx < len(hits) and hits[hit_idx].ts <= event.ts:
             hit = hits[hit_idx]
             hit_idx += 1
-            if hit.ts < current.start:
-                continue  # hit fell in a gap with no matching usage row
-            hit.window_index = len(windows) - 1
-            hit.usage_at_hit = round(current.value_usd, 6)
-            current.hit_kinds.append(hit.kind)
-            if (
-                hit.kind == "session"
-                and hit.reset_at is not None
-                and current.start < hit.reset_at <= current.start + WINDOW_SPAN + SNAP_TOLERANCE
-            ):
-                current.end = hit.reset_at
+            attach(hit)
+    while hit_idx < len(hits):
+        hit = hits[hit_idx]
+        hit_idx += 1
+        if current is None or hit.ts >= current.end:
+            current = open_window(hit.ts)
+        attach(hit)
     for window in windows:
         window.value_usd = round(window.value_usd, 6)
     return windows

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -155,6 +155,7 @@ def update_settings(payload: SettingsResponse) -> SettingsResponse:
     current = read_settings()
     current.historical_pricing = payload.historical_pricing
     current.privacy_mode = payload.privacy_mode
+    current.plan_history = [dict(row) for row in payload.plan_history]
     saved = write_settings(current)
     return SettingsResponse(**asdict(saved))
 

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -22,6 +22,7 @@ from ccfr.analysis.context_economics import (
     session_context_economics,
 )
 from ccfr.analysis.discovery import discovery_analytics
+from ccfr.analysis.limits import limits_analytics
 from ccfr.analysis.team_bundles import (
     build_team_bundle,
     delete_team_member,
@@ -47,6 +48,7 @@ from ccfr.api.schemas import (
     ImportProgressResponse,
     ImportRequest,
     ImportSummaryResponse,
+    LimitsResponse,
     ProjectResponse,
     RiskFindingResponse,
     RuntimeConfigResponse,
@@ -643,3 +645,18 @@ def get_usage_characteristics(
         **usage_characteristics_analytics(conn, project_id=project_id,
                                           date_from=date_from, date_to=date_to, historical=historical)
     )
+
+
+@router.get("/analytics/limits", response_model=LimitsResponse)
+def get_limits(
+    date_from: str | None = None,
+    date_to: str | None = None,
+    conn: Connection = Depends(get_db),
+    historical: bool = Depends(get_historical_pricing),
+) -> LimitsResponse:
+    # Deliberately no project_id: limits are account-level, the window that
+    # capped may have been filled by several projects at once.
+    return LimitsResponse(**limits_analytics(
+        conn, historical=historical, date_from=date_from, date_to=date_to,
+        plan_history=read_settings().plan_history,
+    ))

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -157,7 +157,8 @@ def update_settings(payload: SettingsResponse) -> SettingsResponse:
     current = read_settings()
     current.historical_pricing = payload.historical_pricing
     current.privacy_mode = payload.privacy_mode
-    current.plan_history = [dict(row) for row in payload.plan_history]
+    if payload.plan_history is not None:
+        current.plan_history = [dict(row) for row in payload.plan_history]
     saved = write_settings(current)
     return SettingsResponse(**asdict(saved))
 

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -677,6 +677,60 @@ class UsageCharacteristicsResponse(BaseModel):
     characteristics: list[UsageCharacteristic] = Field(default_factory=list)
 
 
+class LimitHitOut(BaseModel):
+    ts: str
+    kind: str
+    reset_at: str | None = None
+    blocked_minutes: float | None = None
+    usage_at_hit: float | None = None
+    occurrence_count: int = 1
+    window_index: int | None = None
+    session_ids: list[int] = Field(default_factory=list)
+    session_titles: list[str] = Field(default_factory=list)
+
+
+class LimitWindowOut(BaseModel):
+    start: str
+    end: str
+    value_usd: float = 0
+    tokens: int = 0
+    era: str = ""
+    hit_kinds: list[str] = Field(default_factory=list)
+
+
+class LimitEraOut(BaseModel):
+    era: str = ""
+    window_count: int = 0
+    session_hit_count: int = 0
+    blocked_minutes: float = 0
+    cap_median_usd: float | None = None
+    cap_min_usd: float | None = None
+    cap_max_usd: float | None = None
+    near_miss_count: int = 0
+    cap_percentile: float | None = None
+    usage_at_hit_usd: list[float] = Field(default_factory=list)
+
+
+class LimitsMeta(BaseModel):
+    window: UsageMapWindow = Field(default_factory=UsageMapWindow)
+    cost_available: bool = False
+    costs_partial: bool = False
+    total_hits: int = 0
+    total_windows: int = 0
+    blocked_minutes: float = 0
+    hits_per_week_recent: float = 0
+    hit_counts: dict[str, int] = Field(default_factory=dict)
+    plan_history: list[dict[str, str]] = Field(default_factory=list)
+    method_note: str = ""
+
+
+class LimitsResponse(BaseModel):
+    meta: LimitsMeta = Field(default_factory=LimitsMeta)
+    hits: list[LimitHitOut] = Field(default_factory=list)
+    windows: list[LimitWindowOut] = Field(default_factory=list)
+    eras: list[LimitEraOut] = Field(default_factory=list)
+
+
 class ContributionPreviewResponse(BaseModel):
     manifest: dict[str, Any]
     bundle: dict[str, Any]

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -21,6 +21,7 @@ class SettingsResponse(BaseModel):
     historical_pricing: bool = True
     privacy_mode: bool = False
     team_export_prefs: dict[str, Any] = Field(default_factory=dict)
+    plan_history: list[dict[str, str]] = Field(default_factory=list)
 
 
 class CacheStatsResponse(BaseModel):

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -21,7 +21,7 @@ class SettingsResponse(BaseModel):
     historical_pricing: bool = True
     privacy_mode: bool = False
     team_export_prefs: dict[str, Any] = Field(default_factory=dict)
-    plan_history: list[dict[str, str]] = Field(default_factory=list)
+    plan_history: list[dict[str, str]] | None = None
 
 
 class CacheStatsResponse(BaseModel):

--- a/backend/src/ccfr/settings.py
+++ b/backend/src/ccfr/settings.py
@@ -49,10 +49,10 @@ def _clean_plan_history(raw: object) -> list[dict[str, str]]:
         if not plan:
             continue
         try:
-            date.fromisoformat(start)
+            parsed = date.fromisoformat(start)
         except ValueError:
             continue
-        rows.append({"plan": plan, "start_date": start})
+        rows.append({"plan": plan, "start_date": parsed.isoformat()})
     rows.sort(key=lambda row: row["start_date"])
     return rows
 

--- a/backend/src/ccfr/settings.py
+++ b/backend/src/ccfr/settings.py
@@ -8,6 +8,7 @@ import json
 import secrets
 import uuid
 from dataclasses import asdict, dataclass, field, replace
+from datetime import date
 from pathlib import Path
 
 from ccfr.config import data_dir
@@ -27,10 +28,33 @@ class Settings:
     # and deselected export_names (deselected, not selected, so newly imported
     # projects default to included — protecting full-snapshot semantics).
     team_export_prefs: dict = field(default_factory=dict)
+    # Optional subscription history for the limit-hits analysis: sanitized rows
+    # of {"plan": str, "start_date": "YYYY-MM-DD"}, kept sorted ascending.
+    plan_history: list = field(default_factory=list)
 
 
 def _settings_path() -> Path:
     return data_dir() / "settings.json"
+
+
+def _clean_plan_history(raw: object) -> list[dict[str, str]]:
+    if not isinstance(raw, list):
+        return []
+    rows: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        plan = str(item.get("plan") or "").strip()
+        start = str(item.get("start_date") or "").strip()
+        if not plan:
+            continue
+        try:
+            date.fromisoformat(start)
+        except ValueError:
+            continue
+        rows.append({"plan": plan, "start_date": start})
+    rows.sort(key=lambda row: row["start_date"])
+    return rows
 
 
 def read_settings() -> Settings:
@@ -50,12 +74,14 @@ def read_settings() -> Settings:
         contributor_id=raw.get("contributor_id"),
         team_bundle_seq=int(raw.get("team_bundle_seq", 0) or 0),
         team_export_prefs=raw.get("team_export_prefs") if isinstance(raw.get("team_export_prefs"), dict) else {},
+        plan_history=_clean_plan_history(raw.get("plan_history")),
     )
 
 
 def write_settings(settings: Settings) -> Settings:
     path = _settings_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    settings.plan_history = _clean_plan_history(settings.plan_history)
     # Preserve existing contributor identity if the incoming settings omits it.
     # Use replace() to create a copy so we don't mutate the caller's object.
     to_write = settings

--- a/backend/src/ccfr/settings.py
+++ b/backend/src/ccfr/settings.py
@@ -81,14 +81,14 @@ def read_settings() -> Settings:
 def write_settings(settings: Settings) -> Settings:
     path = _settings_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    settings.plan_history = _clean_plan_history(settings.plan_history)
+    # Always write a copy so we never mutate the caller's object; sanitize the
+    # plan history on the way out, mirroring read_settings.
+    to_write = replace(settings, plan_history=_clean_plan_history(settings.plan_history))
     # Preserve existing contributor identity if the incoming settings omits it.
-    # Use replace() to create a copy so we don't mutate the caller's object.
-    to_write = settings
     if settings.contributor_salt is None or settings.contributor_id is None:
         existing = read_settings()
         to_write = replace(
-            settings,
+            to_write,
             contributor_salt=settings.contributor_salt or existing.contributor_salt,
             contributor_id=settings.contributor_id or existing.contributor_id,
         )

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -74,7 +74,7 @@ def test_parse_reset_unknown_timezone_or_garbage_returns_none() -> None:
 
 
 def _make_conn() -> sqlite3.Connection:
-    conn = sqlite3.connect(":memory:")
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
     conn.row_factory = sqlite3.Row
     init_db(conn)
     import_id = conn.execute(

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -5,8 +5,11 @@ import sqlite3
 from datetime import datetime, timedelta, timezone
 
 from ccfr.analysis.limits import (
+    LimitHit,
+    UsageEvent,
     classify_hit_text,
     detect_limit_hits,
+    fold_windows,
     parse_reset_at,
 )
 from ccfr.storage import init_db
@@ -147,3 +150,69 @@ def test_detect_unparseable_reset_buckets_by_time() -> None:
     assert len(hits) == 2
     assert hits[0].reset_at is None
     assert hits[0].blocked_minutes is None
+
+
+# ---------------------------------------------------------------------------
+# Window folding
+# ---------------------------------------------------------------------------
+
+def _events(*specs: tuple[str, float]) -> list[UsageEvent]:
+    return [UsageEvent(ts=_utc(ts), cost=cost, tokens=int(cost * 1000))
+            for ts, cost in specs]
+
+
+def test_fold_windows_groups_by_five_hours() -> None:
+    events = _events(
+        ("2026-07-03T08:00:00Z", 1.0),
+        ("2026-07-03T09:00:00Z", 2.0),   # same window (starts 08:00, ends 13:00)
+        ("2026-07-03T14:00:00Z", 4.0),   # next window
+    )
+    windows = fold_windows(events, [])
+    assert len(windows) == 2
+    assert windows[0].start == _utc("2026-07-03T08:00:00Z")
+    assert windows[0].end == _utc("2026-07-03T13:00:00Z")
+    assert windows[0].value_usd == 3.0
+    assert windows[1].value_usd == 4.0
+
+
+def test_fold_windows_attaches_hit_and_measures_usage_at_hit() -> None:
+    events = _events(
+        ("2026-07-03T08:00:00Z", 1.0),
+        ("2026-07-03T09:00:00Z", 2.0),
+        ("2026-07-03T09:40:44Z", 0.0),   # the synthetic hit row itself (zero cost)
+        ("2026-07-03T12:00:00Z", 8.0),   # after the snapped reset: a NEW window
+    )
+    hit = LimitHit(ts=_utc("2026-07-03T09:40:44Z"), kind="session",
+                   reset_at=_utc("2026-07-03T10:30:00Z"))
+    windows = fold_windows(events, [hit])
+    # The hit snaps window 0's end to the reset stamp, so the 12:00 event opens window 1.
+    assert len(windows) == 2
+    assert windows[0].end == _utc("2026-07-03T10:30:00Z")
+    assert windows[0].hit_kinds == ["session"]
+    assert hit.window_index == 0
+    assert hit.usage_at_hit == 3.0
+    assert windows[1].start == _utc("2026-07-03T12:00:00Z")
+
+
+def test_fold_windows_never_snaps_weekly_hits() -> None:
+    events = _events(
+        ("2026-07-03T08:00:00Z", 1.0),
+        ("2026-07-03T08:30:00Z", 0.0),
+    )
+    hit = LimitHit(ts=_utc("2026-07-03T08:30:00Z"), kind="weekly",
+                   reset_at=_utc("2026-07-06T09:00:00Z"))  # days away
+    windows = fold_windows(events, [hit])
+    assert windows[0].end == _utc("2026-07-03T13:00:00Z")  # untouched
+    assert hit.window_index == 0
+
+
+def test_fold_windows_ignores_out_of_tolerance_reset() -> None:
+    events = _events(
+        ("2026-07-03T08:00:00Z", 1.0),
+        ("2026-07-03T08:10:00Z", 0.0),
+    )
+    # A "session" stamp 7h out is inconsistent with a 5h window: keep the inferred end.
+    hit = LimitHit(ts=_utc("2026-07-03T08:10:00Z"), kind="session",
+                   reset_at=_utc("2026-07-03T15:00:00Z"))
+    windows = fold_windows(events, [hit])
+    assert windows[0].end == _utc("2026-07-03T13:00:00Z")

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
 
 from ccfr.analysis.limits import (
     LimitHit,
@@ -10,6 +13,7 @@ from ccfr.analysis.limits import (
     classify_hit_text,
     detect_limit_hits,
     fold_windows,
+    limits_analytics,
     parse_reset_at,
 )
 from ccfr.storage import init_db
@@ -241,3 +245,91 @@ def test_fold_windows_hit_in_activity_gap_opens_its_own_window() -> None:
     assert len(windows) == 2
     assert hit.window_index == 1
     assert hit.usage_at_hit == 0.0
+
+
+# ---------------------------------------------------------------------------
+# limits_analytics composition
+# ---------------------------------------------------------------------------
+
+def _add_usage(conn: sqlite3.Connection, session_id: int, ts: str, base: int) -> int:
+    ev = conn.execute(
+        "INSERT INTO events (session_id, source_path, line_no, type, timestamp, raw_json)"
+        " VALUES (?, 'f.jsonl', 1, 'assistant', ?, '{}')",
+        (session_id, ts),
+    ).lastrowid
+    conn.execute(
+        "INSERT INTO messages (event_id, role, model, input_tokens, output_tokens,"
+        " base_input_tokens, cache_5m_tokens, cache_1h_tokens, cache_read_tokens)"
+        " VALUES (?, 'assistant', 'claude-opus-4-8', ?, 0, ?, 0, 0, 0)",
+        (ev, base, base),
+    )
+    return int(ev)
+
+
+@pytest.fixture()
+def priced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    csv = tmp_path / "pricing.csv"
+    # $10 per million base-input tokens: 1M tokens = $10.
+    csv.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,"
+        "cache-hits-&-refreshes,output-tokens\n"
+        "claude-opus-4-8,10,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    import ccfr.analysis.limits as limits_mod
+    monkeypatch.setattr(limits_mod, "pricing_path", lambda: csv)
+    monkeypatch.setattr(limits_mod, "pricing_dir", lambda: tmp_path / "no-sheets")
+
+
+def test_limits_analytics_full_payload(priced: None) -> None:
+    conn = _make_conn()
+    # Window 1 (May 20, Pro era): $10 usage then a session hit.
+    _add_usage(conn, 1, "2026-05-20T08:00:00Z", 1_000_000)
+    _add_limit_hit(conn, 1, "2026-05-20T09:00:00Z",
+                   "You've hit your session limit · resets 1pm (UTC)")
+    # Window 2 (July 3, Max era): $30 usage then a session hit.
+    _add_usage(conn, 1, "2026-07-03T08:00:00Z", 3_000_000)
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:00Z")
+    # Window 3 (July 4, Max era): $25 quiet usage. 25 >= 0.6 * 30: a near-miss.
+    _add_usage(conn, 1, "2026-07-04T08:00:00Z", 2_500_000)
+
+    payload = limits_analytics(conn, plan_history=[
+        {"plan": "Pro", "start_date": "2026-05-01"},
+        {"plan": "Max 5x", "start_date": "2026-06-10"},
+    ])
+
+    assert payload["meta"]["total_hits"] == 2
+    assert payload["meta"]["hit_counts"] == {"session": 2}
+    assert payload["meta"]["total_windows"] == 3
+    assert payload["meta"]["cost_available"] is True
+    assert payload["meta"]["method_note"]
+
+    eras = {era["era"]: era for era in payload["eras"]}
+    assert set(eras) == {"Pro", "Max 5x"}
+    assert eras["Pro"]["session_hit_count"] == 1
+    assert eras["Pro"]["cap_median_usd"] == 10.0
+    assert eras["Max 5x"]["cap_median_usd"] == 30.0
+    assert eras["Max 5x"]["near_miss_count"] == 1
+    assert eras["Max 5x"]["window_count"] == 2
+
+    assert [w["era"] for w in payload["windows"]] == ["Pro", "Max 5x", "Max 5x"]
+    assert payload["windows"][0]["hit_kinds"] == ["session"]
+    assert payload["hits"][0]["kind"] == "session"
+    assert payload["hits"][0]["usage_at_hit"] == 10.0
+    assert payload["hits"][0]["session_ids"] == [1]
+
+
+def test_limits_analytics_without_plan_history_or_hits(priced: None) -> None:
+    conn = _make_conn()
+    _add_usage(conn, 1, "2026-05-20T08:00:00Z", 1_000_000)
+    payload = limits_analytics(conn)
+    assert payload["meta"]["total_hits"] == 0
+    assert payload["meta"]["total_windows"] == 1
+    assert payload["eras"] == [
+        {
+            "era": "", "window_count": 1, "session_hit_count": 0,
+            "blocked_minutes": 0.0, "cap_median_usd": None, "cap_min_usd": None,
+            "cap_max_usd": None, "near_miss_count": 0, "cap_percentile": None,
+            "usage_at_hit_usd": [],
+        }
+    ]

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -73,6 +73,15 @@ def test_parse_reset_unknown_timezone_or_garbage_returns_none() -> None:
     assert parse_reset_at("", hit) is None
 
 
+def test_parse_reset_out_of_range_minute_returns_none() -> None:
+    # The minute group is \d{2}, so a garbled stamp can carry 60-99. It must
+    # read as unparsed, not raise out of the analytics endpoint.
+    hit = _utc("2026-05-20T14:00:00Z")
+    assert parse_reset_at("resets 5:99pm (UTC)", hit) is None
+    assert parse_reset_at("resets 5:60pm (UTC)", hit) is None
+    assert parse_reset_at("resets 5:59pm (UTC)", hit) == _utc("2026-05-20T17:59:00Z")
+
+
 def _make_conn() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:", check_same_thread=False)
     conn.row_factory = sqlite3.Row

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -333,3 +333,19 @@ def test_limits_analytics_without_plan_history_or_hits(priced: None) -> None:
             "usage_at_hit_usd": [],
         }
     ]
+
+
+def test_limits_analytics_zero_usage_cap_zone_stays_defined(priced: None) -> None:
+    conn = _make_conn()
+    # A hit as the first logged call of its window: measured usage-at-hit is
+    # $0 (the real usage lived outside these logs). The zone is still
+    # reported, but near-miss and percentile are meaningless against a $0
+    # cap and stay unset.
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:00Z")
+    payload = limits_analytics(conn)
+    era = payload["eras"][0]
+    assert era["session_hit_count"] == 1
+    assert era["cap_median_usd"] == 0.0
+    assert era["usage_at_hit_usd"] == [0.0]
+    assert era["near_miss_count"] == 0
+    assert era["cap_percentile"] is None

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -6,8 +6,10 @@ from datetime import datetime, timedelta, timezone
 
 from ccfr.analysis.limits import (
     classify_hit_text,
+    detect_limit_hits,
     parse_reset_at,
 )
+from ccfr.storage import init_db
 
 
 def _utc(text: str) -> datetime:
@@ -62,3 +64,86 @@ def test_parse_reset_unknown_timezone_or_garbage_returns_none() -> None:
     assert parse_reset_at("resets 5pm (Middle/Nowhere)", hit) is None
     assert parse_reset_at("You've hit your session limit", hit) is None
     assert parse_reset_at("", hit) is None
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_id = conn.execute(
+        "INSERT INTO imports (source_path, imported_at, file_count, status, error_count)"
+        " VALUES ('fx', '2026-01-01T00:00:00Z', 0, 'complete', 0)"
+    ).lastrowid
+    project = conn.execute(
+        "INSERT INTO projects (import_id, export_name, inferred_cwd) VALUES (?, 'alpha', NULL)",
+        (import_id,),
+    ).lastrowid
+    conn.execute(
+        "INSERT INTO sessions (project_id, session_id, title, first_ts, last_ts)"
+        " VALUES (?, 's1', 'Session One', '2026-07-03T00:00:00Z', '2026-07-03T12:00:00Z')",
+        (project,),
+    )
+    return conn
+
+
+HIT_TEXT = "You've hit your session limit · resets 12:30pm (Europe/Paris)"
+
+
+def _add_limit_hit(conn: sqlite3.Connection, session_id: int, ts: str,
+                   text: str = HIT_TEXT, *, error: str | None = "rate_limit") -> int:
+    raw: dict = {"isApiErrorMessage": True,
+                 "message": {"model": "<synthetic>",
+                             "content": [{"type": "text", "text": text}]}}
+    if error is not None:
+        raw["error"] = error
+        raw["apiErrorStatus"] = 429
+    ev = conn.execute(
+        "INSERT INTO events (session_id, source_path, line_no, type, timestamp, raw_json)"
+        " VALUES (?, 'f.jsonl', 1, 'assistant', ?, ?)",
+        (session_id, ts, json.dumps(raw)),
+    ).lastrowid
+    conn.execute(
+        "INSERT INTO messages (event_id, role, model, text_preview)"
+        " VALUES (?, 'assistant', '<synthetic>', ?)",
+        (ev, text),
+    )
+    return int(ev)
+
+
+# ---------------------------------------------------------------------------
+# Detection and dedup
+# ---------------------------------------------------------------------------
+
+def test_detect_merges_same_reset_stamp_and_keeps_earliest_ts() -> None:
+    conn = _make_conn()
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:44Z")
+    _add_limit_hit(conn, 1, "2026-07-03T09:52:00Z")  # retry against the same cap
+    hits = detect_limit_hits(conn)
+    assert len(hits) == 1
+    assert hits[0].kind == "session"
+    assert hits[0].occurrence_count == 2
+    assert hits[0].ts == _utc("2026-07-03T09:40:44Z")
+    assert hits[0].reset_at == _utc("2026-07-03T10:30:00Z")
+    assert hits[0].blocked_minutes is not None
+    assert round(hits[0].blocked_minutes, 1) == 49.3
+    assert hits[0].session_ids == [1]
+    assert hits[0].session_titles == ["Session One"]
+
+
+def test_detect_ignores_synthetic_rows_without_rate_limit_marker() -> None:
+    conn = _make_conn()
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:44Z", "Some other synthetic notice",
+                   error=None)
+    assert detect_limit_hits(conn) == []
+
+
+def test_detect_unparseable_reset_buckets_by_time() -> None:
+    conn = _make_conn()
+    text = "You've hit your session limit — resets 5pm"  # no timezone: unparseable
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:00Z", text)
+    _add_limit_hit(conn, 1, "2026-07-03T09:42:00Z", text)  # same 5-minute bucket
+    _add_limit_hit(conn, 1, "2026-07-03T11:00:00Z", text)  # separate hit
+    hits = detect_limit_hits(conn)
+    assert len(hits) == 2
+    assert hits[0].reset_at is None
+    assert hits[0].blocked_minutes is None

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from ccfr.analysis.limits import (
+    classify_hit_text,
+    parse_reset_at,
+)
+
+
+def _utc(text: str) -> datetime:
+    return datetime.fromisoformat(text.replace("Z", "+00:00"))
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+def test_classify_session_weekly_org_unknown() -> None:
+    assert classify_hit_text(
+        "You've hit your session limit · resets 12:30pm (Europe/Paris)") == "session"
+    assert classify_hit_text("You've hit your weekly limit · resets Tuesday") == "weekly"
+    assert classify_hit_text("Your org has hit its monthly usage limit") == "org"
+    assert classify_hit_text("Something rate-limited happened") == "unknown"
+    assert classify_hit_text("") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Reset-stamp parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_reset_same_day() -> None:
+    # Hit at 09:40:44 UTC = 11:40 in Paris (July, UTC+2). Reset 12:30pm Paris = 10:30 UTC.
+    hit = _utc("2026-07-03T09:40:44Z")
+    reset = parse_reset_at(
+        "You've hit your session limit · resets 12:30pm (Europe/Paris)", hit)
+    assert reset == _utc("2026-07-03T10:30:00Z")
+
+
+def test_parse_reset_rolls_to_next_day() -> None:
+    # Hit at 22:00 UTC = 00:00 Paris next day; "resets 2am" is 2h later, not 22h earlier.
+    hit = _utc("2026-07-03T22:00:00Z")
+    reset = parse_reset_at("You've hit your session limit · resets 2am (Europe/Paris)", hit)
+    assert reset == _utc("2026-07-04T00:00:00Z")
+
+
+def test_parse_reset_hour_only_and_capitalized() -> None:
+    hit = _utc("2026-05-20T14:00:00Z")
+    reset = parse_reset_at("You've hit your session limit. Resets 5pm (UTC)", hit)
+    assert reset == _utc("2026-05-20T17:00:00Z")
+
+
+def test_parse_reset_without_timezone_returns_none() -> None:
+    hit = _utc("2026-05-20T14:00:00Z")
+    assert parse_reset_at("You've hit your session limit — resets 5pm", hit) is None
+
+
+def test_parse_reset_unknown_timezone_or_garbage_returns_none() -> None:
+    hit = _utc("2026-05-20T14:00:00Z")
+    assert parse_reset_at("resets 5pm (Middle/Nowhere)", hit) is None
+    assert parse_reset_at("You've hit your session limit", hit) is None
+    assert parse_reset_at("", hit) is None

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -216,3 +216,28 @@ def test_fold_windows_ignores_out_of_tolerance_reset() -> None:
                    reset_at=_utc("2026-07-03T15:00:00Z"))
     windows = fold_windows(events, [hit])
     assert windows[0].end == _utc("2026-07-03T13:00:00Z")
+
+
+def test_fold_windows_attaches_deferred_hit_without_matching_event() -> None:
+    # The hit has no event row of its own; a later event must not steal it.
+    events = _events(
+        ("2026-07-03T08:00:00Z", 1.0),
+        ("2026-07-03T20:00:00Z", 4.0),
+    )
+    hit = LimitHit(ts=_utc("2026-07-03T10:00:00Z"), kind="session",
+                   reset_at=_utc("2026-07-03T10:30:00Z"))
+    windows = fold_windows(events, [hit])
+    assert len(windows) == 2
+    assert hit.window_index == 0
+    assert hit.usage_at_hit == 1.0
+    assert windows[0].end == _utc("2026-07-03T10:30:00Z")
+    assert windows[0].hit_kinds == ["session"]
+
+
+def test_fold_windows_hit_in_activity_gap_opens_its_own_window() -> None:
+    events = _events(("2026-07-03T08:00:00Z", 1.0))
+    hit = LimitHit(ts=_utc("2026-07-03T14:00:00Z"), kind="session", reset_at=None)
+    windows = fold_windows(events, [hit])
+    assert len(windows) == 2
+    assert hit.window_index == 1
+    assert hit.usage_at_hit == 0.0

--- a/backend/tests/test_limits_api.py
+++ b/backend/tests/test_limits_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 
 import pytest
@@ -10,7 +9,6 @@ import ccfr.analysis.limits as limits_mod
 from ccfr import settings as settings_mod
 from ccfr.api.deps import get_db
 from ccfr.main import create_app
-from ccfr.storage import init_db
 from tests.test_limits import HIT_TEXT, _add_limit_hit, _add_usage, _make_conn
 
 
@@ -27,24 +25,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(limits_mod, "pricing_dir", lambda: tmp_path / "no-sheets")
     monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
     monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")
-    # Create a file-based database (thread-safe) instead of in-memory.
-    db_path = tmp_path / "test.sqlite3"
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    init_db(conn)
-    import_id = conn.execute(
-        "INSERT INTO imports (source_path, imported_at, file_count, status, error_count)"
-        " VALUES ('fx', '2026-01-01T00:00:00Z', 0, 'complete', 0)"
-    ).lastrowid
-    project = conn.execute(
-        "INSERT INTO projects (import_id, export_name, inferred_cwd) VALUES (?, 'alpha', NULL)",
-        (import_id,),
-    ).lastrowid
-    conn.execute(
-        "INSERT INTO sessions (project_id, session_id, title, first_ts, last_ts)"
-        " VALUES (?, 's1', 'Session One', '2026-07-03T00:00:00Z', '2026-07-03T12:00:00Z')",
-        (project,),
-    )
+    conn = _make_conn()
     app = create_app()
     app.dependency_overrides[get_db] = lambda: conn
     with TestClient(app) as c:

--- a/backend/tests/test_limits_api.py
+++ b/backend/tests/test_limits_api.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import ccfr.analysis.limits as limits_mod
+from ccfr import settings as settings_mod
+from ccfr.api.deps import get_db
+from ccfr.main import create_app
+from ccfr.storage import init_db
+from tests.test_limits import HIT_TEXT, _add_limit_hit, _add_usage, _make_conn
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    csv = tmp_path / "pricing.csv"
+    csv.write_text(
+        "model,base-input-tokens,5m-cache-writes,1h-cache-writes,"
+        "cache-hits-&-refreshes,output-tokens\n"
+        "claude-opus-4-8,10,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(limits_mod, "pricing_path", lambda: csv)
+    monkeypatch.setattr(limits_mod, "pricing_dir", lambda: tmp_path / "no-sheets")
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")
+    # Create a file-based database (thread-safe) instead of in-memory.
+    db_path = tmp_path / "test.sqlite3"
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    import_id = conn.execute(
+        "INSERT INTO imports (source_path, imported_at, file_count, status, error_count)"
+        " VALUES ('fx', '2026-01-01T00:00:00Z', 0, 'complete', 0)"
+    ).lastrowid
+    project = conn.execute(
+        "INSERT INTO projects (import_id, export_name, inferred_cwd) VALUES (?, 'alpha', NULL)",
+        (import_id,),
+    ).lastrowid
+    conn.execute(
+        "INSERT INTO sessions (project_id, session_id, title, first_ts, last_ts)"
+        " VALUES (?, 's1', 'Session One', '2026-07-03T00:00:00Z', '2026-07-03T12:00:00Z')",
+        (project,),
+    )
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: conn
+    with TestClient(app) as c:
+        yield c
+    conn.close()
+
+
+def test_limits_endpoint_returns_hits_windows_and_eras(client: TestClient) -> None:
+    # Seed through the shared helpers: usage then a hit in the same window.
+    conn = client.app.dependency_overrides[get_db]()
+    _add_usage(conn, 1, "2026-07-03T08:00:00Z", 1_000_000)
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:00Z", HIT_TEXT)
+
+    client.put("/api/settings", json={
+        "historical_pricing": True, "privacy_mode": False,
+        "team_export_prefs": {},
+        "plan_history": [{"plan": "Max 5x", "start_date": "2026-06-10"}],
+    })
+    resp = client.get("/api/analytics/limits")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"]["total_hits"] == 1
+    assert body["meta"]["hit_counts"] == {"session": 1}
+    assert body["meta"]["plan_history"] == [{"plan": "Max 5x", "start_date": "2026-06-10"}]
+    assert body["windows"][0]["hit_kinds"] == ["session"]
+    assert body["eras"][0]["era"] == "Max 5x"
+    assert body["hits"][0]["usage_at_hit"] == 10.0
+    assert body["hits"][0]["session_titles"] == ["Session One"]
+
+
+def test_limits_endpoint_rejects_no_params_gracefully(client: TestClient) -> None:
+    resp = client.get("/api/analytics/limits")
+    assert resp.status_code == 200
+    assert resp.json()["meta"]["total_hits"] == 0

--- a/backend/tests/test_limits_api.py
+++ b/backend/tests/test_limits_api.py
@@ -56,7 +56,7 @@ def test_limits_endpoint_returns_hits_windows_and_eras(client: TestClient) -> No
     assert body["hits"][0]["session_titles"] == ["Session One"]
 
 
-def test_limits_endpoint_rejects_no_params_gracefully(client: TestClient) -> None:
+def test_limits_endpoint_empty_corpus_returns_zeroes(client: TestClient) -> None:
     resp = client.get("/api/analytics/limits")
     assert resp.status_code == 200
     assert resp.json()["meta"]["total_hits"] == 0

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -89,3 +89,18 @@ def test_plan_history_round_trip_and_sanitization(tmp_path, monkeypatch) -> None
         {"plan": "Pro", "start_date": "2026-05-01"},
         {"plan": "Max 5x", "start_date": "2026-06-10"},
     ]
+
+
+def test_write_settings_does_not_mutate_caller_plan_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    original = [
+        {"plan": "Max 5x", "start_date": "2026-06-10"},
+        {"plan": "Pro", "start_date": "2026-05-01"},
+    ]
+    settings = Settings(plan_history=list(original))
+    saved = write_settings(settings)
+    assert settings.plan_history == original
+    assert saved.plan_history == [
+        {"plan": "Pro", "start_date": "2026-05-01"},
+        {"plan": "Max 5x", "start_date": "2026-06-10"},
+    ]

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -71,3 +71,21 @@ def test_write_settings_does_not_mutate_input(tmp_path, monkeypatch):
     assert arg.contributor_salt is None and arg.contributor_id is None  # input untouched
     reloaded = settings_mod.read_settings()
     assert reloaded.contributor_salt == salt and reloaded.contributor_id == cid  # disk preserved
+
+
+def test_plan_history_round_trip_and_sanitization(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    settings = settings_mod.read_settings()
+    settings.plan_history = [
+        {"plan": "Max 5x", "start_date": "2026-06-10"},
+        {"plan": "Pro", "start_date": "2026-05-01"},
+        {"plan": "", "start_date": "2026-01-01"},        # dropped: empty plan
+        {"plan": "Bad", "start_date": "not-a-date"},     # dropped: bad date
+        "not-a-dict",                                     # dropped
+    ]
+    settings_mod.write_settings(settings)
+    loaded = settings_mod.read_settings()
+    assert loaded.plan_history == [
+        {"plan": "Pro", "start_date": "2026-05-01"},
+        {"plan": "Max 5x", "start_date": "2026-06-10"},
+    ]

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -91,6 +91,16 @@ def test_plan_history_round_trip_and_sanitization(tmp_path, monkeypatch) -> None
     ]
 
 
+def test_plan_history_normalizes_compact_iso_dates(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    settings = settings_mod.read_settings()
+    settings.plan_history = [{"plan": "Pro", "start_date": "20260501"}]
+    settings_mod.write_settings(settings)
+    assert settings_mod.read_settings().plan_history == [
+        {"plan": "Pro", "start_date": "2026-05-01"}
+    ]
+
+
 def test_write_settings_does_not_mutate_caller_plan_history(monkeypatch, tmp_path):
     monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
     original = [

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -12,12 +12,30 @@ def test_settings_get_default_and_put_round_trip(monkeypatch, tmp_path):
 
     got = client.get("/api/settings")
     assert got.status_code == 200
-    assert got.json() == {"historical_pricing": True, "privacy_mode": False, "team_export_prefs": {}}
+    assert got.json() == {"historical_pricing": True, "privacy_mode": False, "team_export_prefs": {},
+                          "plan_history": []}
 
     put = client.put("/api/settings", json={"historical_pricing": False})
     assert put.status_code == 200
-    assert put.json() == {"historical_pricing": False, "privacy_mode": False, "team_export_prefs": {}}
+    assert put.json() == {"historical_pricing": False, "privacy_mode": False, "team_export_prefs": {},
+                          "plan_history": []}
 
     assert client.get("/api/settings").json() == {
-        "historical_pricing": False, "privacy_mode": False, "team_export_prefs": {}
+        "historical_pricing": False, "privacy_mode": False, "team_export_prefs": {}, "plan_history": []
     }
+
+
+def test_settings_api_round_trips_plan_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    client = TestClient(create_app())
+    put = client.put("/api/settings", json={
+        "historical_pricing": True,
+        "privacy_mode": False,
+        "team_export_prefs": {},
+        "plan_history": [{"plan": "Pro", "start_date": "2026-05-01"}],
+    })
+    assert put.status_code == 200
+    assert put.json()["plan_history"] == [{"plan": "Pro", "start_date": "2026-05-01"}]
+    assert client.get("/api/settings").json()["plan_history"] == [
+        {"plan": "Pro", "start_date": "2026-05-01"}
+    ]

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -39,3 +39,25 @@ def test_settings_api_round_trips_plan_history(monkeypatch, tmp_path):
     assert client.get("/api/settings").json()["plan_history"] == [
         {"plan": "Pro", "start_date": "2026-05-01"}
     ]
+
+
+def test_partial_settings_put_preserves_plan_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings_mod, "data_dir", lambda: tmp_path)
+    client = TestClient(create_app())
+    client.put("/api/settings", json={
+        "historical_pricing": True,
+        "privacy_mode": False,
+        "team_export_prefs": {},
+        "plan_history": [{"plan": "Pro", "start_date": "2026-05-01"}],
+    })
+    # The shell's toggles send partial payloads; they must not wipe history.
+    put = client.put("/api/settings", json={"historical_pricing": False})
+    assert put.status_code == 200
+    assert put.json()["plan_history"] == [{"plan": "Pro", "start_date": "2026-05-01"}]
+    assert client.get("/api/settings").json()["plan_history"] == [
+        {"plan": "Pro", "start_date": "2026-05-01"}
+    ]
+    # An explicit empty list still clears it.
+    client.put("/api/settings", json={"historical_pricing": False, "privacy_mode": False,
+                                      "team_export_prefs": {}, "plan_history": []})
+    assert client.get("/api/settings").json()["plan_history"] == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -49,6 +49,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -64,6 +65,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 provides-extras = ["dev"]
@@ -459,6 +461,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,6 +137,9 @@ team bundles do not contain raw per-session events.
 - `team_bundles.py` and `team_cost.py`: content-free team sharing and team
   aggregate cost.
 - `contribution.py`: content-free contribution bundle export.
+- `limits.py`: detects subscription limit-hit events (synthetic rate-limit
+  messages), folds usage into priced 5-hour windows, and derives per-era
+  measured cap zones. Corpus-wide on purpose (limits are account-level).
 
 ## Configuration Reference
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   EventDetail,
   ImportProgress,
   ImportSummary,
+  LimitsResponse,
   Project,
   RiskFinding,
   RuntimeConfig,
@@ -247,6 +248,10 @@ export function getUsageCharacteristics(filters: UsageMapFilters = {}) {
   return request<UsageCharacteristicsResponse>(
     `/analytics/usage-characteristics${query ? `?${query}` : ""}`,
   );
+}
+
+export function getLimits() {
+  return request<LimitsResponse>("/analytics/limits");
 }
 
 export function getSettings() {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -653,6 +653,66 @@ export interface Settings {
   historical_pricing: boolean;
   privacy_mode: boolean;
   team_export_prefs?: Record<string, unknown>;
+  plan_history?: PlanEra[];
+}
+
+export interface PlanEra {
+  plan: string;
+  start_date: string;
+}
+
+export interface LimitHitEntry {
+  ts: string;
+  kind: string;
+  reset_at: string | null;
+  blocked_minutes: number | null;
+  usage_at_hit: number | null;
+  occurrence_count: number;
+  window_index: number | null;
+  session_ids: number[];
+  session_titles: string[];
+}
+
+export interface LimitWindowEntry {
+  start: string;
+  end: string;
+  value_usd: number;
+  tokens: number;
+  era: string;
+  hit_kinds: string[];
+}
+
+export interface LimitEraEntry {
+  era: string;
+  window_count: number;
+  session_hit_count: number;
+  blocked_minutes: number;
+  cap_median_usd: number | null;
+  cap_min_usd: number | null;
+  cap_max_usd: number | null;
+  near_miss_count: number;
+  cap_percentile: number | null;
+  usage_at_hit_usd: number[];
+}
+
+export interface LimitsMeta {
+  window: { date_from: string | null; date_to: string | null };
+  cost_available: boolean;
+  costs_partial: boolean;
+  total_hits: number;
+  total_windows: number;
+  blocked_minutes: number;
+  hits_per_week_recent: number;
+  hit_counts: Record<string, number>;
+  plan_history: PlanEra[];
+  method_note: string;
+}
+
+export interface LimitsResponse {
+  meta: LimitsMeta;
+  hits: LimitHitEntry[];
+  windows: LimitWindowEntry[];
+  eras: LimitEraEntry[];
 }
 
 export interface ContributionManifest {

--- a/frontend/src/discover/DiscoverPage.test.tsx
+++ b/frontend/src/discover/DiscoverPage.test.tsx
@@ -4,8 +4,11 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Project } from "../api/types";
 
-const { getDiscoveryAnalytics } = vi.hoisted(() => ({ getDiscoveryAnalytics: vi.fn() }));
-vi.mock("../api/client", () => ({ getDiscoveryAnalytics }));
+const { getDiscoveryAnalytics, getLimits } = vi.hoisted(() => ({
+  getDiscoveryAnalytics: vi.fn(),
+  getLimits: vi.fn(),
+}));
+vi.mock("../api/client", () => ({ getDiscoveryAnalytics, getLimits }));
 
 import DiscoverPage from "./DiscoverPage";
 
@@ -21,6 +24,17 @@ function renderPage(technique: string) {
 }
 
 beforeEach(() => {
+  getLimits.mockReset();
+  getLimits.mockResolvedValue({
+    meta: {
+      window: { date_from: null, date_to: null },
+      cost_available: true, costs_partial: false,
+      total_hits: 0, total_windows: 0, blocked_minutes: 0,
+      hits_per_week_recent: 0, hit_counts: {}, plan_history: [],
+      method_note: "note",
+    },
+    hits: [], windows: [], eras: [],
+  });
   getDiscoveryAnalytics.mockReset();
   getDiscoveryAnalytics.mockResolvedValue({
     meta: { project_id: null, min_support: 5, total_sessions: 12, cost_available: true },
@@ -59,10 +73,10 @@ describe("DiscoverPage", () => {
     expect(await screen.findByRole("heading", { name: "What drives high-cost sessions?" })).toBeInTheDocument();
   });
 
-  it("falls back to the default technique for an unregistered key", async () => {
+  it("falls back to the default technique (limits) for an unregistered key", async () => {
     renderPage("sequence");
     expect(
-      await screen.findByRole("heading", { name: "What drives high-cost sessions?" }),
+      await screen.findByRole("heading", { name: "Limit hits" }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/discover/context/chartTooltip.tsx
+++ b/frontend/src/discover/context/chartTooltip.tsx
@@ -5,6 +5,7 @@ interface TipState {
   x: number;
   y: number;
   hostWidth: number;
+  hostHeight: number;
   title: string;
   lines: string[];
   blur: boolean;
@@ -34,6 +35,7 @@ export function useChartTooltip<T extends HTMLElement>() {
       x: event.clientX - host.left,
       y: event.clientY - host.top,
       hostWidth: host.width,
+      hostHeight: host.height,
       title,
       lines,
       blur: options?.blur ?? false,
@@ -42,12 +44,13 @@ export function useChartTooltip<T extends HTMLElement>() {
 
   const hide = React.useCallback(() => setTip(null), []);
 
-  // Flip to the left of the cursor in the right 40% of the host so the tooltip
-  // never clips at the container edge.
+  // Flip to the left of the cursor in the right 40% of the host, and above it
+  // in the bottom 40%, so the tooltip never clips at the container edge.
   const flipped = tip !== null && tip.x > tip.hostWidth * 0.6;
+  const flippedY = tip !== null && tip.y > tip.hostHeight * 0.6;
   const tooltip = tip && (
     <div
-      className={`chart-tooltip${flipped ? " is-flipped" : ""}`}
+      className={`chart-tooltip${flipped ? " is-flipped" : ""}${flippedY ? " is-flipped-y" : ""}`}
       style={{ left: tip.x, top: tip.y }}
       role="presentation"
     >

--- a/frontend/src/discover/limits/CapZones.tsx
+++ b/frontend/src/discover/limits/CapZones.tsx
@@ -1,13 +1,53 @@
 import React from "react";
 import type { LimitEraEntry } from "../../api/types";
-import { formatUsd } from "./LimitHits";
+import { formatBlocked, formatUsd, meanUsageAtHit } from "./limitMath";
+import { useChartTooltip } from "../context/chartTooltip";
 
-const STRIP_W = 360;
+const FALLBACK_W = 560;
+const STRIP_H = 26;
+const PAD = 10; // keeps edge dots inside the strip
+
+// The per-plan metrics live here (one row per era, not one card per era, so
+// any number of plans scales). Only the parts an era actually has are shown.
+function eraSummary(era: LimitEraEntry): string {
+  const hits = era.session_hit_count;
+  const avg = meanUsageAtHit(era);
+  const parts = [`${hits} session hit${hits === 1 ? "" : "s"}`];
+  if (era.cap_median_usd != null) parts.push(`median ${formatUsd(era.cap_median_usd)}`);
+  if (avg != null) parts.push(`avg ${formatUsd(avg)}`);
+  if (era.blocked_minutes > 0) parts.push(`${formatBlocked(era.blocked_minutes)} blocked`);
+  parts.push(`${era.near_miss_count} near-miss${era.near_miss_count === 1 ? "" : "es"}`);
+  if (era.cap_percentile != null) {
+    parts.push(`cap at p${Math.round(era.cap_percentile * 100)} of windows`);
+  }
+  return parts.join(", ");
+}
 
 // Per era: usage-at-hit dots, the min-max band, and a median marker, plus the
 // percentile insight (a cap is a percentile of your windows, not a quota).
+// Rendered in measured pixel space so markers keep their shape at any width;
+// all eras share one dollar scale and the axis at the bottom.
 export default function CapZones({ eras }: { eras: LimitEraEntry[] }) {
-  const zoned = eras.filter((e) => e.usage_at_hit_usd.length > 0);
+  const { ref, show, hide, tooltip } = useChartTooltip<HTMLDivElement>();
+  const [width, setWidth] = React.useState(FALLBACK_W);
+
+  React.useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const update = (next: number) => {
+      const rounded = Math.max(280, Math.round(next));
+      setWidth((current) => (current === rounded ? current : rounded));
+    };
+    if (node.clientWidth) update(node.clientWidth);
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      if (entries[0]) update(entries[0].contentRect.width);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  const zoned = eras.filter((e) => e.usage_at_hit_usd.length > 0 || e.blocked_minutes > 0);
   if (zoned.length === 0) {
     return (
       <div className="empty-state">
@@ -16,40 +56,63 @@ export default function CapZones({ eras }: { eras: LimitEraEntry[] }) {
     );
   }
   const max = Math.max(1e-9, ...zoned.map((e) => e.cap_max_usd ?? 0));
-  const px = (v: number) => Math.min(STRIP_W - 4, (v / max) * (STRIP_W - 8) + 4);
+  const px = (v: number) => PAD + (v / max) * (width - 2 * PAD);
+  const ticks = [0, max / 2, max];
+
   return (
-    <div className="limit-zones">
-      {zoned.map((era) => (
+    <div className="limit-zones chart-tooltip-host" ref={ref}>
+      {zoned.map((era) => {
+        const avg = meanUsageAtHit(era);
+        return (
         <div key={era.era || "all"} className="limit-zone-row">
           <div className="limit-zone-head">
             <strong>{era.era || "All usage"}</strong>
-            <span>
-              {era.session_hit_count} session hits, median {formatUsd(era.cap_median_usd)},{" "}
-              {era.near_miss_count} near-misses
-              {era.cap_percentile != null
-                ? `, cap at p${Math.round(era.cap_percentile * 100)} of windows`
-                : ""}
-            </span>
+            <span>{eraSummary(era)}</span>
           </div>
-          <svg viewBox={`0 0 ${STRIP_W} 24`} preserveAspectRatio="none"
-               className="limit-zone-strip" role="img"
+          <svg width={width} height={STRIP_H} className="limit-zone-strip" role="img"
                aria-label={`${era.era || "All usage"} cap zone`}>
-            <rect x={0} y={10} width={STRIP_W} height={4} rx={2} className="lane-track" />
+            {ticks.map((t) => (
+              <line key={t} className="limit-zone-grid"
+                    x1={px(t)} y1={3} x2={px(t)} y2={STRIP_H - 3} />
+            ))}
+            <rect x={PAD} y={STRIP_H / 2 - 2} width={Math.max(0, width - 2 * PAD)}
+                  height={4} rx={2} className="lane-track" />
             {era.cap_min_usd != null && era.cap_max_usd != null && (
-              <rect x={px(era.cap_min_usd)} y={8}
+              <rect x={px(era.cap_min_usd)} y={STRIP_H / 2 - 5}
                     width={Math.max(2, px(era.cap_max_usd) - px(era.cap_min_usd))}
-                    height={8} className="limit-zone-band" />
+                    height={10} rx={5} className="limit-zone-band" />
             )}
             {era.usage_at_hit_usd.map((v, i) => (
-              <circle key={i} cx={px(v)} cy={12} r={4} className="limit-zone-dot" />
+              <circle key={i} cx={px(v)} cy={STRIP_H / 2} r={5}
+                      className="limit-zone-dot"
+                      onMouseMove={(e) => show(e, formatUsd(v), ["window usage when the cap hit"])}
+                      onMouseLeave={hide} />
             ))}
             {era.cap_median_usd != null && (
-              <rect x={px(era.cap_median_usd) - 1} y={4} width={2} height={16}
+              <rect x={px(era.cap_median_usd) - 1} y={2} width={2} height={STRIP_H - 4}
                     className="limit-zone-median" />
+            )}
+            {avg != null && (
+              <line x1={px(avg)} y1={2} x2={px(avg)} y2={STRIP_H - 2}
+                    className="limit-zone-avg" />
             )}
           </svg>
         </div>
-      ))}
+        );
+      })}
+      <div className="limit-zone-axis" aria-hidden={true}>
+        {ticks.map((t) => (
+          <span key={t} style={{ left: px(t) }}>{t === 0 ? "$0" : formatUsd(t)}</span>
+        ))}
+      </div>
+      <div className="chip-legend card-bottom-legend limit-legend">
+        <span><i className="is-hit-dot" />usage at a session-limit hit</span>
+        <span><i className="is-band" />min-max cap zone</span>
+        <span><i className="is-median" />median cap</span>
+        <span><i className="is-avg" />avg hit</span>
+        <em>x-axis: window usage, $ API-equivalent</em>
+      </div>
+      {tooltip}
     </div>
   );
 }

--- a/frontend/src/discover/limits/CapZones.tsx
+++ b/frontend/src/discover/limits/CapZones.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import type { LimitEraEntry } from "../../api/types";
+import { formatUsd } from "./LimitHits";
+
+const STRIP_W = 360;
+
+// Per era: usage-at-hit dots, the min-max band, and a median marker, plus the
+// percentile insight (a cap is a percentile of your windows, not a quota).
+export default function CapZones({ eras }: { eras: LimitEraEntry[] }) {
+  const zoned = eras.filter((e) => e.usage_at_hit_usd.length > 0);
+  if (zoned.length === 0) {
+    return (
+      <div className="empty-state">
+        No session-limit hits, so no measured cap zone. That is headroom.
+      </div>
+    );
+  }
+  const max = Math.max(1e-9, ...zoned.map((e) => e.cap_max_usd ?? 0));
+  const px = (v: number) => Math.min(STRIP_W - 4, (v / max) * (STRIP_W - 8) + 4);
+  return (
+    <div className="limit-zones">
+      {zoned.map((era) => (
+        <div key={era.era || "all"} className="limit-zone-row">
+          <div className="limit-zone-head">
+            <strong>{era.era || "All usage"}</strong>
+            <span>
+              {era.session_hit_count} session hits, median {formatUsd(era.cap_median_usd)},{" "}
+              {era.near_miss_count} near-misses
+              {era.cap_percentile != null
+                ? `, cap at p${Math.round(era.cap_percentile * 100)} of windows`
+                : ""}
+            </span>
+          </div>
+          <svg viewBox={`0 0 ${STRIP_W} 24`} preserveAspectRatio="none"
+               className="limit-zone-strip" role="img"
+               aria-label={`${era.era || "All usage"} cap zone`}>
+            <rect x={0} y={10} width={STRIP_W} height={4} rx={2} className="lane-track" />
+            {era.cap_min_usd != null && era.cap_max_usd != null && (
+              <rect x={px(era.cap_min_usd)} y={8}
+                    width={Math.max(2, px(era.cap_max_usd) - px(era.cap_min_usd))}
+                    height={8} className="limit-zone-band" />
+            )}
+            {era.usage_at_hit_usd.map((v, i) => (
+              <circle key={i} cx={px(v)} cy={12} r={4} className="limit-zone-dot" />
+            ))}
+            {era.cap_median_usd != null && (
+              <rect x={px(era.cap_median_usd) - 1} y={4} width={2} height={16}
+                    className="limit-zone-median" />
+            )}
+          </svg>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/discover/limits/LimitHits.test.tsx
+++ b/frontend/src/discover/limits/LimitHits.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { LimitsResponse, Project } from "../../api/types";
+import CapZones from "./CapZones";
+import LimitHits from "./LimitHits";
+
+const payload: LimitsResponse = {
+  meta: {
+    window: { date_from: null, date_to: null },
+    cost_available: true,
+    costs_partial: false,
+    total_hits: 1,
+    total_windows: 2,
+    blocked_minutes: 49.3,
+    hits_per_week_recent: 0.25,
+    hit_counts: { session: 1 },
+    plan_history: [{ plan: "Max 5x", start_date: "2026-06-10" }],
+    method_note: "Account-level view: dollars are API-equivalent value.",
+  },
+  hits: [
+    {
+      ts: "2026-07-03T09:40:44+00:00", kind: "session",
+      reset_at: "2026-07-03T10:30:00+00:00", blocked_minutes: 49.3,
+      usage_at_hit: 76.2, occurrence_count: 2, window_index: 0,
+      session_ids: [7], session_titles: ["Ship the release"],
+    },
+  ],
+  windows: [
+    { start: "2026-07-03T08:00:00+00:00", end: "2026-07-03T10:30:00+00:00",
+      value_usd: 76.2, tokens: 900000, era: "Max 5x", hit_kinds: ["session"] },
+    { start: "2026-07-03T14:00:00+00:00", end: "2026-07-03T19:00:00+00:00",
+      value_usd: 12.5, tokens: 150000, era: "Max 5x", hit_kinds: [] },
+  ],
+  eras: [
+    {
+      era: "Max 5x", window_count: 2, session_hit_count: 1, blocked_minutes: 49.3,
+      cap_median_usd: 76.2, cap_min_usd: 76.2, cap_max_usd: 76.2,
+      near_miss_count: 0, cap_percentile: 0.5, usage_at_hit_usd: [76.2],
+    },
+  ],
+};
+
+vi.mock("../../api/client", () => ({
+  getLimits: vi.fn(() => Promise.resolve(payload)),
+}));
+
+const projects: Project[] = [];
+
+function renderPage(onOpenSession = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <LimitHits projects={projects} onOpenSession={onOpenSession} />
+    </QueryClientProvider>,
+  );
+  return onOpenSession;
+}
+
+describe("LimitHits", () => {
+  it("renders the stat tiles and the measured cap", async () => {
+    renderPage();
+    expect(await screen.findByText("limit hits")).toBeInTheDocument();
+    expect(screen.getByText("$76.2")).toBeInTheDocument();
+    expect(screen.getByText(/Max 5x cap, median/)).toBeInTheDocument();
+    expect(screen.getByText(/hits\/week, last 28 days/)).toBeInTheDocument();
+  });
+
+  it("shows the windows timeline and opens the hit detail on click", async () => {
+    const onOpenSession = renderPage();
+    await screen.findByText("limit hits");
+    expect(screen.getByRole("img", { name: "5-hour windows timeline" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /window 1/i }));
+    expect(await screen.findByText(/session limit/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Ship the release/ }));
+    expect(onOpenSession).toHaveBeenCalledWith(7);
+  });
+
+  it("shows the cap zone strip per era", async () => {
+    renderPage();
+    await screen.findByText("limit hits");
+    expect(screen.getByText(/1 session hits/)).toBeInTheDocument();
+    expect(screen.getByText(/cap at p50 of windows/)).toBeInTheDocument();
+  });
+
+  it("shows the headroom message when no session hits exist", () => {
+    render(<CapZones eras={[{
+      era: "", window_count: 1, session_hit_count: 0, blocked_minutes: 0,
+      cap_median_usd: null, cap_min_usd: null, cap_max_usd: null,
+      near_miss_count: 0, cap_percentile: null, usage_at_hit_usd: [],
+    }]} />);
+    expect(screen.getByText(/That is headroom/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/discover/limits/LimitHits.test.tsx
+++ b/frontend/src/discover/limits/LimitHits.test.tsx
@@ -41,8 +41,12 @@ const payload: LimitsResponse = {
   ],
 };
 
+const updateSettingsMock = vi.fn((s) => Promise.resolve(s));
 vi.mock("../../api/client", () => ({
   getLimits: vi.fn(() => Promise.resolve(payload)),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ historical_pricing: true, privacy_mode: false, plan_history: [] })),
+  updateSettings: (s: unknown) => updateSettingsMock(s),
 }));
 
 const projects: Project[] = [];
@@ -90,5 +94,20 @@ describe("LimitHits", () => {
       near_miss_count: 0, cap_percentile: null, usage_at_hit_usd: [],
     }]} />);
     expect(screen.getByText(/That is headroom/)).toBeInTheDocument();
+  });
+
+  it("edits plan history through the modal and saves it to settings", async () => {
+    renderPage();
+    await screen.findByText("limit hits");
+    fireEvent.click(screen.getByRole("button", { name: "Plan history" }));
+    expect(await screen.findByRole("dialog", { name: "Plan history" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add plan" }));
+    fireEvent.change(screen.getByLabelText("Plan name 1"), { target: { value: "Pro" } });
+    fireEvent.change(screen.getByLabelText("Start date 1"), { target: { value: "2026-05-01" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await vi.waitFor(() => expect(updateSettingsMock).toHaveBeenCalled());
+    expect(updateSettingsMock.mock.calls[0][0]).toMatchObject({
+      plan_history: [{ plan: "Pro", start_date: "2026-05-01" }],
+    });
   });
 });

--- a/frontend/src/discover/limits/LimitHits.test.tsx
+++ b/frontend/src/discover/limits/LimitHits.test.tsx
@@ -62,29 +62,48 @@ function renderPage(onOpenSession = vi.fn()) {
 }
 
 describe("LimitHits", () => {
-  it("renders the stat tiles and the measured cap", async () => {
+  it("renders the stat tiles without per-plan cards", async () => {
     renderPage();
-    expect(await screen.findByText("limit hits")).toBeInTheDocument();
-    expect(screen.getByText("$76.2")).toBeInTheDocument();
-    expect(screen.getByText(/Max 5x cap, median/)).toBeInTheDocument();
-    expect(screen.getByText(/hits\/week, last 28 days/)).toBeInTheDocument();
+    expect(await screen.findByText("Time blocked")).toBeInTheDocument();
+    expect(screen.getByText("Capped windows")).toBeInTheDocument();
+    expect(screen.getByText("1 of 2 windows hit a cap")).toBeInTheDocument();
+    expect(screen.queryByText("Hits per week")).not.toBeInTheDocument();
+    expect(screen.queryByText("Max 5x cap")).not.toBeInTheDocument();
   });
 
-  it("shows the windows timeline and opens the hit detail on click", async () => {
+  it("shows the windows timeline with its legend and opens the hit detail on click", async () => {
     const onOpenSession = renderPage();
-    await screen.findByText("limit hits");
+    await screen.findByText("Time blocked");
     expect(screen.getByRole("img", { name: "5-hour windows timeline" })).toBeInTheDocument();
+    expect(screen.getByText("window usage")).toBeInTheDocument();
+    expect(screen.getByText("limit hit")).toBeInTheDocument();
+    expect(screen.getByText("1.0 hits/wk")).toBeInTheDocument();
+    expect(screen.getByText("x-axis: window start date")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /window 1/i }));
     expect(await screen.findByText(/session limit/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Ship the release/ }));
     expect(onOpenSession).toHaveBeenCalledWith(7);
   });
 
-  it("shows the cap zone strip per era", async () => {
+  it("shows the per-plan metrics on the cap zone rows", async () => {
     renderPage();
-    await screen.findByText("limit hits");
-    expect(screen.getByText(/1 session hits/)).toBeInTheDocument();
+    await screen.findByText("Time blocked");
+    expect(screen.getByText(/1 session hit\b/)).toBeInTheDocument();
+    expect(screen.getByText(/median \$76\.2/)).toBeInTheDocument();
+    expect(screen.getByText(/avg \$76\.2/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.8h blocked/)).toBeInTheDocument();
     expect(screen.getByText(/cap at p50 of windows/)).toBeInTheDocument();
+    expect(screen.getByText("min-max cap zone")).toBeInTheDocument();
+    expect(screen.getByText("avg hit")).toBeInTheDocument();
+    expect(screen.getByText(/x-axis: window usage/)).toBeInTheDocument();
+  });
+
+  it("shows a verdict about the active plan", async () => {
+    renderPage();
+    await screen.findByText("Time blocked");
+    expect(
+      screen.getByText(/You hit the Max 5x cap about 1\.0 times a week/),
+    ).toBeInTheDocument();
   });
 
   it("shows the headroom message when no session hits exist", () => {
@@ -98,7 +117,7 @@ describe("LimitHits", () => {
 
   it("edits plan history through the modal and saves it to settings", async () => {
     renderPage();
-    await screen.findByText("limit hits");
+    await screen.findByText("Time blocked");
     fireEvent.click(screen.getByRole("button", { name: "Plan history" }));
     expect(await screen.findByRole("dialog", { name: "Plan history" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Add plan" }));
@@ -109,5 +128,16 @@ describe("LimitHits", () => {
     expect(updateSettingsMock.mock.calls[0][0]).toMatchObject({
       plan_history: [{ plan: "Pro", start_date: "2026-05-01" }],
     });
+  });
+
+  it("keeps Add plan disabled until the saved history has loaded", async () => {
+    // A row added before the settings fetch resolves would be wiped by it.
+    const { getSettings } = await import("../../api/client");
+    vi.mocked(getSettings).mockImplementationOnce(() => new Promise(() => {}));
+    renderPage();
+    await screen.findByText("Time blocked");
+    fireEvent.click(screen.getByRole("button", { name: "Plan history" }));
+    expect(await screen.findByRole("dialog", { name: "Plan history" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add plan" })).toBeDisabled();
   });
 });

--- a/frontend/src/discover/limits/LimitHits.tsx
+++ b/frontend/src/discover/limits/LimitHits.tsx
@@ -7,16 +7,22 @@ import WindowsTimeline from "./WindowsTimeline";
 import CapZones from "./CapZones";
 import PlanHistoryModal from "./PlanHistoryModal";
 import { Blurred } from "../../shell/Blurred";
+import InsightStat from "../../components/InsightStat";
+import LoadingBar from "../../components/LoadingBar";
+import { activeEra, buildVerdict, eraRates, formatBlocked, formatUsd } from "./limitMath";
 
-export function formatBlocked(minutes: number): string {
-  if (!minutes) return "0h";
-  const hours = minutes / 60;
-  return hours >= 10 ? `${Math.round(hours)}h` : `${hours.toFixed(1)}h`;
+function hitCountsHint(counts: Record<string, number>): string {
+  const parts = Object.entries(counts).map(([kind, count]) => `${count} ${kind}`);
+  return parts.length > 0 ? parts.join(" · ") : "in your exported logs";
 }
 
-export function formatUsd(value: number | null | undefined): string {
-  if (value == null) return "n/a";
-  return `$${value >= 100 ? value.toFixed(0) : value.toFixed(1)}`;
+function cappedCount(windows: LimitsResponse["windows"]): number {
+  return windows.filter((w) => w.hit_kinds.length > 0).length;
+}
+
+function cappedPct(windows: LimitsResponse["windows"]): number {
+  if (windows.length === 0) return 0;
+  return Math.round((cappedCount(windows) / windows.length) * 100);
 }
 
 // Explore technique: measured subscription limits. Account-level by design,
@@ -27,6 +33,16 @@ export default function LimitHits({ onOpenSession }: TechniqueProps) {
   const data = query.data;
   const [selected, setSelected] = React.useState<number | null>(null);
   const [planOpen, setPlanOpen] = React.useState(false);
+
+  // The verdict reads the plan the user is on now (the newest window's era).
+  const verdict = React.useMemo(() => {
+    if (!data || data.windows.length === 0) return null;
+    const era = activeEra(data.windows);
+    return buildVerdict(
+      data.eras.find((e) => e.era === era),
+      eraRates(data.windows, data.hits).get(era ?? ""),
+    );
+  }, [data]);
 
   return (
     <main className="discover-page">
@@ -39,44 +55,50 @@ export default function LimitHits({ onOpenSession }: TechniqueProps) {
               them. Covers all projects: limits are account-level.
             </p>
           </div>
-          <button type="button" onClick={() => setPlanOpen(true)}>
+          <button type="button" className="ghost-action" onClick={() => setPlanOpen(true)}>
             Plan history
           </button>
         </div>
 
-        {query.isLoading && <div className="empty-state">Reconstructing windows.</div>}
-        {query.isError && <div className="empty-state">Could not load limit analytics.</div>}
+        {query.isLoading && (
+          <div className="loading-view"><LoadingBar caption="Reconstructing 5-hour windows…" /></div>
+        )}
+        {query.isError && (
+          <div className="empty-state panel-error">
+            <strong>Failed to load</strong>
+            <span>Limit analytics could not be loaded.</span>
+          </div>
+        )}
 
         {data && (
           <>
-            <div className="limit-tiles" aria-label="Limit stats">
-              <div className="limit-tile">
-                <strong>{data.meta.total_hits}</strong>
-                <span>limit hits</span>
-              </div>
-              <div className="limit-tile">
-                <strong>{formatBlocked(data.meta.blocked_minutes)}</strong>
-                <span>blocked</span>
-              </div>
-              <div className="limit-tile">
-                <strong>{data.meta.hits_per_week_recent}</strong>
-                <span>hits/week, last 28 days</span>
-              </div>
-              {data.eras
-                .filter((era) => era.cap_median_usd != null)
-                .map((era) => (
-                  <div key={era.era || "all"} className="limit-tile">
-                    <strong>{formatUsd(era.cap_median_usd)}</strong>
-                    <span>{era.era ? `${era.era} cap, median` : "measured cap, median"}</span>
-                  </div>
-                ))}
+            {!data.meta.cost_available && (
+              <p className="tile-note">Price table unavailable, so window dollar values cannot be computed.</p>
+            )}
+            {data.meta.cost_available && data.meta.costs_partial && (
+              <p className="tile-note">Some models lack prices, so window values are a lower bound.</p>
+            )}
+            <div className="cost-insight-strip limit-insight-strip" aria-label="Limit stats">
+              <InsightStat label="Limit hits" value={data.meta.total_hits}
+                           hint={hitCountsHint(data.meta.hit_counts)} />
+              <InsightStat label="Time blocked" value={formatBlocked(data.meta.blocked_minutes)}
+                           hint="from parsed reset times" />
+              <InsightStat label="Capped windows" value={`${cappedPct(data.windows)}%`}
+                           hint={`${cappedCount(data.windows)} of ${data.windows.length} windows hit a cap`} />
             </div>
+            {verdict && (
+              <p className="limit-verdict" data-tone={verdict.tone}>
+                <i aria-hidden={true} />
+                <span>{verdict.text}</span>
+              </p>
+            )}
             <section className="card" aria-label="Windows timeline">
               <div className="card-head">
                 <h2>5-hour windows, hits marked</h2>
+                <span className="card-count"><b>{data.meta.total_windows}</b> windows</span>
               </div>
               <div className="card-pad">
-                <WindowsTimeline windows={data.windows} selected={selected}
+                <WindowsTimeline windows={data.windows} hits={data.hits} selected={selected}
                                  onSelectWindow={setSelected} />
               </div>
             </section>
@@ -94,6 +116,9 @@ export default function LimitHits({ onOpenSession }: TechniqueProps) {
               <section className="card" aria-label="Window detail">
                 <div className="card-head">
                   <h2>Window detail</h2>
+                  <span className="card-count">
+                    {new Date(data.windows[selected].start).toLocaleString()}
+                  </span>
                 </div>
                 <div className="card-pad">
                   {data.hits.filter((h) => h.window_index === selected).map((h) => (

--- a/frontend/src/discover/limits/LimitHits.tsx
+++ b/frontend/src/discover/limits/LimitHits.tsx
@@ -3,6 +3,9 @@ import { useQuery } from "@tanstack/react-query";
 import type { TechniqueProps } from "../techniques";
 import type { LimitsResponse } from "../../api/types";
 import { getLimits } from "../../api/client";
+import WindowsTimeline from "./WindowsTimeline";
+import CapZones from "./CapZones";
+import { Blurred } from "../../shell/Blurred";
 
 export function formatBlocked(minutes: number): string {
   if (!minutes) return "0h";
@@ -18,9 +21,10 @@ export function formatUsd(value: number | null | undefined): string {
 // Explore technique: measured subscription limits. Account-level by design,
 // so unlike the other techniques there is no project filter (the window that
 // capped may have been filled by several projects at once).
-export default function LimitHits(_props: TechniqueProps) {
+export default function LimitHits({ onOpenSession }: TechniqueProps) {
   const query = useQuery<LimitsResponse>({ queryKey: ["limits"], queryFn: getLimits });
   const data = query.data;
+  const [selected, setSelected] = React.useState<number | null>(null);
 
   return (
     <main className="discover-page">
@@ -62,6 +66,61 @@ export default function LimitHits(_props: TechniqueProps) {
                   </div>
                 ))}
             </div>
+            <section className="card" aria-label="Windows timeline">
+              <div className="card-head">
+                <h2>5-hour windows, hits marked</h2>
+              </div>
+              <div className="card-pad">
+                <WindowsTimeline windows={data.windows} selected={selected}
+                                 onSelectWindow={setSelected} />
+              </div>
+            </section>
+
+            <section className="card" aria-label="Measured cap zones">
+              <div className="card-head">
+                <h2>Measured cap zones</h2>
+              </div>
+              <div className="card-pad">
+                <CapZones eras={data.eras} />
+              </div>
+            </section>
+
+            {selected != null && (
+              <section className="card" aria-label="Window detail">
+                <div className="card-head">
+                  <h2>Window detail</h2>
+                </div>
+                <div className="card-pad">
+                  {data.hits.filter((h) => h.window_index === selected).map((h) => (
+                    <div key={h.ts} className="limit-hit-detail">
+                      <span className={`limit-kind limit-kind-${h.kind}`}>{h.kind} limit</span>
+                      <span>{new Date(h.ts).toLocaleString()}</span>
+                      <span>
+                        {h.blocked_minutes != null
+                          ? `blocked ${formatBlocked(h.blocked_minutes)}`
+                          : "reset time unknown"}
+                      </span>
+                      {h.usage_at_hit != null && (
+                        <span>at {formatUsd(h.usage_at_hit)} of window usage</span>
+                      )}
+                      {h.occurrence_count > 1 && <span>seen {h.occurrence_count} times</span>}
+                      <span className="limit-sessions">
+                        {h.session_ids.map((id, i) => (
+                          <button key={id} type="button" className="link-button"
+                                  onClick={() => onOpenSession(id)}>
+                            <Blurred>{h.session_titles[i] || `Session ${id}`}</Blurred>
+                          </button>
+                        ))}
+                      </span>
+                    </div>
+                  ))}
+                  {data.hits.every((h) => h.window_index !== selected) && (
+                    <p>No hits in this window.</p>
+                  )}
+                </div>
+              </section>
+            )}
+
             <p className="limit-footnote">{data.meta.method_note}</p>
           </>
         )}

--- a/frontend/src/discover/limits/LimitHits.tsx
+++ b/frontend/src/discover/limits/LimitHits.tsx
@@ -5,6 +5,7 @@ import type { LimitsResponse } from "../../api/types";
 import { getLimits } from "../../api/client";
 import WindowsTimeline from "./WindowsTimeline";
 import CapZones from "./CapZones";
+import PlanHistoryModal from "./PlanHistoryModal";
 import { Blurred } from "../../shell/Blurred";
 
 export function formatBlocked(minutes: number): string {
@@ -25,6 +26,7 @@ export default function LimitHits({ onOpenSession }: TechniqueProps) {
   const query = useQuery<LimitsResponse>({ queryKey: ["limits"], queryFn: getLimits });
   const data = query.data;
   const [selected, setSelected] = React.useState<number | null>(null);
+  const [planOpen, setPlanOpen] = React.useState(false);
 
   return (
     <main className="discover-page">
@@ -37,6 +39,9 @@ export default function LimitHits({ onOpenSession }: TechniqueProps) {
               them. Covers all projects: limits are account-level.
             </p>
           </div>
+          <button type="button" onClick={() => setPlanOpen(true)}>
+            Plan history
+          </button>
         </div>
 
         {query.isLoading && <div className="empty-state">Reconstructing windows.</div>}
@@ -124,6 +129,8 @@ export default function LimitHits({ onOpenSession }: TechniqueProps) {
             <p className="limit-footnote">{data.meta.method_note}</p>
           </>
         )}
+
+        {planOpen && <PlanHistoryModal onClose={() => setPlanOpen(false)} />}
       </div>
     </main>
   );

--- a/frontend/src/discover/limits/LimitHits.tsx
+++ b/frontend/src/discover/limits/LimitHits.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { TechniqueProps } from "../techniques";
+import type { LimitsResponse } from "../../api/types";
+import { getLimits } from "../../api/client";
+
+export function formatBlocked(minutes: number): string {
+  if (!minutes) return "0h";
+  const hours = minutes / 60;
+  return hours >= 10 ? `${Math.round(hours)}h` : `${hours.toFixed(1)}h`;
+}
+
+export function formatUsd(value: number | null | undefined): string {
+  if (value == null) return "n/a";
+  return `$${value >= 100 ? value.toFixed(0) : value.toFixed(1)}`;
+}
+
+// Explore technique: measured subscription limits. Account-level by design,
+// so unlike the other techniques there is no project filter (the window that
+// capped may have been filled by several projects at once).
+export default function LimitHits(_props: TechniqueProps) {
+  const query = useQuery<LimitsResponse>({ queryKey: ["limits"], queryFn: getLimits });
+  const data = query.data;
+
+  return (
+    <main className="discover-page">
+      <div className="discover-page-inner">
+        <div className="discover-toolbar" aria-label="Limit hits controls">
+          <div className="discover-toolbar-lead">
+            <h1>Limit hits</h1>
+            <p className="discover-subtitle">
+              Every cap hit recorded in your logs, and the 5-hour windows behind
+              them. Covers all projects: limits are account-level.
+            </p>
+          </div>
+        </div>
+
+        {query.isLoading && <div className="empty-state">Reconstructing windows.</div>}
+        {query.isError && <div className="empty-state">Could not load limit analytics.</div>}
+
+        {data && (
+          <>
+            <div className="limit-tiles" aria-label="Limit stats">
+              <div className="limit-tile">
+                <strong>{data.meta.total_hits}</strong>
+                <span>limit hits</span>
+              </div>
+              <div className="limit-tile">
+                <strong>{formatBlocked(data.meta.blocked_minutes)}</strong>
+                <span>blocked</span>
+              </div>
+              <div className="limit-tile">
+                <strong>{data.meta.hits_per_week_recent}</strong>
+                <span>hits/week, last 28 days</span>
+              </div>
+              {data.eras
+                .filter((era) => era.cap_median_usd != null)
+                .map((era) => (
+                  <div key={era.era || "all"} className="limit-tile">
+                    <strong>{formatUsd(era.cap_median_usd)}</strong>
+                    <span>{era.era ? `${era.era} cap, median` : "measured cap, median"}</span>
+                  </div>
+                ))}
+            </div>
+            <p className="limit-footnote">{data.meta.method_note}</p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/discover/limits/PlanHistoryModal.tsx
+++ b/frontend/src/discover/limits/PlanHistoryModal.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { getSettings, updateSettings } from "../../api/client";
+import type { PlanEra } from "../../api/types";
+
+// Small editor for the optional subscription history. Rows are {plan, start
+// date}; the backend sanitizes and sorts. Saving invalidates the limits query
+// so eras recompute immediately.
+export default function PlanHistoryModal({ onClose }: { onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [rows, setRows] = React.useState<PlanEra[] | null>(null);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    let alive = true;
+    getSettings().then((settings) => {
+      if (alive) setRows(settings.plan_history ?? []);
+    });
+    return () => { alive = false; };
+  }, []);
+
+  const setRow = (index: number, patch: Partial<PlanEra>) =>
+    setRows((r) => r!.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const settings = await getSettings();
+      await updateSettings({
+        ...settings,
+        plan_history: (rows ?? []).filter((row) => row.plan && row.start_date),
+      });
+      await queryClient.invalidateQueries({ queryKey: ["limits"] });
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal card" role="dialog" aria-label="Plan history"
+           onClick={(e) => e.stopPropagation()}>
+        <div className="card-head">
+          <h2>Plan history</h2>
+        </div>
+        <div className="card-pad">
+          <p className="limit-footnote">
+            Which subscription you were on, and since when. Eras split the
+            timeline and the measured cap zones. Leave empty for a single view.
+          </p>
+          {(rows ?? []).map((row, i) => (
+            <div key={i} className="plan-row">
+              <input aria-label={`Plan name ${i + 1}`} placeholder="Pro / Max 5x / Max 20x"
+                     value={row.plan}
+                     onChange={(e) => setRow(i, { plan: e.target.value })} />
+              <input aria-label={`Start date ${i + 1}`} type="date" value={row.start_date}
+                     onChange={(e) => setRow(i, { start_date: e.target.value })} />
+              <button type="button" aria-label={`Remove plan ${i + 1}`}
+                      onClick={() => setRows((r) => r!.filter((_, j) => j !== i))}>
+                ×
+              </button>
+            </div>
+          ))}
+          <div className="plan-actions">
+            <button type="button"
+                    onClick={() => setRows((r) => [...(r ?? []), { plan: "", start_date: "" }])}>
+              Add plan
+            </button>
+            <button type="button" onClick={onClose}>Cancel</button>
+            <button type="button" disabled={saving || rows === null} onClick={save}>
+              {saving ? "Saving" : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/discover/limits/PlanHistoryModal.tsx
+++ b/frontend/src/discover/limits/PlanHistoryModal.tsx
@@ -3,6 +3,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { getSettings, updateSettings } from "../../api/client";
 import type { PlanEra } from "../../api/types";
 
+// The subscription tiers a cap can belong to. A saved value outside this list
+// (from an older cache or a hand-edited settings file) is kept as an extra
+// option so opening the editor never silently rewrites history.
+const PLAN_OPTIONS = ["Pro", "Max 5x", "Max 20x", "Team", "Enterprise"];
+
 // Small editor for the optional subscription history. Rows are {plan, start
 // date}; the backend sanitizes and sorts. Saving invalidates the limits query
 // so eras recompute immediately.
@@ -45,30 +50,44 @@ export default function PlanHistoryModal({ onClose }: { onClose: () => void }) {
           <h2>Plan history</h2>
         </div>
         <div className="card-pad">
-          <p className="limit-footnote">
+          <p className="plan-intro">
             Which subscription you were on, and since when. Eras split the
             timeline and the measured cap zones. Leave empty for a single view.
           </p>
+          {rows !== null && rows.length === 0 && (
+            <p className="plan-empty">No plans recorded yet.</p>
+          )}
           {(rows ?? []).map((row, i) => (
             <div key={i} className="plan-row">
-              <input aria-label={`Plan name ${i + 1}`} placeholder="Pro / Max 5x / Max 20x"
-                     value={row.plan}
-                     onChange={(e) => setRow(i, { plan: e.target.value })} />
+              <select aria-label={`Plan name ${i + 1}`} value={row.plan}
+                      onChange={(e) => setRow(i, { plan: e.target.value })}>
+                <option value="" disabled>Select plan</option>
+                {row.plan !== "" && !PLAN_OPTIONS.includes(row.plan) && (
+                  <option value={row.plan}>{row.plan}</option>
+                )}
+                {PLAN_OPTIONS.map((plan) => (
+                  <option key={plan} value={plan}>{plan}</option>
+                ))}
+              </select>
               <input aria-label={`Start date ${i + 1}`} type="date" value={row.start_date}
                      onChange={(e) => setRow(i, { start_date: e.target.value })} />
-              <button type="button" aria-label={`Remove plan ${i + 1}`}
+              <button type="button" className="plan-remove" aria-label={`Remove plan ${i + 1}`}
+                      title="Remove plan"
                       onClick={() => setRows((r) => r!.filter((_, j) => j !== i))}>
                 ×
               </button>
             </div>
           ))}
           <div className="plan-actions">
-            <button type="button"
+            {/* Disabled until the saved history arrives: a row added before
+                then would be overwritten by the fetch callback. */}
+            <button type="button" className="ghost-action" disabled={rows === null}
                     onClick={() => setRows((r) => [...(r ?? []), { plan: "", start_date: "" }])}>
               Add plan
             </button>
-            <button type="button" onClick={onClose}>Cancel</button>
-            <button type="button" disabled={saving || rows === null} onClick={save}>
+            <button type="button" className="ghost-action" onClick={onClose}>Cancel</button>
+            <button type="button" className="primary-action"
+                    disabled={saving || rows === null} onClick={save}>
               {saving ? "Saving" : "Save"}
             </button>
           </div>

--- a/frontend/src/discover/limits/WindowsTimeline.tsx
+++ b/frontend/src/discover/limits/WindowsTimeline.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import type { LimitWindowEntry } from "../../api/types";
+
+const BAR_W = 6;
+const GAP = 2;
+const HEIGHT = 150;
+const LABEL_H = 14;
+
+// One bar per reconstructed 5-hour window, uniform spacing. Hits are marked by
+// color; era changes get a background band with the plan label. The chart lives
+// inside a horizontally scrolling container so the page never scrolls sideways.
+export default function WindowsTimeline({ windows, selected, onSelectWindow }: {
+  windows: LimitWindowEntry[];
+  selected: number | null;
+  onSelectWindow: (index: number) => void;
+}) {
+  if (windows.length === 0) {
+    return <div className="empty-state">No usage found, so no windows to show.</div>;
+  }
+  const max = Math.max(1e-9, ...windows.map((w) => w.value_usd));
+  const x = (i: number) => GAP + i * (BAR_W + GAP);
+  const width = x(windows.length) + GAP;
+
+  const bands: { era: string; from: number; to: number }[] = [];
+  windows.forEach((w, i) => {
+    const last = bands[bands.length - 1];
+    if (last && last.era === w.era) last.to = i;
+    else bands.push({ era: w.era, from: i, to: i });
+  });
+
+  return (
+    <div className="limit-timeline-scroll">
+      <svg width={Math.max(width, 320)} height={HEIGHT}
+           role="img" aria-label="5-hour windows timeline">
+        {bands.map((b, bi) => (
+          <g key={`${b.era}-${b.from}`}>
+            <rect x={x(b.from) - GAP / 2} y={0}
+                  width={x(b.to) + BAR_W + GAP / 2 - x(b.from) + GAP / 2}
+                  height={HEIGHT}
+                  className={bi % 2 ? "limit-era-band alt" : "limit-era-band"} />
+            {b.era && (
+              <text x={x(b.from) + 2} y={LABEL_H - 3} className="limit-era-label">
+                {b.era}
+              </text>
+            )}
+          </g>
+        ))}
+        {windows.map((w, i) => {
+          const h = Math.max(2, (w.value_usd / max) * (HEIGHT - LABEL_H - 6));
+          const hit = w.hit_kinds.length > 0;
+          const cls = [
+            "limit-bar",
+            hit ? "limit-bar-hit" : "",
+            selected === i ? "limit-bar-selected" : "",
+          ].join(" ").trim();
+          const day = w.start.slice(0, 10);
+          return (
+            <rect key={w.start} x={x(i)} y={HEIGHT - h} width={BAR_W} height={h}
+                  className={cls} role="button" tabIndex={0}
+                  aria-label={`window ${i + 1}: ${day}, $${w.value_usd.toFixed(2)}${hit ? `, ${w.hit_kinds.join(" and ")} hit` : ""}`}
+                  onClick={() => onSelectWindow(i)}
+                  onKeyDown={(e) => e.key === "Enter" && onSelectWindow(i)}>
+              <title>{`${day} · $${w.value_usd.toFixed(2)}${hit ? ` · ${w.hit_kinds.join(", ")} hit` : ""}`}</title>
+            </rect>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/discover/limits/WindowsTimeline.tsx
+++ b/frontend/src/discover/limits/WindowsTimeline.tsx
@@ -1,25 +1,80 @@
 import React from "react";
-import type { LimitWindowEntry } from "../../api/types";
+import type { LimitHitEntry, LimitWindowEntry } from "../../api/types";
+import { useChartTooltip } from "../context/chartTooltip";
+import { eraRates } from "./limitMath";
 
 const BAR_W = 6;
 const GAP = 2;
-const HEIGHT = 150;
-const LABEL_H = 14;
+const MAX_SLOT_SCALE = 2.5; // bars may widen up to this much to fill the panel
+const PLOT_TOP = 18; // era label strip
+const PLOT_H = 210;
+const XLABEL_H = 20;
+const HEIGHT = PLOT_TOP + PLOT_H + XLABEL_H;
+const MIN_XLABEL_GAP = 64; // px between date labels
+const FALLBACK_W = 860;
+const Y_FRACTIONS = [1, 0.75, 0.5, 0.25, 0];
+
+function dayLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function tickLabel(value: number): string {
+  if (value === 0) return "$0";
+  return `$${value >= 10 ? Math.round(value) : value.toFixed(1)}`;
+}
 
 // One bar per reconstructed 5-hour window, uniform spacing. Hits are marked by
-// color; era changes get a background band with the plan label. The chart lives
-// inside a horizontally scrolling container so the page never scrolls sideways.
-export default function WindowsTimeline({ windows, selected, onSelectWindow }: {
+// color; era changes get a background band with the plan label. Bars widen (to
+// a cap) to fill the panel; past that the chart scrolls horizontally inside
+// its container so the page never scrolls sideways, and the dollar axis stays
+// fixed outside the scroller.
+export default function WindowsTimeline({ windows, hits, selected, onSelectWindow }: {
   windows: LimitWindowEntry[];
+  hits: LimitHitEntry[];
   selected: number | null;
   onSelectWindow: (index: number) => void;
 }) {
+  const { ref, show, hide, tooltip } = useChartTooltip<HTMLDivElement>();
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const [hostWidth, setHostWidth] = React.useState(FALLBACK_W);
+
+  React.useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const update = (next: number) => {
+      const rounded = Math.max(320, Math.round(next));
+      setHostWidth((current) => (current === rounded ? current : rounded));
+    };
+    if (node.clientWidth) update(node.clientWidth);
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      if (entries[0]) update(entries[0].contentRect.width);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  // Land on the most recent windows; the far past is a scroll away.
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollLeft = el.scrollWidth;
+  }, [windows.length, hostWidth]);
+
   if (windows.length === 0) {
     return <div className="empty-state">No usage found, so no windows to show.</div>;
   }
   const max = Math.max(1e-9, ...windows.map((w) => w.value_usd));
-  const x = (i: number) => GAP + i * (BAR_W + GAP);
-  const width = x(windows.length) + GAP;
+  const needed = GAP + windows.length * (BAR_W + GAP) + GAP;
+  const scale = Math.min(MAX_SLOT_SCALE, Math.max(1, hostWidth / needed));
+  const barW = BAR_W * scale;
+  const gap = GAP * scale;
+  const x = (i: number) => gap + i * (barW + gap);
+  const width = Math.max(x(windows.length) + gap, hostWidth);
+  const yTicks = Y_FRACTIONS.map((f) => ({
+    f,
+    y: PLOT_TOP + PLOT_H * (1 - f),
+    label: tickLabel(max * f),
+  }));
 
   const bands: { era: string; from: number; to: number }[] = [];
   windows.forEach((w, i) => {
@@ -27,44 +82,95 @@ export default function WindowsTimeline({ windows, selected, onSelectWindow }: {
     if (last && last.era === w.era) last.to = i;
     else bands.push({ era: w.era, from: i, to: i });
   });
+  const hasEras = bands.some((b) => b.era);
+
+  // Average hits per week of each plan's tenure, annotated on its era band.
+  // The rate cannot share the dollar axis, so it rides the band label instead
+  // of pretending to be a level line.
+  const rates = eraRates(windows, hits);
+
+  const labelStep = Math.ceil(MIN_XLABEL_GAP / (barW + gap));
+  const xLabelIdx: number[] = [];
+  for (let i = 0; i < windows.length; i += labelStep) xLabelIdx.push(i);
 
   return (
-    <div className="limit-timeline-scroll">
-      <svg width={Math.max(width, 320)} height={HEIGHT}
-           role="img" aria-label="5-hour windows timeline">
-        {bands.map((b, bi) => (
-          <g key={`${b.era}-${b.from}`}>
-            <rect x={x(b.from) - GAP / 2} y={0}
-                  width={x(b.to) + BAR_W + GAP / 2 - x(b.from) + GAP / 2}
-                  height={HEIGHT}
-                  className={bi % 2 ? "limit-era-band alt" : "limit-era-band"} />
-            {b.era && (
-              <text x={x(b.from) + 2} y={LABEL_H - 3} className="limit-era-label">
-                {b.era}
-              </text>
-            )}
-          </g>
-        ))}
-        {windows.map((w, i) => {
-          const h = Math.max(2, (w.value_usd / max) * (HEIGHT - LABEL_H - 6));
-          const hit = w.hit_kinds.length > 0;
-          const cls = [
-            "limit-bar",
-            hit ? "limit-bar-hit" : "",
-            selected === i ? "limit-bar-selected" : "",
-          ].join(" ").trim();
-          const day = w.start.slice(0, 10);
-          return (
-            <rect key={w.start} x={x(i)} y={HEIGHT - h} width={BAR_W} height={h}
-                  className={cls} role="button" tabIndex={0}
-                  aria-label={`window ${i + 1}: ${day}, $${w.value_usd.toFixed(2)}${hit ? `, ${w.hit_kinds.join(" and ")} hit` : ""}`}
-                  onClick={() => onSelectWindow(i)}
-                  onKeyDown={(e) => e.key === "Enter" && onSelectWindow(i)}>
-              <title>{`${day} · $${w.value_usd.toFixed(2)}${hit ? ` · ${w.hit_kinds.join(", ")} hit` : ""}`}</title>
-            </rect>
-          );
-        })}
-      </svg>
-    </div>
+    <>
+      <div className="limit-timeline">
+        <span className="limit-axis-title-y">$ per window</span>
+        <div className="limit-timeline-yaxis" style={{ height: HEIGHT }} aria-hidden={true}>
+          {yTicks.map((t) => (
+            <span key={t.f} className="limit-ylabel" style={{ top: t.y }}>{t.label}</span>
+          ))}
+        </div>
+        <div className="limit-timeline-plot chart-tooltip-host" ref={ref}>
+          <div className="limit-timeline-scroll" ref={scrollRef}>
+            <svg width={width} height={HEIGHT}
+                 role="img" aria-label="5-hour windows timeline">
+              {bands.map((b, bi) => (
+                <g key={`${b.era}-${b.from}`}>
+                  <rect x={x(b.from) - gap / 2} y={0}
+                        width={x(b.to) + barW + gap / 2 - x(b.from) + gap / 2}
+                        height={PLOT_TOP + PLOT_H}
+                        className={bi % 2 ? "limit-era-band alt" : "limit-era-band"} />
+                  {b.era && (
+                    <text x={x(b.from) + 2} y={12} className="limit-era-label">
+                      {b.era}
+                    </text>
+                  )}
+                  {(rates.get(b.era)?.hitCount ?? 0) > 0 && (
+                    <text x={x(b.from) + 2} y={b.era ? 24 : 12} className="limit-era-rate">
+                      {`${rates.get(b.era)!.perWeek.toFixed(1)} hits/wk`}
+                    </text>
+                  )}
+                </g>
+              ))}
+              {yTicks.map((t) => (
+                <line key={t.f} className="limit-grid"
+                      x1={0} y1={t.y} x2={width} y2={t.y} />
+              ))}
+              {xLabelIdx.map((i) => (
+                <text key={windows[i].start}
+                      x={i === 0 ? x(i) : x(i) + barW / 2}
+                      y={PLOT_TOP + PLOT_H + 13}
+                      className="limit-xlabel"
+                      textAnchor={i === 0 ? "start" : "middle"}>
+                  {dayLabel(windows[i].start)}
+                </text>
+              ))}
+              {windows.map((w, i) => {
+                const h = Math.max(2, (w.value_usd / max) * PLOT_H);
+                const hit = w.hit_kinds.length > 0;
+                const cls = [
+                  "limit-bar",
+                  hit ? "limit-bar-hit" : "",
+                  selected === i ? "limit-bar-selected" : "",
+                ].join(" ").trim();
+                return (
+                  <rect key={w.start} x={x(i)} y={PLOT_TOP + PLOT_H - h}
+                        width={barW} height={h}
+                        className={cls} role="button" tabIndex={0}
+                        aria-label={`window ${i + 1}: ${w.start.slice(0, 10)}, $${w.value_usd.toFixed(2)}${hit ? `, ${w.hit_kinds.join(" and ")} hit` : ""}`}
+                        onClick={() => onSelectWindow(i)}
+                        onKeyDown={(e) => e.key === "Enter" && onSelectWindow(i)}
+                        onMouseMove={(e) => show(e, dayLabel(w.start), [
+                          `$${w.value_usd.toFixed(2)} in this window`,
+                          ...(hit ? [`${w.hit_kinds.join(", ")} limit hit`] : []),
+                          ...(w.era ? [`plan: ${w.era}`] : []),
+                        ])}
+                        onMouseLeave={hide} />
+                );
+              })}
+            </svg>
+          </div>
+          {tooltip}
+        </div>
+      </div>
+      <div className="chip-legend card-bottom-legend limit-legend">
+        <span><i className="is-window" />window usage</span>
+        <span><i className="is-hit" />limit hit</span>
+        {hasEras && <span><i className="is-era" />plan era</span>}
+        <em>x-axis: window start date</em>
+      </div>
+    </>
   );
 }

--- a/frontend/src/discover/limits/limitMath.test.ts
+++ b/frontend/src/discover/limits/limitMath.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { LimitEraEntry, LimitHitEntry, LimitWindowEntry } from "../../api/types";
+import { activeEra, buildVerdict, eraRates, meanUsageAtHit } from "./limitMath";
+
+function win(start: string, end: string, era: string, hit = false): LimitWindowEntry {
+  return { start, end, value_usd: 10, tokens: 1, era, hit_kinds: hit ? ["session"] : [] };
+}
+
+function hit(windowIndex: number | null): LimitHitEntry {
+  return {
+    ts: "2026-07-01T01:00:00Z", kind: "session", reset_at: null,
+    blocked_minutes: null, usage_at_hit: null, occurrence_count: 1,
+    window_index: windowIndex, session_ids: [], session_titles: [],
+  };
+}
+
+function era(overrides: Partial<LimitEraEntry>): LimitEraEntry {
+  return {
+    era: "Pro", window_count: 10, session_hit_count: 2, blocked_minutes: 60,
+    cap_median_usd: 10, cap_min_usd: 8, cap_max_usd: 12, near_miss_count: 1,
+    cap_percentile: 0.7, usage_at_hit_usd: [8, 12], ...overrides,
+  };
+}
+
+describe("eraRates", () => {
+  it("floors tenure at one week and counts hits per era", () => {
+    const windows = [
+      win("2026-07-01T00:00:00Z", "2026-07-01T05:00:00Z", "Pro", true),
+      win("2026-07-02T00:00:00Z", "2026-07-02T05:00:00Z", "Pro"),
+    ];
+    const rates = eraRates(windows, [hit(0)]);
+    expect(rates.get("Pro")).toMatchObject({ hitCount: 1, weeks: 1, perWeek: 1 });
+  });
+
+  it("uses real tenure once past a week and skips unattached hits", () => {
+    const windows = [
+      win("2026-06-01T00:00:00Z", "2026-06-01T05:00:00Z", "Pro", true),
+      win("2026-06-15T00:00:00Z", "2026-06-15T05:00:00Z", "Pro", true),
+    ];
+    const rates = eraRates(windows, [hit(0), hit(1), hit(null)]);
+    expect(rates.get("Pro")!.weeks).toBeGreaterThan(2);
+    expect(rates.get("Pro")!.hitCount).toBe(2);
+    expect(rates.get("Pro")!.perWeek).toBeCloseTo(1, 1);
+  });
+});
+
+describe("activeEra and meanUsageAtHit", () => {
+  it("reports the newest window's era and the mean hit usage", () => {
+    const windows = [
+      win("2026-06-01T00:00:00Z", "2026-06-01T05:00:00Z", "Pro"),
+      win("2026-07-01T00:00:00Z", "2026-07-01T05:00:00Z", "Max 5x"),
+    ];
+    expect(activeEra(windows)).toBe("Max 5x");
+    expect(activeEra([])).toBeNull();
+    expect(meanUsageAtHit(era({}))).toBe(10);
+    expect(meanUsageAtHit(era({ usage_at_hit_usd: [] }))).toBeNull();
+  });
+});
+
+describe("buildVerdict", () => {
+  it("calls a hit-free plan comfortably dimensioned", () => {
+    const v = buildVerdict(
+      era({ session_hit_count: 0, blocked_minutes: 0 }),
+      { hitCount: 0, weeks: 4, perWeek: 0 },
+    );
+    expect(v?.tone).toBe("good");
+    expect(v?.text).toMatch(/comfortably dimensioned/);
+  });
+
+  it("flags heavy weekly waiting as outgrown", () => {
+    const v = buildVerdict(era({ blocked_minutes: 1000 }), { hitCount: 5, weeks: 2, perWeek: 2.5 });
+    expect(v?.tone).toBe("tight");
+    expect(v?.text).toMatch(/outgrown/);
+  });
+
+  it("calls a top-decile cap well dimensioned", () => {
+    const v = buildVerdict(
+      era({ cap_percentile: 0.95, blocked_minutes: 30 }),
+      { hitCount: 1, weeks: 4, perWeek: 0.25 },
+    );
+    expect(v?.tone).toBe("good");
+    expect(v?.text).toMatch(/well dimensioned: only your top 5%/);
+  });
+
+  it("defaults to the watch verdict in between", () => {
+    const v = buildVerdict(era({}), { hitCount: 2, weeks: 2, perWeek: 1 });
+    expect(v?.tone).toBe("watch");
+    expect(v?.text).toMatch(/watch the trend/);
+  });
+
+  it("returns nothing without an era", () => {
+    expect(buildVerdict(undefined, undefined)).toBeNull();
+  });
+});

--- a/frontend/src/discover/limits/limitMath.ts
+++ b/frontend/src/discover/limits/limitMath.ts
@@ -1,0 +1,118 @@
+import type { LimitEraEntry, LimitHitEntry, LimitWindowEntry } from "../../api/types";
+
+export function formatBlocked(minutes: number): string {
+  if (!minutes) return "0h";
+  const hours = minutes / 60;
+  return hours >= 10 ? `${Math.round(hours)}h` : `${hours.toFixed(1)}h`;
+}
+
+export function formatUsd(value: number | null | undefined): string {
+  if (value == null) return "n/a";
+  return `$${value >= 100 ? value.toFixed(0) : value.toFixed(1)}`;
+}
+
+export interface EraRate {
+  hitCount: number;
+  weeks: number;
+  perWeek: number;
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Hits per calendar week of each plan's tenure (the span of its windows in
+ * the logs). Tenure is floored at one week so a young corpus reports what
+ * actually happened instead of extrapolating a single day into a wild rate.
+ */
+export function eraRates(
+  windows: LimitWindowEntry[],
+  hits: LimitHitEntry[],
+): Map<string, EraRate> {
+  const spans = new Map<string, { from: number; to: number }>();
+  windows.forEach((w) => {
+    const from = Date.parse(w.start);
+    const to = Date.parse(w.end);
+    const current = spans.get(w.era);
+    if (!current) spans.set(w.era, { from, to });
+    else {
+      current.from = Math.min(current.from, from);
+      current.to = Math.max(current.to, to);
+    }
+  });
+  const counts = new Map<string, number>();
+  hits.forEach((h) => {
+    if (h.window_index == null) return;
+    const window = windows[h.window_index];
+    if (!window) return;
+    counts.set(window.era, (counts.get(window.era) ?? 0) + 1);
+  });
+  const rates = new Map<string, EraRate>();
+  spans.forEach((span, era) => {
+    const weeks = Math.max((span.to - span.from) / WEEK_MS, 1);
+    const hitCount = counts.get(era) ?? 0;
+    rates.set(era, { hitCount, weeks, perWeek: hitCount / weeks });
+  });
+  return rates;
+}
+
+/** The plan the user is on now: the era of the newest window. */
+export function activeEra(windows: LimitWindowEntry[]): string | null {
+  return windows.length > 0 ? windows[windows.length - 1].era : null;
+}
+
+export function meanUsageAtHit(era: LimitEraEntry): number | null {
+  if (era.usage_at_hit_usd.length === 0) return null;
+  const sum = era.usage_at_hit_usd.reduce((s, v) => s + v, 0);
+  return sum / era.usage_at_hit_usd.length;
+}
+
+export type VerdictTone = "good" | "watch" | "tight";
+
+export interface Verdict {
+  tone: VerdictTone;
+  text: string;
+}
+
+// Waiting this long per week is treated as the plan being outgrown.
+const TIGHT_BLOCKED_MIN_PER_WEEK = 120;
+// A cap that only the top decile of windows can reach is a healthy fit.
+const COMFORTABLE_CAP_PERCENTILE = 0.9;
+
+/**
+ * One-sentence reading of the active plan: is it dimensioned for this usage?
+ * Decision markers, in order: no hits at all, heavy weekly waiting, cap only
+ * reachable by outlier windows, and the in-between "fits but watch it" case.
+ */
+export function buildVerdict(
+  era: LimitEraEntry | undefined,
+  rate: EraRate | undefined,
+): Verdict | null {
+  if (!era) return null;
+  const plan = era.era || "your plan";
+  const weeks = rate?.weeks ?? 1;
+  const blockedPerWeek = era.blocked_minutes / weeks;
+  if (era.session_hit_count === 0 && era.blocked_minutes === 0) {
+    return {
+      tone: "good",
+      text: `No cap hits recorded on ${plan}. It is comfortably dimensioned for this usage.`,
+    };
+  }
+  if (blockedPerWeek >= TIGHT_BLOCKED_MIN_PER_WEEK) {
+    return {
+      tone: "tight",
+      text: `Caps cost you about ${formatBlocked(blockedPerWeek)} of waiting per week on ${plan}. This usage has outgrown the plan.`,
+    };
+  }
+  if (era.cap_percentile != null && era.cap_percentile >= COMFORTABLE_CAP_PERCENTILE) {
+    const topPct = Math.max(1, Math.round((1 - era.cap_percentile) * 100));
+    return {
+      tone: "good",
+      text: `${plan} is well dimensioned: only your top ${topPct}% of windows reach the cap, costing about ${formatBlocked(blockedPerWeek)} of waiting per week.`,
+    };
+  }
+  const perWeek = rate ? rate.perWeek : era.session_hit_count;
+  return {
+    tone: "watch",
+    text: `You hit the ${plan} cap about ${perWeek.toFixed(1)} times a week, costing about ${formatBlocked(blockedPerWeek)} of waiting. The plan fits, but watch the trend.`,
+  };
+}

--- a/frontend/src/discover/techniques.test.tsx
+++ b/frontend/src/discover/techniques.test.tsx
@@ -14,4 +14,11 @@ describe("technique registry", () => {
     expect(DEFAULT_TECHNIQUE).toBe("subgroup");
     expect(TECHNIQUES.some((t) => t.key === DEFAULT_TECHNIQUE)).toBe(true);
   });
+
+  it("registers Limit hits as a ready technique with a component", () => {
+    const limits = TECHNIQUES.find((t) => t.key === "limits");
+    expect(limits?.status).toBe("ready");
+    expect(limits?.label).toBe("Limit hits");
+    expect(limits?.component).toBeTruthy();
+  });
 });

--- a/frontend/src/discover/techniques.test.tsx
+++ b/frontend/src/discover/techniques.test.tsx
@@ -10,9 +10,11 @@ describe("technique registry", () => {
     expect(drivers?.component).toBeTypeOf("function");
   });
 
-  it("keeps subgroup as the default technique", () => {
-    expect(DEFAULT_TECHNIQUE).toBe("subgroup");
-    expect(TECHNIQUES.some((t) => t.key === DEFAULT_TECHNIQUE)).toBe(true);
+  it("ranks techniques limits-first and opens Explore on the top entry", () => {
+    expect(TECHNIQUES.map((t) => t.key)).toEqual([
+      "limits", "context", "drivers", "mindmap", "subgroup",
+    ]);
+    expect(DEFAULT_TECHNIQUE).toBe(TECHNIQUES[0].key);
   });
 
   it("registers Limit hits as a ready technique with a component", () => {

--- a/frontend/src/discover/techniques.tsx
+++ b/frontend/src/discover/techniques.tsx
@@ -22,12 +22,14 @@ export interface Technique {
 // Attach a component here when a technique becomes ready. The "soon" status is
 // intentionally kept in the type so a future technique can register as a
 // not-yet-ready stub; DiscoverPage renders those through its ComingSoon fallback.
+// Listed in priority order; the sidebar renders this order verbatim and the
+// first entry is what Explore opens to.
 export const TECHNIQUES: Technique[] = [
-  { key: "subgroup", label: "Subgroups", status: "ready", component: SubgroupDiscovery },
-  { key: "context", label: "Context economics", status: "ready", component: ContextEconomics },
-  { key: "mindmap", label: "Usage Mindmap", status: "ready", component: UsageMindmap },
-  { key: "drivers", label: "Usage drivers", status: "ready", component: UsageDrivers },
   { key: "limits", label: "Limit hits", status: "ready", component: LimitHits },
+  { key: "context", label: "Context economics", status: "ready", component: ContextEconomics },
+  { key: "drivers", label: "Usage drivers", status: "ready", component: UsageDrivers },
+  { key: "mindmap", label: "Usage Mindmap", status: "ready", component: UsageMindmap },
+  { key: "subgroup", label: "Subgroups", status: "ready", component: SubgroupDiscovery },
 ];
 
-export const DEFAULT_TECHNIQUE = "subgroup";
+export const DEFAULT_TECHNIQUE = "limits";

--- a/frontend/src/discover/techniques.tsx
+++ b/frontend/src/discover/techniques.tsx
@@ -4,6 +4,7 @@ import SubgroupDiscovery from "./SubgroupDiscovery";
 import ContextEconomics from "./context/ContextEconomics";
 import UsageMindmap from "./mindmap/UsageMindmap";
 import UsageDrivers from "./drivers/UsageDrivers";
+import LimitHits from "./limits/LimitHits";
 
 export interface TechniqueProps {
   projects: Project[];
@@ -26,6 +27,7 @@ export const TECHNIQUES: Technique[] = [
   { key: "context", label: "Context economics", status: "ready", component: ContextEconomics },
   { key: "mindmap", label: "Usage Mindmap", status: "ready", component: UsageMindmap },
   { key: "drivers", label: "Usage drivers", status: "ready", component: UsageDrivers },
+  { key: "limits", label: "Limit hits", status: "ready", component: LimitHits },
 ];
 
 export const DEFAULT_TECHNIQUE = "subgroup";

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -4352,3 +4352,10 @@ html:has(.specimen-dialog[open]) {
 .limit-footnote { font-size: 12px; opacity: 0.7; margin-top: 10px; }
 .link-button { background: none; border: none; padding: 0; cursor: pointer;
   color: var(--accent); text-decoration: underline; font: inherit; }
+
+.modal-backdrop { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.45);
+  display: flex; align-items: center; justify-content: center; z-index: 50; }
+.modal { max-width: 480px; width: 92%; max-height: 80vh; overflow-y: auto; }
+.plan-row { display: flex; gap: 8px; margin-bottom: 8px; }
+.plan-row input { flex: 1; }
+.plan-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -4321,3 +4321,34 @@ html:has(.specimen-dialog[open]) {
   margin: 0; padding: 10px 16px; border-top: 1px solid var(--border);
   color: var(--faint); font-size: 11px;
 }
+
+/* Limit hits explore page */
+.limit-tiles { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.limit-tile {
+  flex: 1 1 140px; padding: 12px 14px; border: 1px solid var(--border);
+  border-radius: 8px; background: var(--raised);
+  display: flex; flex-direction: column; gap: 2px;
+}
+.limit-tile strong { font-size: 20px; }
+.limit-tile span { font-size: 12px; opacity: 0.75; }
+.limit-timeline-scroll { overflow-x: auto; }
+.limit-era-band { fill: transparent; }
+.limit-era-band.alt { fill: rgba(127, 127, 127, 0.08); }
+.limit-era-label { font-size: 10px; fill: currentColor; opacity: 0.7; }
+.limit-bar { fill: var(--accent); cursor: pointer; }
+.limit-bar-hit { fill: var(--danger); }
+.limit-bar-selected { stroke: currentColor; stroke-width: 1; }
+.limit-zones { display: flex; flex-direction: column; gap: 14px; }
+.limit-zone-head { display: flex; gap: 10px; align-items: baseline; font-size: 13px; }
+.limit-zone-head span { opacity: 0.75; }
+.limit-zone-strip { width: 100%; height: 24px; display: block; }
+.limit-zone-band { fill: rgba(241, 115, 127, 0.25); }
+.limit-zone-dot { fill: var(--danger); }
+.limit-zone-median { fill: currentColor; }
+.limit-hit-detail { display: flex; gap: 12px; flex-wrap: wrap; align-items: baseline; }
+.limit-kind { font-size: 12px; padding: 1px 8px; border-radius: 10px;
+  border: 1px solid var(--danger); }
+.limit-sessions { display: inline-flex; gap: 8px; flex-wrap: wrap; }
+.limit-footnote { font-size: 12px; opacity: 0.7; margin-top: 10px; }
+.link-button { background: none; border: none; padding: 0; cursor: pointer;
+  color: var(--accent); text-decoration: underline; font: inherit; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1518,6 +1518,8 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
   .session-insight-list { grid-template-columns: 1fr; }
   .cost-insight-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .discover-toolbar { align-items: stretch; flex-direction: column; }
+  /* In column direction the lead's 300px flex-basis would become height. */
+  .discover-toolbar-lead { flex: 0 0 auto; min-width: 0; }
   .discover-filterbar { margin-left: 0; justify-content: flex-start; }
   .discover-overview { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .driver-board { grid-template-columns: 1fr; }
@@ -2333,6 +2335,8 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
 }
 
 .chart-tooltip.is-flipped { transform: translate(calc(-100% - 12px), 14px); }
+.chart-tooltip.is-flipped-y { transform: translate(12px, calc(-100% - 14px)); }
+.chart-tooltip.is-flipped.is-flipped-y { transform: translate(calc(-100% - 12px), calc(-100% - 14px)); }
 
 .chart-tooltip strong {
   font-size: 11.5px;
@@ -4322,40 +4326,112 @@ html:has(.specimen-dialog[open]) {
   color: var(--faint); font-size: 11px;
 }
 
-/* Limit hits explore page */
-.limit-tiles { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
-.limit-tile {
-  flex: 1 1 140px; padding: 12px 14px; border: 1px solid var(--border);
-  border-radius: 8px; background: var(--raised);
-  display: flex; flex-direction: column; gap: 2px;
+/* Limit hits explore page. Chart chrome follows the app's chart grammar:
+   muted HTML tick labels around the plot (.sot idiom), .chip-legend chips,
+   and theme tokens only. */
+.limit-timeline { display: flex; gap: 6px; }
+.limit-axis-title-y {
+  writing-mode: vertical-rl; transform: rotate(180deg); align-self: center;
+  font-size: 10px; color: var(--muted); flex: 0 0 auto;
 }
-.limit-tile strong { font-size: 20px; }
-.limit-tile span { font-size: 12px; opacity: 0.75; }
+.limit-timeline-yaxis { position: relative; flex: 0 0 38px; }
+.limit-ylabel {
+  position: absolute; right: 4px; transform: translateY(-50%);
+  font-size: 9px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.limit-timeline-plot { position: relative; flex: 1 1 auto; min-width: 0; }
 .limit-timeline-scroll { overflow-x: auto; }
+.limit-grid { stroke: var(--border); stroke-width: 1; }
+.limit-xlabel { font-size: 9px; fill: var(--muted); }
 .limit-era-band { fill: transparent; }
-.limit-era-band.alt { fill: rgba(127, 127, 127, 0.08); }
-.limit-era-label { font-size: 10px; fill: currentColor; opacity: 0.7; }
+.limit-era-band.alt { fill: color-mix(in srgb, var(--text) 5%, transparent); }
+.limit-era-label { font-size: 10px; fill: var(--muted); }
 .limit-bar { fill: var(--accent); cursor: pointer; }
 .limit-bar-hit { fill: var(--danger); }
-.limit-bar-selected { stroke: currentColor; stroke-width: 1; }
-.limit-zones { display: flex; flex-direction: column; gap: 14px; }
+.limit-bar-selected { stroke: var(--text); stroke-width: 1.5; }
+.limit-era-rate {
+  font-size: 9px; fill: var(--text);
+  paint-order: stroke; stroke: var(--surface); stroke-width: 3px;
+}
+.limit-verdict {
+  margin: 0; padding: 10px 14px; font-size: 13px; line-height: 1.45;
+  border: 1px solid var(--border); border-radius: 10px; background: var(--raised);
+  color: var(--text); display: flex; align-items: center; gap: 9px;
+}
+.limit-verdict i {
+  width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto;
+  background: var(--warning);
+}
+.limit-verdict[data-tone="good"] i { background: var(--success); }
+.limit-verdict[data-tone="tight"] i { background: var(--danger); }
+.limit-insight-strip.cost-insight-strip { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+@media (max-width: 980px) {
+  .limit-insight-strip.cost-insight-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 620px) {
+  .limit-insight-strip.cost-insight-strip { grid-template-columns: 1fr; }
+}
+.limit-legend em { margin-left: auto; font-style: normal; color: var(--faint); }
+.limit-legend i.is-window { background: var(--accent); }
+.limit-legend i.is-hit { background: var(--danger); }
+.limit-legend i.is-hit-dot { background: var(--danger); border-radius: 50%; }
+.limit-legend i.is-era {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  border: 1px solid var(--border-2);
+}
+.limit-legend i.is-band { background: color-mix(in srgb, var(--danger) 22%, transparent); }
+.limit-legend i.is-median { width: 2px; height: 12px; border-radius: 1px; background: var(--text); }
+.limit-legend i.is-avg {
+  width: 0; height: 12px; background: transparent; border-radius: 0;
+  border-left: 2px dashed var(--danger);
+}
+.limit-zones { display: flex; flex-direction: column; gap: 14px; position: relative; }
 .limit-zone-head { display: flex; gap: 10px; align-items: baseline; font-size: 13px; }
-.limit-zone-head span { opacity: 0.75; }
-.limit-zone-strip { width: 100%; height: 24px; display: block; }
-.limit-zone-band { fill: rgba(241, 115, 127, 0.25); }
-.limit-zone-dot { fill: var(--danger); }
-.limit-zone-median { fill: currentColor; }
+.limit-zone-head span { color: var(--muted); font-size: 12px; }
+.limit-zone-strip { display: block; }
+.limit-zone-grid { stroke: var(--border); stroke-width: 1; }
+.limit-zone-band { fill: color-mix(in srgb, var(--danger) 20%, transparent); }
+.limit-zone-dot { fill: var(--danger); stroke: var(--surface); stroke-width: 1.5; }
+.limit-zone-median { fill: var(--text); }
+.limit-zone-avg { stroke: var(--danger); stroke-width: 2; stroke-dasharray: 3 2; }
+.limit-zone-axis { position: relative; height: 13px; margin-top: -6px; }
+.limit-zone-axis span {
+  position: absolute; transform: translateX(-50%);
+  font-size: 9px; color: var(--muted); font-variant-numeric: tabular-nums;
+}
 .limit-hit-detail { display: flex; gap: 12px; flex-wrap: wrap; align-items: baseline; }
 .limit-kind { font-size: 12px; padding: 1px 8px; border-radius: 10px;
   border: 1px solid var(--danger); }
 .limit-sessions { display: inline-flex; gap: 8px; flex-wrap: wrap; }
-.limit-footnote { font-size: 12px; opacity: 0.7; margin-top: 10px; }
+.limit-footnote { font-size: 12px; color: var(--faint); margin-top: 10px; }
 .link-button { background: none; border: none; padding: 0; cursor: pointer;
   color: var(--accent); text-decoration: underline; font: inherit; }
 
 .modal-backdrop { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.45);
   display: flex; align-items: center; justify-content: center; z-index: 50; }
 .modal { max-width: 480px; width: 92%; max-height: 80vh; overflow-y: auto; }
-.plan-row { display: flex; gap: 8px; margin-bottom: 8px; }
-.plan-row input { flex: 1; }
-.plan-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
+.plan-intro { margin: 0 0 12px; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.plan-empty { margin: 0 0 12px; color: var(--faint); font-size: 12px; }
+.plan-row { display: flex; gap: 8px; margin-bottom: 8px; align-items: center; }
+.plan-row select { flex: 1.3; min-width: 0; }
+.plan-row input[type="date"] { flex: 1; min-width: 0; }
+.plan-row select,
+.plan-row input[type="date"] {
+  height: 33px; box-sizing: border-box; padding: 0 10px; border-radius: 9px;
+  border: 1px solid var(--border-2); background: var(--surface); color: var(--text);
+  font-size: 12px;
+}
+.plan-row select:focus-visible,
+.plan-row input[type="date"]:focus-visible { outline: none; border-color: var(--accent); }
+.plan-row input[type="date"]::-webkit-calendar-picker-indicator { opacity: .55; cursor: pointer; }
+.plan-row input[type="date"]:hover::-webkit-calendar-picker-indicator { opacity: .9; }
+.plan-remove {
+  flex: 0 0 auto; width: 33px; height: 33px; border-radius: 9px;
+  border: 1px solid var(--border); background: transparent; color: var(--muted);
+  font-size: 16px; line-height: 1; display: inline-flex; align-items: center; justify-content: center;
+  transition: border-color .15s ease, color .15s ease;
+}
+.plan-remove:hover { border-color: var(--danger); color: var(--danger); }
+.plan-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 14px; }
+.plan-actions .ghost-action { height: 35px; box-sizing: border-box; padding: 0 14px; }
+.plan-actions .primary-action { height: 35px; box-sizing: border-box; padding: 0 18px; font-size: 12.5px; border-radius: 9px; }


### PR DESCRIPTION
## What

A new Explore technique, "Limit hits": every subscription cap you actually hit, and the 5-hour windows behind them. It answers whether your plan is dimensioned for how you work, and what the caps cost you in waiting. Corpus-wide by design, since 5-hour windows are account-level.

## How

Cap hits are already in the logs (assistant events with `error == "rate_limit"` and a `<synthetic>` model row). `analysis/limits.py` detects and dedups them, parses the reset stamp into blocked minutes, folds all usage into priced 5-hour windows, and derives the measured cap zone per plan era. The output worth reading is the cap percentile: a cap is not a quota you can look up, it is a percentile of your own windows.

## Changes

- `analysis/limits.py` and `GET /api/analytics/limits` (read-only, no project filter).
- Settings gains an optional `plan_history` so cap zones split by subscription era, with a small editor modal.
- `discover/limits/`: windows timeline, cap zones, and a one-sentence verdict on the active plan. Explore now opens here.
- `tzdata` dependency, since `zoneinfo` needs it to resolve names like `Europe/Paris` on Windows.
- Along the way: `write_settings` no longer mutates the caller, and a partial settings PUT no longer wipes plan history.

## Testing

Backend 466 passed, frontend 302 passed. New coverage for stamp parsing, retry dedup, window folding and reset snapping, the endpoint, and plan-history round-trip.
