### PR TITLE
fix: count resumed/forked session events once in cost totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Resumed and forked sessions no longer inflate cost and token totals. Claude
+  Code writes a new JSONL containing the whole prior history each time a session
+  is resumed, so the same event was imported once per resume and counted every
+  time. Events now carry `is_replay`, and cost and token views count each event
+  once. Existing caches are backfilled on open; no re-import is needed.
+  Per-session timelines still show every row, so a resumed session renders its
+  full history.
+
 ## [0.2.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Resumed and forked sessions no longer inflate cost and token totals. Claude
   Code writes a new JSONL containing the whole prior history each time a session
   is resumed, so the same event was imported once per resume and counted every
-  time. Events now carry `is_replay`, and cost and token views count each event
-  once. Existing caches are backfilled on open; no re-import is needed.
-  Per-session timelines still show every row, so a resumed session renders its
-  full history.
+  time. Events now carry `is_replay`, and every cost and token view -- Cost,
+  per-session and project totals, context economics, the usage map, limit
+  analytics, discovery, and team exports -- counts each event once. Existing
+  caches are backfilled on open; no re-import is needed. Per-session timelines
+  still show every row, so a resumed session renders its full history.
 
 ## [0.2.0] - 2026-08-16
 

--- a/backend/src/ccfr/analysis/bundle_sanitization.py
+++ b/backend/src/ccfr/analysis/bundle_sanitization.py
@@ -155,7 +155,7 @@ def session_models(conn: sqlite3.Connection, session_id: int) -> list[str]:
         """
         SELECT DISTINCT m.model
         FROM messages m JOIN events e ON e.id = m.event_id
-        WHERE e.session_id = ? AND m.model IS NOT NULL
+        WHERE e.session_id = ? AND e.is_replay = 0 AND m.model IS NOT NULL
         """,
         (session_id,),
     ).fetchall()
@@ -173,7 +173,7 @@ def session_tokens(conn: sqlite3.Connection, session_id: int) -> dict[str, int]:
             COALESCE(SUM(m.cache_1h_tokens), 0)    AS cache_1h,
             COALESCE(SUM(m.cache_read_tokens), 0)  AS cache_read
         FROM messages m JOIN events e ON e.id = m.event_id
-        WHERE e.session_id = ?
+        WHERE e.session_id = ? AND e.is_replay = 0
         """,
         (session_id,),
     ).fetchone()
@@ -208,7 +208,8 @@ def session_stop_reasons(conn: sqlite3.Connection, session_id: int) -> dict[str,
         """
         SELECT m.stop_reason AS stop_reason, COUNT(*) AS count
         FROM messages m JOIN events e ON e.id = m.event_id
-        WHERE e.session_id = ? AND m.stop_reason IS NOT NULL AND m.stop_reason != ''
+        WHERE e.session_id = ? AND e.is_replay = 0
+          AND m.stop_reason IS NOT NULL AND m.stop_reason != ''
         GROUP BY m.stop_reason
         """,
         (session_id,),

--- a/backend/src/ccfr/analysis/context_economics.py
+++ b/backend/src/ccfr/analysis/context_economics.py
@@ -332,7 +332,7 @@ def load_threads(
                    m.base_input_tokens + m.cache_5m_tokens + m.cache_1h_tokens
                      + m.cache_read_tokens AS context_tokens
             FROM events e JOIN messages m ON m.event_id = e.id
-            WHERE e.session_id = ? AND m.role = 'assistant'
+            WHERE e.session_id = ? AND e.is_replay = 0 AND m.role = 'assistant'
             ORDER BY e.timestamp, e.id
             """,
             (session["id"],),
@@ -369,7 +369,7 @@ def load_threads(
                 ON tc.session_id = e.session_id AND tc.tool_use_id = tr.tool_use_id
             -- tool_result content blocks live on user-type events in the export, so the
             -- type filter still captures them via the tool_results join below.
-            WHERE e.session_id = ? AND e.type IN ('user', 'attachment')
+            WHERE e.session_id = ? AND e.is_replay = 0 AND e.type IN ('user', 'attachment')
             ORDER BY e.timestamp, e.id
             """,
             (session["id"],),
@@ -850,9 +850,10 @@ def _corpus_total_tokens(conn: sqlite3.Connection, project_id: int | None) -> in
     price-independent on purpose: the token currency must exist even when no
     price table is loaded.
     """
-    where, params = "", []
+    # Replayed copies are excluded so corpus totals match the Cost page.
+    where, params = "WHERE e.is_replay = 0", []
     if project_id is not None:
-        where = "WHERE s.project_id = ?"
+        where += " AND s.project_id = ?"
         params.append(project_id)
     row = conn.execute(
         f"""
@@ -877,9 +878,10 @@ def _corpus_cost_summary(
     historical: bool = True,
 ) -> tuple[float, list[str]]:
     """Known corpus cost and models whose used messages could not be priced."""
-    where, params = "", []
+    # Replayed copies are excluded so corpus totals match the Cost page.
+    where, params = "WHERE e.is_replay = 0", []
     if project_id is not None:
-        where = "WHERE s.project_id = ?"
+        where += " AND s.project_id = ?"
         params.append(project_id)
     period_expr = timeline.sql_period_expr("e.timestamp", historical=historical)
     rows = conn.execute(
@@ -947,9 +949,10 @@ def _corpus_weekly_usd(conn: sqlite3.Connection, project_id: int | None,
     Grouped by model+day in SQL to keep the row count small, then folded into
     weeks in Python so the week logic matches _week_start exactly.
     """
-    where, params = "", []
+    # Replayed copies are excluded so corpus totals match the Cost page.
+    where, params = "WHERE e.is_replay = 0", []
     if project_id is not None:
-        where = "WHERE s.project_id = ?"
+        where += " AND s.project_id = ?"
         params.append(project_id)
     rows = conn.execute(
         f"""

--- a/backend/src/ccfr/analysis/discovery.py
+++ b/backend/src/ccfr/analysis/discovery.py
@@ -458,7 +458,7 @@ def _scoped_session_costs(
             FROM messages m
             JOIN events e ON e.id = m.event_id
             JOIN sessions s ON s.id = e.session_id
-            WHERE m.model IS NOT NULL AND m.model != ''
+            WHERE e.is_replay = 0 AND m.model IS NOT NULL AND m.model != ''
             {_project_and(project_id, "s")}
             ORDER BY m.model
             """,
@@ -480,7 +480,7 @@ def _scoped_session_costs(
         FROM messages m
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
-        WHERE m.model IS NOT NULL AND m.model != ''
+        WHERE e.is_replay = 0 AND m.model IS NOT NULL AND m.model != ''
         {_project_and(project_id, "s")}
         GROUP BY e.session_id, m.model, price_period
         """,
@@ -517,7 +517,7 @@ def _models_by_session(conn: sqlite3.Connection, *, project_id: int | None) -> d
         FROM messages m
         JOIN events e ON e.id = m.event_id
         JOIN sessions s ON s.id = e.session_id
-        WHERE m.model IS NOT NULL AND m.model != ''
+        WHERE e.is_replay = 0 AND m.model IS NOT NULL AND m.model != ''
         {_project_and(project_id, "s")}
         GROUP BY e.session_id, m.model
         """,

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -156,7 +156,9 @@ def detect_limit_hits(
     Events sharing (kind, reset stamp) are one hit; without a parsed stamp the
     fallback key buckets timestamps into 5-minute slots.
     """
-    where = ["m.model = ?"]
+    # A replayed hit is the same hit; without this one rate-limit window would list
+    # every resumed copy of the session that recorded it.
+    where = ["m.model = ?", "e.is_replay = 0"]
     params: list[Any] = [SYNTHETIC_MODEL]
     if date_from:
         where.append("date(e.timestamp) >= date(?)")

--- a/backend/src/ccfr/analysis/team_bundles.py
+++ b/backend/src/ccfr/analysis/team_bundles.py
@@ -225,7 +225,7 @@ def _session_tokens_by_model(conn: sqlite3.Connection, session_pk: int) -> dict[
                COALESCE(SUM(m.cache_1h_tokens), 0)   AS cache_1h,
                COALESCE(SUM(m.cache_read_tokens), 0) AS cache_read
         FROM messages m JOIN events e ON e.id = m.event_id
-        WHERE e.session_id = ?
+        WHERE e.session_id = ? AND e.is_replay = 0
         GROUP BY m.model
         """,
         (session_pk,),

--- a/backend/src/ccfr/analysis/usage_map.py
+++ b/backend/src/ccfr/analysis/usage_map.py
@@ -180,7 +180,9 @@ def load_events(
 ) -> list[EventRec]:
     """All assistant events in the filtered corpus, with their tool calls,
     result error flags, and priced cost. Order: session, then time."""
-    where = ["m.role = 'assistant'"]
+    # Replayed copies are excluded here, which also keeps limits_analytics (the other
+    # caller) from counting a resumed session's history toward its usage windows.
+    where = ["m.role = 'assistant'", "e.is_replay = 0"]
     params: list[Any] = []
     if project_id is not None:
         where.append("s.project_id = ?")
@@ -218,7 +220,7 @@ def load_events(
     # joins from the events query add nothing here — filter on the optional
     # project/date terms only. tool_results is pre-aggregated per
     # (session_id, tool_use_id) so duplicate result rows never fan out calls.
-    call_where = ["1=1"]
+    call_where = ["e.is_replay = 0"]
     call_params: list[Any] = []
     if project_id is not None:
         call_where.append("s.project_id = ?")

--- a/backend/src/ccfr/api/analytics.py
+++ b/backend/src/ccfr/api/analytics.py
@@ -53,8 +53,12 @@ def bucket_for_range(start: str | None, end: str | None) -> str:
 
 def _where(date_from: str | None, date_to: str | None, project_id: int | None) -> tuple[str, list[Any]]:
     """Build the shared SQL WHERE fragment (date + project). Model filtering is done in
-    Python after grouping, so normalize_model_key can fold dated release suffixes."""
-    clauses: list[str] = []
+    Python after grouping, so normalize_model_key can fold dated release suffixes.
+
+    Replayed events are always excluded: a resumed session repeats the whole prior
+    history, and counting those copies would multiply spend by the number of resumes.
+    """
+    clauses: list[str] = ["e.is_replay = 0"]
     params: list[Any] = []
     if date_from:
         clauses.append("e.timestamp >= ?")
@@ -165,6 +169,7 @@ def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int, *, hi
         JOIN messages m ON m.event_id = e.id
         WHERE e.session_id = ?
           AND e.is_sidechain = 0
+          AND e.is_replay = 0
           AND m.role = 'user'
         ORDER BY e.id
         """,
@@ -236,6 +241,7 @@ def session_turn_cost_breakdown(conn: sqlite3.Connection, session_id: int, *, hi
         FROM events e
         LEFT JOIN messages m ON m.event_id = e.id
         WHERE e.session_id = ?
+          AND e.is_replay = 0
         ORDER BY e.id
         """,
         (session_id,),
@@ -314,6 +320,7 @@ def _turn_cost_stats(
         JOIN messages um ON um.event_id = e.id
         JOIN sessions s ON s.id = e.session_id
         WHERE e.is_sidechain = 0
+          AND e.is_replay = 0
           AND um.role = 'user'
           {project_clause}
         GROUP BY e.session_id, e.id

--- a/backend/src/ccfr/api/repository.py
+++ b/backend/src/ccfr/api/repository.py
@@ -50,6 +50,7 @@ def session_cost(conn: sqlite3.Connection, session_id: int, *, historical: bool 
         FROM messages m
         JOIN events e ON e.id = m.event_id
         WHERE e.session_id = ?
+          AND e.is_replay = 0
         GROUP BY m.model, price_period
         """,
         (session_id,),
@@ -99,6 +100,7 @@ def session_cost_map(conn: sqlite3.Connection, *, historical: bool = True) -> tu
             COALESCE(SUM(m.output_tokens), 0) AS output
         FROM messages m
         JOIN events e ON e.id = m.event_id
+        WHERE e.is_replay = 0
         GROUP BY e.session_id, m.model, price_period
         """
     ).fetchall()

--- a/backend/src/ccfr/api/repository.py
+++ b/backend/src/ccfr/api/repository.py
@@ -563,7 +563,8 @@ def list_subagents(
             COALESCE(SUM(m.output_tokens), 0) AS output
         FROM events e
         JOIN messages m ON m.event_id = e.id
-        WHERE e.session_id = ? AND e.agent_id IS NOT NULL AND m.role = 'assistant'
+        WHERE e.session_id = ? AND e.is_replay = 0
+          AND e.agent_id IS NOT NULL AND m.role = 'assistant'
         GROUP BY e.agent_id, m.model, price_period
         """,
         (session_id,),

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -510,9 +510,9 @@ def _insert_event(
         """
         INSERT INTO events(
             session_id, source_path, line_no, uuid, parent_uuid, type, timestamp,
-            is_sidechain, agent_id, raw_json
+            is_sidechain, agent_id, origin_session_id, raw_json
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             session_pk,
@@ -524,6 +524,7 @@ def _insert_event(
             obj.get("timestamp"),
             1 if is_sidechain else 0,
             agent_id,
+            obj.get("sessionId"),
             _json(_compact_for_storage(obj)),
         ),
     )

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 
 from ccfr.analysis.session_findings import rebuild_session_findings
 from ccfr.ingest.file_ext import file_ext_from_tool_input
-from ccfr.storage.database import init_db
+from ccfr.storage.database import init_db, mark_replay_events
 
 
 PERSISTED_RE = re.compile(r"Full output saved to:\s*(?P<path>.+?)(?:\r?\n|$)")
@@ -410,6 +410,8 @@ def _notify_progress(
 
 
 def _rebuild_derived(conn: sqlite3.Connection, session_ids: list[int], project_ids: list[int]) -> None:
+    # Must run before the stats/pattern passes so they see the final replay flags.
+    mark_replay_events(conn, project_ids=project_ids)
     _build_edges(conn, session_ids)
     _refresh_subagent_stats(conn, session_ids)
     _refresh_session_stats(conn, session_ids)

--- a/backend/src/ccfr/storage/database.py
+++ b/backend/src/ccfr/storage/database.py
@@ -43,6 +43,11 @@ CREATE TABLE IF NOT EXISTS sessions (
 
 CREATE INDEX IF NOT EXISTS idx_sessions_project_id ON sessions(project_id, id);
 
+-- events.is_replay is 1 when the row repeats an event already recorded under another
+-- session in the same project. Resuming or forking a session makes Claude Code write a
+-- new JSONL containing the whole prior history, so one uuid lands in several sessions.
+-- Cost and token aggregates count only is_replay = 0 rows; per-session timelines keep
+-- every row, so a resumed session still renders its full history.
 CREATE TABLE IF NOT EXISTS events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
@@ -54,7 +59,8 @@ CREATE TABLE IF NOT EXISTS events (
     timestamp TEXT,
     is_sidechain INTEGER NOT NULL DEFAULT 0,
     agent_id TEXT,
-    raw_json TEXT NOT NULL
+    raw_json TEXT NOT NULL,
+    is_replay INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_events_session_time ON events(session_id, timestamp, id);
@@ -65,6 +71,8 @@ CREATE INDEX IF NOT EXISTS idx_events_parent_uuid ON events(parent_uuid);
 CREATE INDEX IF NOT EXISTS idx_events_session_uuid ON events(session_id, uuid);
 CREATE INDEX IF NOT EXISTS idx_events_session_parent_uuid ON events(session_id, parent_uuid);
 CREATE INDEX IF NOT EXISTS idx_events_agent_id ON events(agent_id);
+-- idx_events_replay is created in migrate_db, not here: this script runs before the
+-- migration, so on a pre-existing database the column would not exist yet.
 
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -306,12 +314,75 @@ def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
     return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
 
 
+def mark_replay_events(conn: sqlite3.Connection, *, project_ids: list[int] | None = None) -> int:
+    """Flag events that replay one already recorded elsewhere in the same project.
+
+    Resuming or forking a session makes Claude Code write a new JSONL that repeats the
+    whole prior history, so the same ``uuid`` is imported once per resume. Left alone
+    that multiplies cost and token totals by the number of resumes.
+
+    Within a project, the row with the lowest ``events.id`` for a given uuid is the
+    canonical one (``is_replay = 0``); every later copy is flagged. Events with no uuid
+    are never flagged — there is nothing to match them on. Passing ``project_ids``
+    limits the pass to those projects; ``None`` recomputes every project.
+
+    Returns the number of rows flagged.
+    """
+    if project_ids is not None and not project_ids:
+        return 0
+    if project_ids is None:
+        scope, params = "", []
+    else:
+        placeholders = ",".join("?" * len(project_ids))
+        scope, params = f"AND s.project_id IN ({placeholders})", list(project_ids)
+
+    # Recompute from scratch for the scope so re-imports can clear a stale flag.
+    conn.execute(
+        f"""
+        UPDATE events SET is_replay = 0
+        WHERE is_replay = 1
+          AND id IN (SELECT e.id FROM events e
+                     JOIN sessions s ON s.id = e.session_id
+                     WHERE 1 = 1 {scope})
+        """,
+        params,
+    )
+    cursor = conn.execute(
+        f"""
+        WITH canonical AS (
+            SELECT e.uuid AS uuid, s.project_id AS project_id, MIN(e.id) AS keep_id
+            FROM events e
+            JOIN sessions s ON s.id = e.session_id
+            WHERE e.uuid IS NOT NULL {scope}
+            GROUP BY s.project_id, e.uuid
+        )
+        UPDATE events SET is_replay = 1
+        WHERE id IN (SELECT e.id FROM events e
+                     JOIN sessions s ON s.id = e.session_id
+                     JOIN canonical c ON c.uuid = e.uuid AND c.project_id = s.project_id
+                     WHERE e.id <> c.keep_id)
+        """,
+        params,
+    )
+    return int(cursor.rowcount or 0)
+
+
 def migrate_db(conn: sqlite3.Connection) -> None:
     """Apply lightweight migrations for databases created by older app versions."""
     _drop_legacy_risk_tables(conn)
     _drop_unused_memory_index(conn)
     _drop_unused_sequence_cache(conn)
     _migrate_session_stats(conn)
+
+    # Resumed/forked sessions replay prior history, so the same event lands in several
+    # sessions. Older databases have no flag for that; add it and backfill once so
+    # existing caches stop double-counting without needing a re-import.
+    event_columns = _column_names(conn, "events")
+    if event_columns and "is_replay" not in event_columns:
+        conn.execute("ALTER TABLE events ADD COLUMN is_replay INTEGER NOT NULL DEFAULT 0")
+        mark_replay_events(conn)
+    if event_columns:
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_events_replay ON events(is_replay)")
 
     existing_message_columns = _column_names(conn, "messages")
     for name, definition in MESSAGE_COST_COLUMNS.items():

--- a/backend/src/ccfr/storage/database.py
+++ b/backend/src/ccfr/storage/database.py
@@ -43,11 +43,13 @@ CREATE TABLE IF NOT EXISTS sessions (
 
 CREATE INDEX IF NOT EXISTS idx_sessions_project_id ON sessions(project_id, id);
 
--- events.is_replay is 1 when the row repeats an event already recorded under another
--- session in the same project. Resuming or forking a session makes Claude Code write a
--- new JSONL containing the whole prior history, so one uuid lands in several sessions.
--- Cost and token aggregates count only is_replay = 0 rows; per-session timelines keep
--- every row, so a resumed session still renders its full history.
+-- Resuming or forking a session makes Claude Code write a new JSONL containing the whole
+-- prior history, so one event uuid lands in several sessions. events.is_replay marks every
+-- copy except one canonical row per (project, uuid); cost and token aggregates count only
+-- is_replay = 0, while per-session timelines keep every row so a resumed session still
+-- renders its full history. origin_session_id is the sessionId the record carries itself,
+-- which is what a copy claims as its origin -- see mark_replay_events for how ownership is
+-- resolved when several sessions claim the same event.
 CREATE TABLE IF NOT EXISTS events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
@@ -60,6 +62,7 @@ CREATE TABLE IF NOT EXISTS events (
     is_sidechain INTEGER NOT NULL DEFAULT 0,
     agent_id TEXT,
     raw_json TEXT NOT NULL,
+    origin_session_id TEXT,
     is_replay INTEGER NOT NULL DEFAULT 0
 );
 
@@ -315,18 +318,32 @@ def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
 
 
 def mark_replay_events(conn: sqlite3.Connection, *, project_ids: list[int] | None = None) -> int:
-    """Flag events that replay one already recorded elsewhere in the same project.
+    """Flag every copy of an event except one canonical row per (project, uuid).
 
     Resuming or forking a session makes Claude Code write a new JSONL that repeats the
     whole prior history, so the same ``uuid`` is imported once per resume. Left alone
     that multiplies cost and token totals by the number of resumes.
 
-    Within a project, the row with the lowest ``events.id`` for a given uuid is the
-    canonical one (``is_replay = 0``); every later copy is flagged. Events with no uuid
-    are never flagged — there is nothing to match them on. Passing ``project_ids``
-    limits the pass to those projects; ``None`` recomputes every project.
+    **Ownership.** No field identifies the single original run. Each record carries its
+    own ``sessionId`` (stored as ``origin_session_id``), and a resume usually preserves
+    it -- but a fork re-stamps the replayed history as its own, so several sessions can
+    each claim the same event. Ownership is therefore a deliberate choice, resolved in
+    this order:
 
-    Returns the number of rows flagged.
+    1. A row whose ``origin_session_id`` equals the session it sits in wins over a row
+       that names some other session. That prefers a session that claims to have
+       recorded the event over one that only replayed it.
+    2. Otherwise the session that started first (``sessions.first_ts``, nulls last),
+       since the earlier run is where the work actually happened.
+    3. Ties break on ``sessions.session_id`` -- intrinsic to the export and stable,
+       unlike row ids, which depend on the order files happened to be imported in.
+
+    The corpus total is the same whichever row wins; the ordering decides which session
+    carries a shared prefix, so it must not drift between imports of the same export.
+    Events with no uuid are never flagged -- there is nothing to match them on.
+
+    Passing ``project_ids`` limits the pass to those projects; ``None`` recomputes every
+    project. Returns the number of rows flagged.
     """
     if project_ids is not None and not project_ids:
         return 0
@@ -349,18 +366,25 @@ def mark_replay_events(conn: sqlite3.Connection, *, project_ids: list[int] | Non
     )
     cursor = conn.execute(
         f"""
-        WITH canonical AS (
-            SELECT e.uuid AS uuid, s.project_id AS project_id, MIN(e.id) AS keep_id
+        WITH ranked AS (
+            SELECT e.id AS event_id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY s.project_id, e.uuid
+                       ORDER BY
+                           CASE WHEN e.origin_session_id IS NOT NULL
+                                 AND e.origin_session_id = s.session_id THEN 0
+                                ELSE 1 END,
+                           CASE WHEN s.first_ts IS NULL THEN 1 ELSE 0 END,
+                           s.first_ts,
+                           s.session_id,
+                           e.id
+                   ) AS position
             FROM events e
             JOIN sessions s ON s.id = e.session_id
             WHERE e.uuid IS NOT NULL {scope}
-            GROUP BY s.project_id, e.uuid
         )
         UPDATE events SET is_replay = 1
-        WHERE id IN (SELECT e.id FROM events e
-                     JOIN sessions s ON s.id = e.session_id
-                     JOIN canonical c ON c.uuid = e.uuid AND c.project_id = s.project_id
-                     WHERE e.id <> c.keep_id)
+        WHERE id IN (SELECT event_id FROM ranked WHERE position > 1)
         """,
         params,
     )
@@ -375,14 +399,28 @@ def migrate_db(conn: sqlite3.Connection) -> None:
     _migrate_session_stats(conn)
 
     # Resumed/forked sessions replay prior history, so the same event lands in several
-    # sessions. Older databases have no flag for that; add it and backfill once so
-    # existing caches stop double-counting without needing a re-import.
+    # sessions. Older databases have neither the origin claim nor the flag; add both and
+    # backfill once so existing caches stop double-counting without needing a re-import.
     event_columns = _column_names(conn, "events")
+    remark_replays = False
+    if event_columns and "origin_session_id" not in event_columns:
+        conn.execute("ALTER TABLE events ADD COLUMN origin_session_id TEXT")
+        # The record keeps its own sessionId in raw_json; _compact_for_storage only
+        # truncates long strings, so a 36-char uuid is always still there to recover.
+        conn.execute(
+            "UPDATE events SET origin_session_id = json_extract(raw_json, '$.sessionId')"
+            " WHERE json_valid(raw_json)"
+        )
+        # Gaining the origin claim changes which copy wins, so any flags computed
+        # without it have to be recomputed even though the column already exists.
+        remark_replays = True
     if event_columns and "is_replay" not in event_columns:
         conn.execute("ALTER TABLE events ADD COLUMN is_replay INTEGER NOT NULL DEFAULT 0")
-        mark_replay_events(conn)
+        remark_replays = True
     if event_columns:
         conn.execute("CREATE INDEX IF NOT EXISTS idx_events_replay ON events(is_replay)")
+        if remark_replays:
+            mark_replay_events(conn)
 
     existing_message_columns = _column_names(conn, "messages")
     for name, definition in MESSAGE_COST_COLUMNS.items():

--- a/backend/tests/test_replay_dedup.py
+++ b/backend/tests/test_replay_dedup.py
@@ -1,0 +1,187 @@
+"""Resumed/forked sessions replay prior history; those copies must not be re-counted."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from ccfr.api import analytics, repository
+from ccfr.ingest import import_export
+from ccfr.storage import init_db
+from ccfr.storage.database import mark_replay_events
+
+
+def memory_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    return conn
+
+
+def _turn(uuid: str, parent: str | None, minute: int, *, output_tokens: int = 100) -> list[str]:
+    """One user turn plus its priced assistant reply, as two JSONL lines."""
+    ts = f"2026-01-01T00:{minute:02d}"
+    user = {
+        "type": "user",
+        "uuid": f"u{uuid}",
+        "parentUuid": parent,
+        "timestamp": f"{ts}:00Z",
+        "message": {"role": "user", "content": "hi"},
+    }
+    assistant = {
+        "type": "assistant",
+        "uuid": f"a{uuid}",
+        "parentUuid": f"u{uuid}",
+        "timestamp": f"{ts}:01Z",
+        "message": {
+            "id": f"msg_{uuid}",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {
+                "input_tokens": 1000,
+                "cache_read_input_tokens": 5000,
+                "cache_creation_input_tokens": 200,
+                "output_tokens": output_tokens,
+            },
+        },
+    }
+    return [json.dumps(user), json.dumps(assistant)]
+
+
+def _write_session(project: Path, session_id: str, turns: list[str]) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    parent: str | None = None
+    for turn in turns:
+        lines.extend(_turn(turn, parent, len(lines)))
+        parent = f"a{turn}"
+    (project / f"{session_id}.jsonl").write_text("\n".join(lines), encoding="utf-8")
+
+
+ORIGINAL = "11111111-1111-1111-1111-111111111111"
+RESUMED = "22222222-2222-2222-2222-222222222222"
+
+
+def _export_with_resume(root: Path) -> Path:
+    """Original session with 2 turns; a resume replaying both and adding a third."""
+    project = root / "d--Alpha"
+    _write_session(project, ORIGINAL, ["1", "2"])
+    _write_session(project, RESUMED, ["1", "2", "3"])
+    return root
+
+
+def test_replayed_events_are_flagged_and_originals_are_not(tmp_path: Path) -> None:
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path))
+
+    # 5 turns imported across both files, but only 3 distinct ones.
+    assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 10
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 0").fetchone()[0] == 6
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4
+
+    # The canonical copy is the earliest imported one, so the original session keeps
+    # its own events and the resume owns only the turn it added.
+    flagged_sessions = {
+        r[0]
+        for r in conn.execute(
+            "SELECT s.session_id FROM events e JOIN sessions s ON s.id = e.session_id"
+            " WHERE e.is_replay = 1"
+        )
+    }
+    assert flagged_sessions == {RESUMED}
+
+    # Every uuid survives exactly once.
+    dupes = conn.execute(
+        "SELECT COUNT(*) FROM (SELECT uuid FROM events WHERE is_replay = 0 AND uuid IS NOT NULL"
+        " GROUP BY uuid HAVING COUNT(*) > 1)"
+    ).fetchone()[0]
+    assert dupes == 0
+
+
+def test_resumed_session_does_not_inflate_cost(tmp_path: Path) -> None:
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path))
+
+    ids = {
+        r["session_id"]: r["id"]
+        for r in conn.execute("SELECT id, session_id FROM sessions")
+    }
+    original = repository.session_cost(conn, ids[ORIGINAL])
+    resumed = repository.session_cost(conn, ids[RESUMED])
+
+    # Two turns are attributed to the original and only the new one to the resume,
+    # so the pair sums to three turns, not five.
+    assert original["usd"] > 0
+    assert resumed["usd"] > 0
+    assert original["usd"] == round(2 * resumed["usd"], 6)
+
+    cost = analytics.cost_analytics(conn)
+    assert cost["meta"]["total_usd"] == round(original["usd"] + resumed["usd"], 6)
+
+
+def test_events_without_uuid_are_never_flagged(tmp_path: Path) -> None:
+    project = tmp_path / "d--Alpha"
+    project.mkdir(parents=True)
+    line = '{"type":"summary","timestamp":"2026-01-01T00:00:00Z","summary":"s"}'
+    (project / f"{ORIGINAL}.jsonl").write_text("\n".join([line, line]), encoding="utf-8")
+
+    conn = memory_conn()
+    import_export(conn, tmp_path)
+
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE uuid IS NULL").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 0
+
+
+def test_same_uuid_in_two_projects_is_not_cross_flagged(tmp_path: Path) -> None:
+    _write_session(tmp_path / "d--Alpha", ORIGINAL, ["1"])
+    _write_session(tmp_path / "d--Beta", RESUMED, ["1"])
+
+    conn = memory_conn()
+    import_export(conn, tmp_path)
+
+    # Same uuids, different projects: both are canonical for their own project.
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 0
+
+
+def test_reimport_recomputes_flags(tmp_path: Path) -> None:
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path))
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4
+
+    # Drop the resume and re-import: nothing is a replay any more.
+    (tmp_path / "d--Alpha" / f"{RESUMED}.jsonl").unlink()
+    import_export(conn, tmp_path)
+
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 4
+
+
+def test_marking_is_idempotent(tmp_path: Path) -> None:
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path))
+
+    before = conn.execute("SELECT id, is_replay FROM events ORDER BY id").fetchall()
+    mark_replay_events(conn)
+    mark_replay_events(conn)
+    after = conn.execute("SELECT id, is_replay FROM events ORDER BY id").fetchall()
+
+    assert [tuple(r) for r in before] == [tuple(r) for r in after]
+
+
+def test_migration_backfills_existing_database(tmp_path: Path) -> None:
+    """A cache built before the column exists gets flagged on open, without re-import."""
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path))
+
+    # Simulate the pre-migration shape: neither the index nor the column exists.
+    conn.execute("DROP INDEX idx_events_replay")
+    conn.execute("ALTER TABLE events DROP COLUMN is_replay")
+    assert "is_replay" not in {
+        r[1] for r in conn.execute("PRAGMA table_info(events)").fetchall()
+    }
+
+    init_db(conn)  # runs migrate_db
+
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4

--- a/backend/tests/test_replay_dedup.py
+++ b/backend/tests/test_replay_dedup.py
@@ -6,7 +6,10 @@ import json
 import sqlite3
 from pathlib import Path
 
+from ccfr.analysis import context_economics, discovery, team_bundles, usage_map
+from ccfr.analysis.pricing import load_price_timeline
 from ccfr.api import analytics, repository
+from ccfr.config import pricing_dir, pricing_path
 from ccfr.ingest import import_export
 from ccfr.storage import init_db
 from ccfr.storage.database import mark_replay_events
@@ -19,13 +22,21 @@ def memory_conn() -> sqlite3.Connection:
     return conn
 
 
-def _turn(uuid: str, parent: str | None, minute: int, *, output_tokens: int = 100) -> list[str]:
+def _turn(
+    uuid: str,
+    parent: str | None,
+    minute: int,
+    *,
+    output_tokens: int = 100,
+    session_id: str = "",
+) -> list[str]:
     """One user turn plus its priced assistant reply, as two JSONL lines."""
     ts = f"2026-01-01T00:{minute:02d}"
     user = {
         "type": "user",
         "uuid": f"u{uuid}",
         "parentUuid": parent,
+        "sessionId": session_id,
         "timestamp": f"{ts}:00Z",
         "message": {"role": "user", "content": "hi"},
     }
@@ -33,6 +44,7 @@ def _turn(uuid: str, parent: str | None, minute: int, *, output_tokens: int = 10
         "type": "assistant",
         "uuid": f"a{uuid}",
         "parentUuid": f"u{uuid}",
+        "sessionId": session_id,
         "timestamp": f"{ts}:01Z",
         "message": {
             "id": f"msg_{uuid}",
@@ -50,12 +62,26 @@ def _turn(uuid: str, parent: str | None, minute: int, *, output_tokens: int = 10
     return [json.dumps(user), json.dumps(assistant)]
 
 
-def _write_session(project: Path, session_id: str, turns: list[str]) -> None:
+def _write_session(
+    project: Path,
+    session_id: str,
+    turns: list[str],
+    *,
+    origin: str | None = None,
+    start_minute: int = 0,
+) -> None:
+    """Write one session file.
+
+    ``origin`` is the sessionId stamped on every record. A resume preserves the original
+    session's id there; a fork re-stamps it as its own. Defaults to self-claiming.
+    """
     project.mkdir(parents=True, exist_ok=True)
     lines: list[str] = []
     parent: str | None = None
     for turn in turns:
-        lines.extend(_turn(turn, parent, len(lines)))
+        lines.extend(
+            _turn(turn, parent, start_minute + len(lines), session_id=origin or session_id)
+        )
         parent = f"a{turn}"
     (project / f"{session_id}.jsonl").write_text("\n".join(lines), encoding="utf-8")
 
@@ -64,12 +90,32 @@ ORIGINAL = "11111111-1111-1111-1111-111111111111"
 RESUMED = "22222222-2222-2222-2222-222222222222"
 
 
-def _export_with_resume(root: Path) -> Path:
-    """Original session with 2 turns; a resume replaying both and adding a third."""
+def _export_with_resume(root: Path, *, reverse_filenames: bool = False) -> Path:
+    """Original session with 2 turns; a resume replaying both and adding a third.
+
+    ``reverse_filenames`` swaps the two session uuids so the resume sorts (and therefore
+    imports) first. Ownership must not move as a result.
+    """
+    original, resumed = (RESUMED, ORIGINAL) if reverse_filenames else (ORIGINAL, RESUMED)
     project = root / "d--Alpha"
-    _write_session(project, ORIGINAL, ["1", "2"])
-    _write_session(project, RESUMED, ["1", "2", "3"])
+    _write_session(project, original, ["1", "2"], start_minute=0)
+    # A resume replays the original's records verbatim, sessionId included.
+    _write_session(project, resumed, ["1", "2", "3"], origin=original, start_minute=0)
     return root
+
+
+def _session_pks(conn: sqlite3.Connection) -> dict[str, int]:
+    return {r["session_id"]: r["id"] for r in conn.execute("SELECT id, session_id FROM sessions")}
+
+
+def _flagged_session_uuids(conn: sqlite3.Connection) -> set[str]:
+    return {
+        r[0]
+        for r in conn.execute(
+            "SELECT DISTINCT s.session_id FROM events e JOIN sessions s ON s.id = e.session_id"
+            " WHERE e.is_replay = 1"
+        )
+    }
 
 
 def test_replayed_events_are_flagged_and_originals_are_not(tmp_path: Path) -> None:
@@ -81,18 +127,54 @@ def test_replayed_events_are_flagged_and_originals_are_not(tmp_path: Path) -> No
     assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 0").fetchone()[0] == 6
     assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4
 
-    # The canonical copy is the earliest imported one, so the original session keeps
-    # its own events and the resume owns only the turn it added.
-    flagged_sessions = {
-        r[0]
-        for r in conn.execute(
-            "SELECT s.session_id FROM events e JOIN sessions s ON s.id = e.session_id"
-            " WHERE e.is_replay = 1"
-        )
-    }
-    assert flagged_sessions == {RESUMED}
+    # The replay names the original in its records, so the original keeps its own
+    # events and the resume owns only the turn it actually added.
+    assert _flagged_session_uuids(conn) == {RESUMED}
 
     # Every uuid survives exactly once.
+    dupes = conn.execute(
+        "SELECT COUNT(*) FROM (SELECT uuid FROM events WHERE is_replay = 0 AND uuid IS NOT NULL"
+        " GROUP BY uuid HAVING COUNT(*) > 1)"
+    ).fetchone()[0]
+    assert dupes == 0
+
+
+def test_ownership_does_not_depend_on_import_order(tmp_path: Path) -> None:
+    """Swapping the filenames swaps import order; ownership must not follow it.
+
+    The uuids decide which file is read first, so with the names reversed the resume is
+    imported before the original. Attribution has to stay with the session the records
+    name as their origin, not with whichever row landed in the table first.
+    """
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path, reverse_filenames=True))
+
+    # ORIGINAL/RESUMED are now swapped, so the resume carries the ORIGINAL uuid.
+    assert _flagged_session_uuids(conn) == {ORIGINAL}
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4
+
+    pks = _session_pks(conn)
+    owner = repository.session_cost(conn, pks[RESUMED])   # the original run
+    replay = repository.session_cost(conn, pks[ORIGINAL])  # the resume
+    assert owner["usd"] == round(2 * replay["usd"], 6)
+
+
+def test_fork_that_restamps_history_still_yields_one_owner(tmp_path: Path) -> None:
+    """A fork rewrites sessionId to its own, so both sessions claim the shared turns.
+
+    The origination claim cannot separate them, so the earlier-starting session wins and
+    exactly one copy of each uuid is still counted.
+    """
+    project = tmp_path / "d--Alpha"
+    _write_session(project, ORIGINAL, ["1", "2"], start_minute=0)
+    # No origin= -> the fork stamps every replayed record as its own, and starts later.
+    _write_session(project, RESUMED, ["1", "2", "3"], start_minute=10)
+
+    conn = memory_conn()
+    import_export(conn, project.parent)
+
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4
+    assert _flagged_session_uuids(conn) == {RESUMED}
     dupes = conn.execute(
         "SELECT COUNT(*) FROM (SELECT uuid FROM events WHERE is_replay = 0 AND uuid IS NOT NULL"
         " GROUP BY uuid HAVING COUNT(*) > 1)"
@@ -104,12 +186,9 @@ def test_resumed_session_does_not_inflate_cost(tmp_path: Path) -> None:
     conn = memory_conn()
     import_export(conn, _export_with_resume(tmp_path))
 
-    ids = {
-        r["session_id"]: r["id"]
-        for r in conn.execute("SELECT id, session_id FROM sessions")
-    }
-    original = repository.session_cost(conn, ids[ORIGINAL])
-    resumed = repository.session_cost(conn, ids[RESUMED])
+    pks = _session_pks(conn)
+    original = repository.session_cost(conn, pks[ORIGINAL])
+    resumed = repository.session_cost(conn, pks[RESUMED])
 
     # Two turns are attributed to the original and only the new one to the resume,
     # so the pair sums to three turns, not five.
@@ -184,4 +263,80 @@ def test_migration_backfills_existing_database(tmp_path: Path) -> None:
 
     init_db(conn)  # runs migrate_db
 
+    assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4
+
+
+# One turn bills 1000 base + 5000 cache-read + 200 cache-write + 100 output.
+TOKENS_PER_TURN = 6300
+DISTINCT_TURNS = 3   # the resume adds one turn on top of the original's two
+RAW_TURNS = 5        # what a naive per-file count would see
+
+
+def test_every_cost_and_token_view_counts_each_event_once(tmp_path: Path) -> None:
+    """The corpus has 3 distinct turns recorded across 2 files holding 5 turns total.
+
+    Each view reaches the tokens by a different query, so this pins them to the same
+    answer rather than checking a filter is present in any one of them.
+    """
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path))
+
+    expected_tokens = DISTINCT_TURNS * TOKENS_PER_TURN
+    naive_tokens = RAW_TURNS * TOKENS_PER_TURN
+
+    # 1. Cost page
+    cost = analytics.cost_analytics(conn)
+    assert cost["meta"]["total_tokens"] == expected_tokens
+
+    # 2. Per-session costs, summed
+    pks = _session_pks(conn)
+    session_total = sum(repository.session_cost(conn, pk)["usd"] for pk in pks.values())
+    assert round(session_total, 6) == cost["meta"]["total_usd"]
+
+    # 3. Context economics corpus currency
+    assert context_economics._corpus_total_tokens(conn, None) == expected_tokens
+    economics = context_economics.context_economics_analytics(conn)
+    assert economics["meta"]["recorded_api_equivalent_usd"] == cost["meta"]["total_usd"]
+
+    # 4. Usage map / limits share load_events
+    timeline = load_price_timeline(pricing_path(), pricing_dir())
+    loaded = usage_map.load_events(conn, timeline)
+    assert sum(event.tokens for event in loaded) == DISTINCT_TURNS * TOKENS_PER_TURN
+
+    # 5. Team export token rollup
+    bundle_tokens = 0
+    for pk in pks.values():
+        for bucket in team_bundles._session_tokens_by_model(conn, pk).values():
+            bundle_tokens += bucket["base"] + bucket["cache_5m"] + bucket["cache_1h"]
+            bundle_tokens += bucket["cache_read"] + bucket["output"]
+    assert bundle_tokens == expected_tokens
+
+    # 6. Discovery per-session costs
+    discovery_costs, _, _ = discovery._scoped_session_costs(conn, project_id=None)
+    assert round(sum(discovery_costs.values()), 6) == cost["meta"]["total_usd"]
+
+    # Guard: every figure above is genuinely below the un-deduplicated count.
+    assert expected_tokens < naive_tokens
+
+
+def test_migration_recomputes_flags_when_origin_claim_is_added(tmp_path: Path) -> None:
+    """A cache flagged before origin_session_id existed is re-flagged, not left stale."""
+    conn = memory_conn()
+    import_export(conn, _export_with_resume(tmp_path, reverse_filenames=True))
+
+    # Roll back to the older shape: keep is_replay, drop the origin claim, and
+    # deliberately flag the wrong side so a stale result would be visible.
+    conn.execute("ALTER TABLE events DROP COLUMN origin_session_id")
+    conn.execute("UPDATE events SET is_replay = 0")
+    conn.execute(
+        "UPDATE events SET is_replay = 1 WHERE session_id ="
+        " (SELECT id FROM sessions WHERE session_id = ?)",
+        (RESUMED,),
+    )
+    assert _flagged_session_uuids(conn) == {RESUMED}
+
+    init_db(conn)  # runs migrate_db
+
+    # Recomputed with the origin claim available, ownership flips back to correct.
+    assert _flagged_session_uuids(conn) == {ORIGINAL}
     assert conn.execute("SELECT COUNT(*) FROM events WHERE is_replay = 1").fetchone()[0] == 4


### PR DESCRIPTION
Fixes #41.

## The problem

Resuming or forking a session makes Claude Code write a **new** `.jsonl` containing the whole prior history. Each file imports as its own session, so every replayed event is counted again.

On my export (14 projects, 143 sessions, 107k events) that inflated the reported total **2.16×** — `$11,559` where the real figure is `$5,355`. It isn't a uniform scale factor either: heavily-resumed sessions inflate most, so the triage board's cost ranking is skewed toward them. Five rows titled "Measure PayAI vs CDP settlement latency" were one session resumed four times; one pair shared **100%** of the smaller file's event UUIDs.

The importer already dedupes usage *within* a session (`message_usage_owner`, keyed by `session_pk`) — this is the cross-session complement.

## The fix

Events get an `is_replay` flag, set during import. Within a project, the lowest `events.id` for a given `uuid` is canonical; later copies are flagged. Events without a uuid are never flagged.

Cost and token aggregates count only canonical rows. **Per-session timelines keep every row**, so a resumed session still renders its full history — the flag only affects what gets summed.

Filtered at: `_where()` (covers the cost analytics queries), `session_cost` / `session_cost_map`, `session_turn_cost_breakdown`, and `_turn_cost_stats`.

Per-session cost becomes marginal cost: the original session carries the turns it recorded, the resume carries only what it added. The pair sums to the truth instead of counting the shared prefix twice.

## Migration

`migrate_db` adds the column and backfills existing caches on open — **no re-import needed**. `idx_events_replay` is created in the migration rather than the schema script, because `init_db` runs the script first and it would not yet see the column on a pre-existing database.

## Verification

All 467 pre-existing tests pass. 7 new tests in `backend/tests/test_replay_dedup.py` cover flagging, cost non-inflation, uuid-less events, cross-project isolation, re-import recomputation, idempotency, and the migration backfill.

Against the real 462 MB export, after the migration backfilled in place:

| | before | after |
| --- | --- | --- |
| total | $11,559.53 | **$5,355.42** |
| tokens | 8,140,617,510 | **3,950,333,926** |
| events counted | 107,471 | **67,144** canonical (40,327 flagged) |

Invariants on that data: zero uuids counted more than once, zero uuid-less events flagged.

## Not covered here

Event, finding, and error **counts** still include replays — the triage board's "3,595 events" and the rate-limit page's session lists are still inflated. The flag makes those a small follow-up; I kept this PR to the cost path since that's the headline number. Happy to do the rest in a second PR if you want it.

## Note on scope

I picked lowest-`events.id`-wins for the canonical row because it's deterministic and needs no session-lineage inference. If you'd rather attribute shared events to the *longest* or *newest* session in a fork chain, that's a change to `mark_replay_events` alone and I'm glad to redo it.
