### PR TITLE
feat: add Claude Opus 5 to the pricing table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- Pricing for Claude Opus 5 (`claude-opus-5`), at the same $5/$25 per million
+  input/output as Opus 4.8. Sessions on that model previously had no price row,
+  so their tokens were silently valued at $0 and the model was reported under
+  `unpriced_models`.
 - Limit hits can now switch between raw token volume and API-equivalent cost;
   the timeline, hit details, cap zones, near-misses, percentile, and plan-fit
   verdict all use the selected measurement basis.

--- a/pricing.csv
+++ b/pricing.csv
@@ -1,6 +1,7 @@
 model,base-input-tokens,5m-cache-writes,1h-cache-writes,cache-hits-&-refreshes,output-tokens
 Claude-Fable-5,10,12.50,20,1,50
 Claude-Mythos-5,10,12.50,20,1,50
+Claude-Opus-5,5,6.25,10,0.50,25
 Claude-Opus-4.8,5,6.25,10,0.50,25
 Claude-Opus-4.7,5,6.25,10,0.50,25
 Claude-Opus-4.6,5,6.25,10,0.50,25


### PR DESCRIPTION
`claude-opus-5` has no row in `pricing.csv`, so its tokens are valued at **$0** and the model shows up under `unpriced_models`. The cost views still render a total, which makes the gap easy to miss — the number just quietly excludes that model.

On my export that was 108.7M tokens contributing nothing.

## The row

```
Claude-Opus-5,5,6.25,10,0.50,25
```

$5/$25 per million input/output — the same tier as Opus 4.8 — with the cache multipliers every other row in the file already uses: 5m write 1.25×, 1h write 2×, cache read 0.1×. That makes the row identical to `Claude-Opus-4.8`, which is expected: the two share a price tier.

No code change is needed. `normalize_model_key` folds `Claude-Opus-5` and `claude-opus-5` to the same key, and `pricing.csv` is the only place models are enumerated — I grepped the docs and frontend for a second list and there isn't one.

## Verification

467 backend tests pass.

Checked against a real 462 MB export, editing the mounted `pricing.csv` and re-reading:

| | before | after |
| --- | --- | --- |
| `unpriced_models` | `["claude-opus-5"]` | **empty** |
| claude-opus-5 | $0.00 (108,715,093 tok) | **$96.41** |

Other models unchanged.

### One thing worth knowing

While testing I hit a Docker gotcha that isn't a repo bug but might bite others: after editing the bind-mounted `pricing.csv` in place, the container kept serving a **truncated** 588-byte view of the 621-byte file, cut off mid-row. That silently un-priced Haiku, whose row is last. `docker compose restart backend` fixed it.

The README says pricing edits take effect on the next request with no rebuild, which is true for the app — but single-file bind mounts on Docker Desktop don't always re-sync when the file is rewritten rather than appended. Might be worth a note next to that line in the README; happy to add one if you want.

## Note

This is independent of #42 and can merge in either order. Both touch `CHANGELOG.md` under `[Unreleased]`, but in different subsections, so they shouldn't conflict.
