### PR TITLE
feat: live log ingestion with debounced watcher and alert badges

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "uvicorn[standard]>=0.30.0",
     "pydantic>=2.8.0",
     "tzdata>=2024.1",
+    "watchdog>=4.0",
 ]
 
 [project.urls]

--- a/backend/src/ccfr/analysis/limits.py
+++ b/backend/src/ccfr/analysis/limits.py
@@ -305,7 +305,7 @@ def _era_for(ts: datetime, history: list[dict[str, str]]) -> str:
     return label
 
 
-def _hit_payload(hit: LimitHit) -> dict[str, Any]:
+def hit_payload(hit: LimitHit) -> dict[str, Any]:
     blocked = hit.blocked_minutes
     return {
         "ts": hit.ts.isoformat(),
@@ -453,7 +453,7 @@ def limits_analytics(
             "plan_history": history,
             "method_note": METHOD_NOTE,
         },
-        "hits": [_hit_payload(h) for h in hits],
+        "hits": [hit_payload(h) for h in hits],
         "windows": [
             {
                 "start": w.start.isoformat(),

--- a/backend/src/ccfr/api/routes.py
+++ b/backend/src/ccfr/api/routes.py
@@ -4,7 +4,7 @@ import json
 import secrets
 import time
 from dataclasses import asdict, replace
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable
 
@@ -22,7 +22,7 @@ from ccfr.analysis.context_economics import (
     session_context_economics,
 )
 from ccfr.analysis.discovery import discovery_analytics
-from ccfr.analysis.limits import limits_analytics
+from ccfr.analysis.limits import detect_limit_hits, hit_payload, limits_analytics
 from ccfr.analysis.team_bundles import (
     build_team_bundle,
     delete_team_member,
@@ -48,6 +48,7 @@ from ccfr.api.schemas import (
     ImportProgressResponse,
     ImportRequest,
     ImportSummaryResponse,
+    LimitHitsAlertResponse,
     LimitsResponse,
     ProjectResponse,
     RiskFindingResponse,
@@ -661,3 +662,18 @@ def get_limits(
         conn, historical=historical, date_from=date_from, date_to=date_to,
         plan_history=read_settings().plan_history,
     ))
+
+
+@router.get("/alerts/limit-hits", response_model=LimitHitsAlertResponse)
+def get_recent_limit_hits(
+    since: str | None = Query(default=None, description="ISO 8601 timestamp; defaults to the last 24h."),
+    conn: Connection = Depends(get_db),
+) -> LimitHitsAlertResponse:
+    # Cheap live-alert poll for the sidebar badge -- bounded to a recent window by
+    # default so an omitted cursor never falls back to scanning the whole corpus.
+    date_from = since or (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+    hits = detect_limit_hits(conn, date_from=date_from)
+    return LimitHitsAlertResponse(
+        hits=[hit_payload(h) for h in hits],
+        checked_at=datetime.now(timezone.utc).isoformat(),
+    )

--- a/backend/src/ccfr/api/schemas.py
+++ b/backend/src/ccfr/api/schemas.py
@@ -738,6 +738,11 @@ class LimitsResponse(BaseModel):
     eras: list[LimitEraOut] = Field(default_factory=list)
 
 
+class LimitHitsAlertResponse(BaseModel):
+    hits: list[LimitHitOut] = Field(default_factory=list)
+    checked_at: str
+
+
 class ContributionPreviewResponse(BaseModel):
     manifest: dict[str, Any]
     bundle: dict[str, Any]

--- a/backend/src/ccfr/ingest/importer.py
+++ b/backend/src/ccfr/ingest/importer.py
@@ -148,8 +148,12 @@ def import_project(
 
 
 def discover_projects(conn: sqlite3.Connection, source_root: Path) -> list[DiscoveredProject]:
+    # Read-only: the schema is already initialized once at app startup
+    # (main.py's lifespan), so re-running init_db()/migrate_db() here on every
+    # scan just takes an unnecessary write lock -- migrate_db's backfill
+    # UPDATE runs unconditionally, colliding with the live watcher's frequent
+    # writes and surfacing as "database is locked" on this listing endpoint.
     source_root = _validate_root(source_root)
-    init_db(conn)
     result: list[DiscoveredProject] = []
     for project_dir in sorted(p for p in source_root.iterdir() if p.is_dir()):
         row = conn.execute(

--- a/backend/src/ccfr/ingest/watcher.py
+++ b/backend/src/ccfr/ingest/watcher.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+from ccfr.config import database_path, import_root, is_docker
+from ccfr.ingest.importer import import_all_new
+from ccfr.storage import connect
+
+
+logger = logging.getLogger(__name__)
+
+DEBOUNCE_SECONDS = 2.0
+
+
+class _DebouncedImportHandler(FileSystemEventHandler):
+    """Coalesces bursty filesystem events into one incremental import.
+
+    Claude Code writes session JSONL incrementally, so a single turn can
+    produce several rapid writes. Debouncing avoids re-running the importer
+    (which hashes every file in a changed project) once per write.
+    """
+
+    def __init__(self, source_root: Path) -> None:
+        self._source_root = source_root
+        self._lock = threading.Lock()
+        self._timer: threading.Timer | None = None
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            return
+        self._arm()
+
+    def _arm(self) -> None:
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(DEBOUNCE_SECONDS, self._run_import)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def cancel_pending(self) -> None:
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    def _run_import(self) -> None:
+        try:
+            conn = connect(database_path())
+            try:
+                import_all_new(conn, self._source_root)
+            finally:
+                conn.close()
+        except Exception:
+            # A partial write mid-import, or a transient filesystem hiccup, must
+            # not kill the watcher thread -- the next debounced cycle picks up
+            # whatever settled.
+            logger.exception("live import failed")
+
+
+class LogWatcher:
+    """Watches CCFR_IMPORT_ROOT and incrementally imports new/changed sessions.
+
+    Runs for the life of the app process (started/stopped from the FastAPI
+    lifespan) -- the first persistent background component in this app. Every
+    other long-running operation here is request-scoped; see
+    api/import_progress.py for the polling equivalent used by the manual
+    "Import" flow.
+    """
+
+    def __init__(self, source_root: Path | None = None) -> None:
+        self._source_root = source_root or import_root()
+        self._handler = _DebouncedImportHandler(self._source_root)
+        # watchdog's native OS-event observer can miss events over Docker
+        # Desktop's bind-mounted volumes on macOS (gRPC-FUSE/virtiofs don't
+        # reliably forward inotify), so poll instead when running in a
+        # container; the native Observer elsewhere is instant and cheap.
+        self._observer = PollingObserver() if is_docker() else Observer()
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        if not self._source_root.is_dir():
+            logger.warning(
+                "live watcher: import root %s does not exist, not watching", self._source_root
+            )
+            return
+        self._observer.schedule(self._handler, str(self._source_root), recursive=True)
+        self._observer.start()
+        self._started = True
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+        self._handler.cancel_pending()
+        self._observer.stop()
+        self._observer.join(timeout=5.0)
+        self._started = False

--- a/backend/src/ccfr/main.py
+++ b/backend/src/ccfr/main.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 
 from ccfr.api import router
 from ccfr.config import allowed_hosts, allowed_origins, app_version, database_path, webui_dir
+from ccfr.ingest.watcher import LogWatcher
 from ccfr.storage import connect, init_db
 
 
@@ -26,7 +27,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         init_db(conn)
     finally:
         conn.close()
-    yield
+    # Always-on live ingestion: incrementally imports new/changed sessions as
+    # Claude Code writes them, so the UI doesn't need a manual "Import" click.
+    watcher = LogWatcher()
+    watcher.start()
+    try:
+        yield
+    finally:
+        watcher.stop()
 
 
 def _mount_webui(app: FastAPI) -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,7 +2,21 @@ from __future__ import annotations
 
 import pytest
 
+import ccfr.ingest.watcher as watcher_mod
 import ccfr.settings as settings_mod
+
+
+@pytest.fixture(autouse=True)
+def isolate_live_watcher(tmp_path, monkeypatch):
+    """Keep the always-on LogWatcher from watching the real repo Data/ dir.
+
+    main.py's lifespan starts a LogWatcher on every app startup, including
+    every ``TestClient(app)`` used across this suite. LogWatcher.start() is a
+    no-op when its source root doesn't exist, so pointing it at an unused
+    tmp_path subdirectory is enough to keep the whole suite from spawning real
+    filesystem observers; a test exercising the watcher itself overrides this.
+    """
+    monkeypatch.setattr(watcher_mod, "import_root", lambda: tmp_path / "_ambient_no_watch")
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_alerts_api.py
+++ b/backend/tests/test_alerts_api.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ccfr.api.deps import get_db
+from ccfr.main import create_app
+from tests.test_limits import HIT_TEXT, _add_limit_hit, _make_conn
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("ccfr.main.database_path", lambda: tmp_path / "startup.sqlite3")
+    conn = _make_conn()
+    app = create_app()
+    app.dependency_overrides[get_db] = lambda: conn
+    with TestClient(app) as c:
+        yield c
+    conn.close()
+
+
+def test_recent_limit_hits_returns_hit_in_default_window(client: TestClient) -> None:
+    conn = client.app.dependency_overrides[get_db]()
+    recent_ts = datetime.now(timezone.utc).isoformat()
+    _add_limit_hit(conn, 1, recent_ts, HIT_TEXT)
+
+    resp = client.get("/api/alerts/limit-hits")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["hits"]) == 1
+    assert body["hits"][0]["session_titles"] == ["Session One"]
+    assert "checked_at" in body
+
+
+def test_recent_limit_hits_excludes_hits_outside_default_window(client: TestClient) -> None:
+    conn = client.app.dependency_overrides[get_db]()
+    _add_limit_hit(conn, 1, "2020-01-01T00:00:00Z", HIT_TEXT)
+
+    resp = client.get("/api/alerts/limit-hits")
+
+    assert resp.status_code == 200
+    assert resp.json()["hits"] == []
+
+
+def test_recent_limit_hits_honors_explicit_since(client: TestClient) -> None:
+    conn = client.app.dependency_overrides[get_db]()
+    _add_limit_hit(conn, 1, "2026-07-03T09:40:00Z", HIT_TEXT)
+
+    before = client.get("/api/alerts/limit-hits", params={"since": "2026-07-01"})
+    after = client.get("/api/alerts/limit-hits", params={"since": "2026-07-04"})
+
+    assert len(before.json()["hits"]) == 1
+    assert after.json()["hits"] == []
+
+
+def test_recent_limit_hits_empty_corpus(client: TestClient) -> None:
+    resp = client.get("/api/alerts/limit-hits")
+
+    assert resp.status_code == 200
+    assert resp.json()["hits"] == []

--- a/backend/tests/test_watcher.py
+++ b/backend/tests/test_watcher.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+import ccfr.ingest.watcher as watcher_mod
+from ccfr.ingest.watcher import LogWatcher, _DebouncedImportHandler
+
+
+class _FakeEvent:
+    def __init__(self, is_directory: bool) -> None:
+        self.is_directory = is_directory
+
+
+def test_start_noops_when_source_root_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    watcher = LogWatcher(source_root=missing)
+
+    watcher.start()
+
+    assert watcher._started is False
+    watcher.stop()  # must not raise on a watcher that never started
+
+
+def test_start_and_stop_lifecycle(tmp_path: Path) -> None:
+    watcher = LogWatcher(source_root=tmp_path)
+
+    watcher.start()
+    assert watcher._started is True
+
+    watcher.stop()
+    assert watcher._started is False
+
+
+def test_uses_polling_observer_in_docker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(watcher_mod, "is_docker", lambda: True)
+
+    watcher = LogWatcher(source_root=tmp_path)
+
+    assert isinstance(watcher._observer, PollingObserver)
+
+
+def test_uses_native_observer_outside_docker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(watcher_mod, "is_docker", lambda: False)
+
+    watcher = LogWatcher(source_root=tmp_path)
+
+    assert isinstance(watcher._observer, Observer)
+
+
+def test_on_any_event_ignores_directory_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    armed = []
+    handler = _DebouncedImportHandler(tmp_path)
+    monkeypatch.setattr(handler, "_arm", lambda: armed.append(True))
+
+    handler.on_any_event(_FakeEvent(is_directory=True))
+
+    assert armed == []
+
+
+def test_on_any_event_arms_for_file_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    armed = []
+    handler = _DebouncedImportHandler(tmp_path)
+    monkeypatch.setattr(handler, "_arm", lambda: armed.append(True))
+
+    handler.on_any_event(_FakeEvent(is_directory=False))
+
+    assert armed == [True]
+
+
+def test_arm_debounces_rapid_events(tmp_path: Path) -> None:
+    handler = _DebouncedImportHandler(tmp_path)
+
+    handler._arm()
+    first_timer = handler._timer
+    handler._arm()
+    second_timer = handler._timer
+
+    # Re-arming cancels the previous timer and schedules a fresh one, so a
+    # burst of writes coalesces into a single eventual import.
+    assert first_timer is not None
+    assert second_timer is not None
+    assert first_timer is not second_timer
+
+    handler.cancel_pending()
+    assert handler._timer is None
+
+
+def test_run_import_invokes_import_all_new(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+    fake_conn = object()
+    monkeypatch.setattr(watcher_mod, "connect", lambda _path: fake_conn)
+    monkeypatch.setattr(
+        watcher_mod, "import_all_new", lambda conn, source_root: calls.append((conn, source_root))
+    )
+
+    handler = _DebouncedImportHandler(tmp_path)
+    handler._run_import()
+
+    assert calls == [(fake_conn, tmp_path)]
+
+
+def test_run_import_swallows_exceptions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(watcher_mod, "connect", lambda _path: object())
+
+    def boom(conn, source_root):
+        raise RuntimeError("partial write mid-import")
+
+    monkeypatch.setattr(watcher_mod, "import_all_new", boom)
+
+    handler = _DebouncedImportHandler(tmp_path)
+    handler._run_import()  # must not raise -- the watcher thread has to survive this

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -51,6 +51,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchdog" },
 ]
 
 [package.optional-dependencies]
@@ -67,6 +68,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
     { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
+    { name = "watchdog", specifier = ">=4.0" },
 ]
 provides-extras = ["dev"]
 
@@ -532,6 +534,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,14 @@ Backend:
 - Storage: SQLite with WAL mode.
 - Config: environment variables in `backend/src/ccfr/config.py`.
 - Importer: Claude Code JSONL project folders under `CCFR_IMPORT_ROOT`.
+- Live watcher: `backend/src/ccfr/ingest/watcher.py`. Runs for the life of
+  the process (started/stopped in `main.py`'s `lifespan`) and incrementally
+  imports new/changed sessions as they're written, so the UI doesn't need a
+  manual "Import" click. Debounces filesystem events (`watchdog`) before
+  calling the existing incremental importer; uses a polling observer instead
+  of native OS events when running in Docker, since bind-mounted volumes on
+  macOS don't reliably forward inotify. The frontend learns about new data by
+  polling, not a push connection -- see "Live alerts" below.
 - API router prefix: `/api`.
 
 Frontend:
@@ -92,6 +100,10 @@ Implemented route groups:
 - Import/cache: `POST /api/imports`, `POST /api/imports/reset`,
   `GET /api/imports`, `GET /api/imports/progress`,
   `GET /api/source/projects`, `GET /api/stats`.
+- Live alerts: `GET /api/alerts/limit-hits` -- rate-limit hits since a
+  `?since=` cursor (default: last 24h), polled by the frontend at ~2s to
+  drive an unseen-count badge on the Limit hits technique. Reuses the
+  detection in `analysis/limits.py`; no separate alert storage.
 - Local data: `GET /api/projects`, `GET /api/sessions`,
   `GET /api/sessions/{id}`, timeline, trace, turn costs, subagents, findings,
   event detail, and search.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -54,6 +54,7 @@ vi.mock("./api/client", () => ({
     active: false, import_id: null, project_count: 0, session_count: 0,
     event_count: 0, subagent_count: 0, memory_count: 0, persisted_output_count: 0,
   })),
+  getRecentLimitHits: vi.fn(async () => ({ hits: [], checked_at: new Date().toISOString() })),
   getCostAnalytics: vi.fn(async () => ({
     meta: { available: false, unpriced_models: [], total_usd: 0, total_tokens: 0,
       available_projects: [], available_models: [], bucket: "day" },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { useDataScope } from "./shell/useDataScope";
 import { DEFAULT_TECHNIQUE } from "./discover/techniques";
 import { useCollapsed } from "./shell/useCollapsed";
 import { useGlossaryHint } from "./shell/useGlossaryHint";
+import { useLiveAlerts } from "./shell/useLiveAlerts";
 import { useSettings } from "./shell/useSettings";
 import { PrivacyModeProvider } from "./shell/PrivacyModeContext";
 import { useTheme } from "./theme/useTheme";
@@ -44,6 +45,7 @@ function App() {
   const { collapsed, toggle: toggleCollapsed } = useCollapsed();
   const { historicalPricing, setHistoricalPricing, privacyMode, setPrivacyMode } = useSettings();
   const { seen: glossaryHintSeen, dismiss: dismissGlossaryHint } = useGlossaryHint();
+  const { unseenCount: limitHitsUnseenCount, markSeen: markLimitHitsSeen } = useLiveAlerts();
   const [glossaryOpen, setGlossaryOpen] = React.useState(false);
   const autoRouted = React.useRef(false);
 
@@ -90,6 +92,7 @@ function App() {
   const selectTechnique = (key: string) => {
     setDiscoverTechnique(key);
     setView("discover");
+    if (key === "limits") markLimitHitsSeen();
   };
 
   // Opening the glossary (from the button or the hint's CTA) counts as
@@ -111,6 +114,7 @@ function App() {
         onSelectView={setView}
         onSelectScope={setScope}
         onSelectTechnique={selectTechnique}
+        limitHitsUnseenCount={limitHitsUnseenCount}
         onToggleCollapsed={toggleCollapsed}
         onToggleTheme={toggle}
         onOpenGlossary={openGlossary}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   EventDetail,
   ImportProgress,
   ImportSummary,
+  LimitHitsAlertResponse,
   LimitsResponse,
   Project,
   RiskFinding,
@@ -252,6 +253,11 @@ export function getUsageCharacteristics(filters: UsageMapFilters = {}) {
 
 export function getLimits() {
   return request<LimitsResponse>("/analytics/limits");
+}
+
+export function getRecentLimitHits(since?: string) {
+  const query = since ? `?since=${encodeURIComponent(since)}` : "";
+  return request<LimitHitsAlertResponse>(`/alerts/limit-hits${query}`);
 }
 
 export function getSettings() {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -722,6 +722,11 @@ export interface LimitsResponse {
   eras: LimitEraEntry[];
 }
 
+export interface LimitHitsAlertResponse {
+  hits: LimitHitEntry[];
+  checked_at: string;
+}
+
 export interface ContributionManifest {
   session_count: number;
   sequence_step_count: number;

--- a/frontend/src/pages/ImportPage.test.tsx
+++ b/frontend/src/pages/ImportPage.test.tsx
@@ -177,6 +177,39 @@ describe("ImportPage", () => {
     await waitFor(() => expect(loadDemo).toHaveBeenCalledTimes(1));
   });
 
+  it("shows 'No imports yet' when the imports table is empty", async () => {
+    vi.spyOn(client, "discoverSourceProjects").mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText("No imports yet")).toBeInTheDocument();
+  });
+
+  it("shows when it last synced, including imports this tab didn't trigger", async () => {
+    vi.spyOn(client, "discoverSourceProjects").mockResolvedValue([]);
+    vi.mocked(client.listImports).mockResolvedValue([
+      { id: 2, source_path: "/srv/Data", imported_at: new Date().toISOString(), file_count: 1, status: "completed", error_count: 0 },
+      { id: 1, source_path: "/srv/Data", imported_at: "2020-01-01T00:00:00Z", file_count: 1, status: "completed", error_count: 0 },
+    ] as never);
+
+    renderPage();
+
+    const badge = await screen.findByText(/^Last synced /);
+    expect(badge).toHaveClass("ok");
+  });
+
+  it("shows a neutral (not 'live') badge when the last sync is stale", async () => {
+    vi.spyOn(client, "discoverSourceProjects").mockResolvedValue([]);
+    vi.mocked(client.listImports).mockResolvedValue([
+      { id: 1, source_path: "/srv/Data", imported_at: "2020-01-01T00:00:00Z", file_count: 1, status: "completed", error_count: 0 },
+    ] as never);
+
+    renderPage();
+
+    const badge = await screen.findByText(/^Last synced /);
+    expect(badge).toHaveClass("neutral");
+  });
+
   it("hides the demo card once projects exist in the source", async () => {
     vi.spyOn(client, "discoverSourceProjects").mockResolvedValue([
       { name: "d--Alpha", imported: false, session_count: 0, last_imported_at: null },

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { FolderInput, RotateCcw, Search, Trash2 } from "lucide-react";
-import { createImport, discoverSourceProjects, getCacheStats, getImportProgress, getRuntimeConfig, loadDemoData, resetImports } from "../api/client";
+import { Clock, FolderInput, RotateCcw, Search, Trash2 } from "lucide-react";
+import { createImport, discoverSourceProjects, getCacheStats, getImportProgress, getRuntimeConfig, listImports, loadDemoData, resetImports } from "../api/client";
 import type { DiscoveredProject } from "../api/types";
 import { useImportRoot } from "./useImportRoot";
 import LoadingBar from "../components/LoadingBar";
+
+const RECENT_IMPORT_MS = 5 * 60 * 1000;
 
 function ImportPage() {
   const queryClient = useQueryClient();
@@ -21,6 +23,14 @@ function ImportPage() {
     enabled: root.length > 0,
   });
   const stats = useQuery({ queryKey: ["stats"], queryFn: getCacheStats });
+  // Polled independently of a manual action so the live watcher's background
+  // imports show up here too, not just imports this tab itself triggered.
+  const imports = useQuery({ queryKey: ["imports"], queryFn: listImports, refetchInterval: 5000 });
+  const lastImportedAtRaw = imports.data?.[0]?.imported_at;
+  const lastImportedAt = typeof lastImportedAtRaw === "string" ? lastImportedAtRaw : null;
+  // "Recent" is a rough signal that the live watcher (not just this tab) is
+  // actively pulling in data -- not a precise freshness guarantee.
+  const isRecentImport = lastImportedAt != null && Date.now() - new Date(lastImportedAt).getTime() < RECENT_IMPORT_MS;
 
   const invalidateAll = async () => {
     await Promise.all([
@@ -74,11 +84,17 @@ function ImportPage() {
             Mounted source
             {isDocker && <span className="docker-badge">Docker</span>}
           </p>
-          {isOverridden && !isDocker && (
-            <button type="button" className="link-reset" onClick={resetToDefault}>
-              Reset to default
-            </button>
-          )}
+          <div className="console-label-right">
+            <span className={`status-badge ${isRecentImport ? "ok" : "neutral"}`}>
+              <Clock size={11} />
+              {lastImportedAt ? `Last synced ${formatSyncedAt(lastImportedAt)}` : "No imports yet"}
+            </span>
+            {isOverridden && !isDocker && (
+              <button type="button" className="link-reset" onClick={resetToDefault}>
+                Reset to default
+              </button>
+            )}
+          </div>
         </div>
 
         <form
@@ -236,6 +252,12 @@ function formatImported(iso: string): string {
   const days = Math.round(hrs / 24);
   if (days < 30) return `${days}d ago`;
   return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatSyncedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
 }
 
 function Metric({ label, value }: { label: string; value: number }) {

--- a/frontend/src/shell/Sidebar.test.tsx
+++ b/frontend/src/shell/Sidebar.test.tsx
@@ -93,6 +93,18 @@ describe("Sidebar", () => {
     expect(screen.queryByRole("button", { name: "Subgroups" })).not.toBeInTheDocument();
   });
 
+  it("shows an unseen-count badge on Limit hits when there are new hits", () => {
+    setup({ view: "discover", limitHitsUnseenCount: 3 });
+    const limitHitsButton = screen.getByRole("button", { name: /Limit hits/ });
+    expect(within(limitHitsButton).getByText("3")).toBeInTheDocument();
+  });
+
+  it("hides the Limit hits badge when there are no unseen hits", () => {
+    setup({ view: "discover", limitHitsUnseenCount: 0 });
+    const limitHitsButton = screen.getByRole("button", { name: "Limit hits" });
+    expect(within(limitHitsButton).queryByText(/^\d+$/)).not.toBeInTheDocument();
+  });
+
   it("fires footer actions", () => {
     const props = setup();
     fireEvent.click(screen.getByRole("button", { name: "Open glossary" }));

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -18,6 +18,9 @@ interface Props {
   onSelectView: (view: View) => void;
   onSelectScope: (scope: DataScope) => void;
   onSelectTechnique: (key: string) => void;
+  // Unseen rate-limit-hit count from the live watcher (see useLiveAlerts),
+  // surfaced on the "Limit hits" technique rather than as new top-level UI.
+  limitHitsUnseenCount?: number;
   onToggleCollapsed: () => void;
   onToggleTheme: () => void;
   onOpenGlossary: () => void;
@@ -40,6 +43,7 @@ export default function Sidebar({
   onSelectView,
   onSelectScope,
   onSelectTechnique,
+  limitHitsUnseenCount = 0,
   onToggleCollapsed,
   onToggleTheme,
   onOpenGlossary,
@@ -94,6 +98,11 @@ export default function Sidebar({
                     >
                       <span className="sb-dot" aria-hidden="true" />
                       <span className="sb-label">{tech.label}</span>
+                      {tech.key === "limits" && limitHitsUnseenCount > 0 && (
+                        <span className="sb-tag is-alert" aria-label={`${limitHitsUnseenCount} new limit hits`}>
+                          {limitHitsUnseenCount}
+                        </span>
+                      )}
                     </button>
                   ))}
                 </div>

--- a/frontend/src/shell/useLiveAlerts.test.tsx
+++ b/frontend/src/shell/useLiveAlerts.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLiveAlerts } from "./useLiveAlerts";
+
+const CURSOR_KEY = "ccfr_limit_hits_since";
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+function mockHitsResponse(hits: Array<{ ts: string }>) {
+  vi.spyOn(global, "fetch").mockImplementation(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          checked_at: new Date().toISOString(),
+          hits: hits.map((h) => ({
+            ts: h.ts,
+            kind: "session",
+            reset_at: null,
+            blocked_minutes: null,
+            usage_at_hit: null,
+            usage_at_hit_tokens: null,
+            occurrence_count: 1,
+            window_index: null,
+            session_ids: [],
+            session_titles: [],
+          })),
+        }),
+        { status: 200 },
+      ),
+    ),
+  );
+}
+
+describe("useLiveAlerts", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("does not count pre-existing hits as unseen on first load", async () => {
+    mockHitsResponse([{ ts: "2020-01-01T00:00:00Z" }]);
+    const { result } = renderHook(() => useLiveAlerts(), { wrapper: createWrapper() });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    // First load has no stored cursor, so it baselines to "now" rather than
+    // flagging whatever the backend's default recent window already had.
+    await waitFor(() => expect(result.current.unseenCount).toBe(0));
+    expect(localStorage.getItem(CURSOR_KEY)).not.toBeNull();
+  });
+
+  it("counts hits newer than a stored cursor as unseen", async () => {
+    localStorage.setItem(CURSOR_KEY, "2020-01-01T00:00:00.000Z");
+    mockHitsResponse([{ ts: "2020-06-01T00:00:00Z" }, { ts: "2020-06-02T00:00:00Z" }]);
+
+    const { result } = renderHook(() => useLiveAlerts(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.unseenCount).toBe(2));
+  });
+
+  it("markSeen advances the cursor and clears the unseen count", async () => {
+    localStorage.setItem(CURSOR_KEY, "2020-01-01T00:00:00.000Z");
+    mockHitsResponse([{ ts: "2020-06-01T00:00:00Z" }]);
+    const { result } = renderHook(() => useLiveAlerts(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.unseenCount).toBe(1));
+
+    act(() => result.current.markSeen());
+
+    await waitFor(() => expect(result.current.unseenCount).toBe(0));
+    expect(localStorage.getItem(CURSOR_KEY)).not.toBe("2020-01-01T00:00:00.000Z");
+  });
+});

--- a/frontend/src/shell/useLiveAlerts.ts
+++ b/frontend/src/shell/useLiveAlerts.ts
@@ -1,0 +1,49 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getRecentLimitHits } from "../api/client";
+
+const CURSOR_KEY = "ccfr_limit_hits_since";
+const POLL_INTERVAL_MS = 2000;
+
+function readInitialCursor(): string {
+  try {
+    const existing = localStorage.getItem(CURSOR_KEY);
+    if (existing) return existing;
+    const initial = new Date().toISOString();
+    localStorage.setItem(CURSOR_KEY, initial);
+    return initial;
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+// Live rate-limit-hit alerts for the sidebar badge. Polls (not push) by
+// design -- see docs/architecture.md; the backend's ?since= filter is
+// day-granular (shared with the Limits page's date range), so "unseen" is
+// refined client-side to full-timestamp precision against the stored cursor.
+export function useLiveAlerts() {
+  const [cursor, setCursor] = React.useState<string>(readInitialCursor);
+
+  const query = useQuery({
+    queryKey: ["alerts", "limit-hits", cursor],
+    queryFn: () => getRecentLimitHits(cursor),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const cursorMs = new Date(cursor).getTime();
+  const unseenCount = (query.data?.hits ?? []).filter(
+    (hit) => new Date(hit.ts).getTime() > cursorMs
+  ).length;
+
+  const markSeen = React.useCallback(() => {
+    const now = new Date().toISOString();
+    setCursor(now);
+    try {
+      localStorage.setItem(CURSOR_KEY, now);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return { unseenCount, markSeen };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -114,6 +114,7 @@ button:disabled { cursor: not-allowed; opacity: 0.5; }
 .sb-subitem.active .sb-dot { background: var(--accent); opacity: 1; }
 .sb-tag { margin-left: auto; font-style: normal; font-size: 8.5px; letter-spacing: .5px;
   color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 1px 6px; }
+.sb-tag.is-alert { color: var(--warning); border-color: var(--warning); }
 
 .sb-bottom {
   margin-top: auto;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -319,6 +319,7 @@ html:has(.glossary-dialog[open]) { overflow: hidden; }
 }
 
 .console-label { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.console-label-right { display: flex; align-items: center; gap: 10px; }
 
 .eyebrow { margin: 0; font-size: 11px; font-weight: 700; letter-spacing: .07em;
   text-transform: uppercase; color: var(--muted); }
@@ -454,9 +455,10 @@ h3 {
 .card-count { font-size: 11.5px; color: var(--faint); }
 .card-count b { color: var(--text); font-weight: 700; }
 .card-pad { padding: 13px 16px; }
-.status-badge { font-size: 10.5px; font-weight: 700; padding: 3px 9px; border-radius: 999px; }
+.status-badge { display: inline-flex; align-items: center; gap: 4px; font-size: 10.5px; font-weight: 700; padding: 3px 9px; border-radius: 999px; white-space: nowrap; }
 .status-badge.ok { color: var(--asst); background: color-mix(in srgb, var(--asst) 14%, transparent); }
 .status-badge.warn { color: var(--loop); background: color-mix(in srgb, var(--loop) 14%, transparent); }
+.status-badge.neutral { color: var(--muted); background: color-mix(in srgb, var(--muted) 14%, transparent); }
 .import-row {
   display: grid; grid-template-columns: 8px minmax(0, 1fr) auto auto; gap: 14px;
   padding: 12px 16px; align-items: center; border-top: 1px solid var(--border);


### PR DESCRIPTION
## ⚠️ Status: not yet reviewed against your pipeline

This has passed its own local test suite, a from-scratch Docker rebuild, and basic
dependency auditing — but it hasn't been through your actual CI/review process yet,
and I haven't checked it against whatever conventions or in-flight work exist here
that I can't see from the outside. Please treat this as a working draft that needs
a proper look before merging, not something ready to wave through.

## Summary
Watches the Claude Code export root and imports new/changed sessions automatically,
with a live alert badge for rate-limit hits, so the UI doesn't need a manual
"Import" click for new sessions to show up.

- **Live watcher** (`backend/src/ccfr/ingest/watcher.py`): watches `CCFR_IMPORT_ROOT`,
  debounces bursty writes (2s), and calls the existing `import_all_new()`
  incrementally. Started/stopped from `main.py`'s lifespan. Uses `PollingObserver`
  under Docker since bind-mounted volumes on macOS don't reliably forward inotify
  (verified live in a container — this is where the old approach broke before).
- **`GET /api/alerts/limit-hits`**: rate-limit hits since a `?since=` cursor, reusing
  `detect_limit_hits()`/`hit_payload()` from `analysis/limits.py`. No new tables.
- **Sidebar badge**: unseen-count badge on the "Limit hits" subnav item, polling
  every ~2s (TanStack Query, same pattern `ImportPage.tsx` already uses for import
  progress), `localStorage`-backed cursor so a reload doesn't re-flag old hits.
- **Import page badge**: "Last synced [date, time]" next to "Mounted source", green
  when within 5 minutes. Backed by its own poll of `GET /api/imports`.
- **Bug fix found while testing this live**: `discover_projects()` (the "Projects in
  source" scan) was calling `init_db()`/`migrate_db()` on every request, including an
  unconditional write-locking backfill `UPDATE`. Harmless before, but the watcher now
  writes every ~2s during an active session, and the two collided as
  `database is locked`. Fixed by dropping the redundant call.

Design choices, happy to discuss/change: polling over SSE (this app has no push-based
pattern anywhere else, and polling avoids the Docker/nginx buffering issues an SSE
approach hit previously); no new DB tables (reuses the existing `imports` table and
`detect_limit_hits()` rather than adding alert storage); badge-only UI (no new
toast/panel component).

## Test plan
- [x] `uv run --extra dev pytest` — 480 passed
- [x] `npm run build && npm test` — build clean, 319 passed
- [x] Manual: local `uvicorn` run against a scratch import root — dropped a new
  session file, confirmed auto-import within the debounce window with zero manual
  `POST /api/imports` calls
- [x] Manual: same test inside a Docker container against a writable scratch mount —
  confirms the `PollingObserver` fallback works for real
- [x] Manual: full no-cache `docker compose build` + up, smoke-tested every touched
  endpoint
- [ ] Not run against this repo's own CI/lint/type-check pipeline — please treat
  green checks here (if any trigger) as necessary, not sufficient

## Risks
- First always-on background thread in this app — every other long operation is
  request-scoped. If the watcher throws outside its per-cycle try/except, it needs
  investigating live rather than via a request/response cycle.
- Built and tested independently without visibility into any of your own in-flight
  work on this repo, so please flag if it overlaps or conflicts with anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)