### PR TITLE
feat: add sortable Ended column to the Overview table

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -823,7 +823,7 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
 
 .tr-name { font-weight: 700; color: var(--text); }
 .tr-sub { font-size: 11px; color: var(--faint); margin-top: 3px; }
-.cell-started { color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.cell-started, .cell-ended { color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .cell-err, .cell-loop, .cell-fan { font-weight: 700; }
 .cell-err { color: var(--err); } .cell-loop { color: var(--loop); } .cell-fan { color: var(--fan); }
 .cell-muted { color: var(--faint); }

--- a/frontend/src/triage/TriageBoard.test.tsx
+++ b/frontend/src/triage/TriageBoard.test.tsx
@@ -162,6 +162,41 @@ describe("TriageBoard", () => {
     expect(screen.getByRole("combobox", { name: "Sort sessions" })).toHaveValue("first_ts");
   });
 
+  it("shows the session end timestamp in the overview table", () => {
+    const lastTs = "2026-06-03T11:30:00Z";
+    render(
+      <TriageBoard
+        projects={projects}
+        sessions={[s({ last_ts: lastTs })]}
+        loading={false}
+        onOpenSession={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Ended" })).toBeInTheDocument();
+    const timestamp = screen.getByText(
+      new Date(lastTs).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }),
+    );
+    expect(timestamp).toHaveAttribute("datetime", lastTs);
+  });
+
+  it("sorts sessions by most recently ended from the Ended column", () => {
+    const sessions = [
+      s({ id: 1, session_id: "older111", last_ts: "2026-06-01T10:00:00Z" }),
+      s({ id: 2, session_id: "undated2", last_ts: null }),
+      s({ id: 3, session_id: "newer333", last_ts: "2026-06-03T10:00:00Z" }),
+    ];
+    render(<TriageBoard projects={projects} sessions={sessions} loading={false} onOpenSession={() => {}} />);
+
+    fireEvent.click(screen.getByRole("columnheader", { name: "Ended" }));
+
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(within(rows[0]).getByText(/newer333/)).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/older111/)).toBeInTheDocument();
+    expect(within(rows[2]).getByText(/undated2/)).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Sort sessions" })).toHaveValue("last_ts");
+  });
+
   it("sorts by the displayed cost when the Cost header is clicked", () => {
     const sessions = [
       s({ id: 1, session_id: "cheap111", cost_usd: 0.5 }),

--- a/frontend/src/triage/TriageBoard.tsx
+++ b/frontend/src/triage/TriageBoard.tsx
@@ -13,11 +13,12 @@ interface Props {
   onOpenSession: (session: SessionCard) => void;
 }
 
-type SortKey = "risk" | "first_ts" | "patterns" | "error_count" | "max_repeat" | "subagent_count" | "event_count" | "cost_usd";
+type SortKey = "risk" | "first_ts" | "last_ts" | "patterns" | "error_count" | "max_repeat" | "subagent_count" | "event_count" | "cost_usd";
 
 const SORT_OPTIONS: Array<{ key: SortKey; label: string }> = [
   { key: "risk", label: "Highest risk" },
   { key: "first_ts", label: "Newest first" },
+  { key: "last_ts", label: "Last ended" },
   { key: "patterns", label: "Strongest finding" },
   { key: "error_count", label: "Most errors" },
   { key: "max_repeat", label: "Largest loop" },
@@ -28,8 +29,9 @@ const SORT_OPTIONS: Array<{ key: SortKey; label: string }> = [
 
 function sortValue(session: SessionCard, sortKey: SortKey): number {
   if (sortKey === "risk") return riskScore(session);
-  if (sortKey === "first_ts") {
-    const timestamp = session.first_ts ? Date.parse(session.first_ts) : Number.NaN;
+  if (sortKey === "first_ts" || sortKey === "last_ts") {
+    const value = sortKey === "first_ts" ? session.first_ts : session.last_ts;
+    const timestamp = value ? Date.parse(value) : Number.NaN;
     return Number.isNaN(timestamp) ? 0 : timestamp;
   }
   if (sortKey === "patterns") return session.pattern_risk_score;
@@ -40,7 +42,7 @@ function formatUsd(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
-function formatSessionStart(value: string | null): string {
+function formatTimestamp(value: string | null): string {
   if (!value) return "—";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
@@ -180,6 +182,7 @@ function TriageBoard({ projects, sessions, loading, onOpenSession }: Props) {
                   {header("risk", "Risk")}
                   <th>Session</th>
                   {header("first_ts", "Started")}
+                  {header("last_ts", "Ended")}
                   {header("patterns", "Top issue")}
                   <th>Impact</th>
                   {header("cost_usd", "Cost")}
@@ -208,7 +211,12 @@ function TriageBoard({ projects, sessions, loading, onOpenSession }: Props) {
                       </td>
                       <td className="cell-started">
                         {session.first_ts ? (
-                          <time dateTime={session.first_ts}>{formatSessionStart(session.first_ts)}</time>
+                          <time dateTime={session.first_ts}>{formatTimestamp(session.first_ts)}</time>
+                        ) : "—"}
+                      </td>
+                      <td className="cell-ended">
+                        {session.last_ts ? (
+                          <time dateTime={session.last_ts}>{formatTimestamp(session.last_ts)}</time>
                         ) : "—"}
                       </td>
                       <td className={`cell-issue issue-${issue.tone}`}>


### PR DESCRIPTION
## ⚠️ Status: not yet reviewed against your pipeline

Small, self-contained change. Passed its own build/test run but hasn't been through
your CI/review process — please treat as a draft that needs a proper look, not
something ready to wave through.

## Summary
Adds an "Ended" column to the Overview table, same pattern as the existing
"Started" column: clickable header, entry in the sort dropdown, always-descending
sort. Frontend-only — the backend already returns `last_ts` on `SessionCard`
(`s.last_ts` is already selected in `list_sessions`), it just wasn't surfaced in
this table.

## Test plan
- [x] `npm run build && npm test` — build clean, 313 passed
- [x] Manually confirmed in the browser
- [ ] Not run against this repo's own CI/lint/type-check pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)