### PR TITLE
ci: publish with an action that accepts core metadata 2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,9 @@ jobs:
           test -f "dist/checkyouragent-${GITHUB_REF_NAME#v}.tar.gz"
 
       - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        # v1.14.2 ships Twine 7, which accepts core metadata 2.5. Hatchling 1.32
+        # emits 2.5, so older publish actions reject the wheel with
+        # "InvalidDistribution: '2.5' is not a valid metadata version".
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           packages-dir: dist/


### PR DESCRIPTION
Hatchling 1.32 writes Metadata-Version: 2.5, and the pinned publish action still bundled a Twine whose packaging library stops at 2.4, so the upload failed validation with "InvalidDistribution: '2.5' is not a valid metadata version" after a successful build.

The distributions themselves are fine; current twine check passes on both. Bump the action to v1.14.2, which ships Twine 7 and accepts metadata 2.5.