### PR TITLE
feat: add sortable Ended column to the Overview table

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -852,7 +852,7 @@ pre { max-height: 260px; overflow: auto; background: var(--track); color: var(--
 
 .tr-name { font-weight: 700; color: var(--text); }
 .tr-sub { font-size: 11px; color: var(--faint); margin-top: 3px; }
-.cell-started { color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.cell-started, .cell-ended { color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .cell-muted { color: var(--faint); }
 .cell-vol b { font-weight: 700; } .vol-dur { color: var(--muted); font-size: 11px; margin-top: 2px; }
 .cell-cost { font-weight: 700; font-variant-numeric: tabular-nums; }

--- a/frontend/src/triage/TriageBoard.test.tsx
+++ b/frontend/src/triage/TriageBoard.test.tsx
@@ -99,6 +99,7 @@ describe("TriageBoard", () => {
 
     expect(options).toEqual([
       { value: "first_ts", label: "Newest first" },
+      { value: "last_ts", label: "Recently ended" },
       { value: "cost_usd", label: "Highest estimated API-equivalent cost" },
       { value: "error_count", label: "Most observed errors" },
       { value: "finding_count", label: "Supported finding" },
@@ -184,7 +185,7 @@ describe("TriageBoard", () => {
 
     expect(screen.getByRole("columnheader", { name: "Started" })).toBeInTheDocument();
     const timestamp = screen.getByText(
-      new Date(firstTs).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }),
+      new Date(firstTs).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" }),
     );
     expect(timestamp).toHaveAttribute("datetime", firstTs);
   });
@@ -204,6 +205,41 @@ describe("TriageBoard", () => {
     expect(within(rows[1]).getByText(/older111/)).toBeInTheDocument();
     expect(within(rows[2]).getByText(/undated2/)).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Sort sessions" })).toHaveValue("first_ts");
+  });
+
+  it("shows the session end timestamp in the Sessions table", () => {
+    const lastTs = "2026-06-03T11:30:00Z";
+    render(
+      <TriageBoard
+        projects={projects}
+        sessions={[s({ last_ts: lastTs })]}
+        loading={false}
+        onOpenSession={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Ended" })).toBeInTheDocument();
+    const timestamp = screen.getByText(
+      new Date(lastTs).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" }),
+    );
+    expect(timestamp).toHaveAttribute("datetime", lastTs);
+  });
+
+  it("sorts sessions by most recently ended from the Ended column", () => {
+    const sessions = [
+      s({ id: 1, session_id: "older111", last_ts: "2026-06-01T10:00:00Z" }),
+      s({ id: 2, session_id: "undated2", last_ts: null }),
+      s({ id: 3, session_id: "newer333", last_ts: "2026-06-03T10:00:00Z" }),
+    ];
+    render(<TriageBoard projects={projects} sessions={sessions} loading={false} onOpenSession={() => {}} />);
+
+    fireEvent.click(screen.getByRole("columnheader", { name: "Ended" }));
+
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(within(rows[0]).getByText(/newer333/)).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/older111/)).toBeInTheDocument();
+    expect(within(rows[2]).getByText(/undated2/)).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Sort sessions" })).toHaveValue("last_ts");
   });
 
   it("sorts by the displayed cost when the Cost header is clicked", () => {

--- a/frontend/src/triage/TriageBoard.tsx
+++ b/frontend/src/triage/TriageBoard.tsx
@@ -11,10 +11,11 @@ interface Props {
   onOpenSession: (session: SessionCard) => void;
 }
 
-type SortKey = "first_ts" | "cost_usd" | "error_count" | "finding_count" | "event_count" | "subagent_count";
+type SortKey = "first_ts" | "last_ts" | "cost_usd" | "error_count" | "finding_count" | "event_count" | "subagent_count";
 
 const SORT_OPTIONS: Array<{ key: SortKey; label: string }> = [
   { key: "first_ts", label: "Newest first" },
+  { key: "last_ts", label: "Recently ended" },
   { key: "cost_usd", label: "Highest estimated API-equivalent cost" },
   { key: "error_count", label: "Most observed errors" },
   { key: "finding_count", label: "Supported finding" },
@@ -23,8 +24,9 @@ const SORT_OPTIONS: Array<{ key: SortKey; label: string }> = [
 ];
 
 function sortValue(session: SessionCard, sortKey: SortKey): number {
-  if (sortKey === "first_ts") {
-    const timestamp = session.first_ts ? Date.parse(session.first_ts) : Number.NaN;
+  if (sortKey === "first_ts" || sortKey === "last_ts") {
+    const value = sortKey === "first_ts" ? session.first_ts : session.last_ts;
+    const timestamp = value ? Date.parse(value) : Number.NaN;
     return Number.isNaN(timestamp) ? 0 : timestamp;
   }
   return session[sortKey] as number;
@@ -34,11 +36,11 @@ function formatUsd(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
-function formatSessionStart(value: string | null): string {
+function formatTimestamp(value: string | null): string {
   if (!value) return "—";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
-  return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  return date.toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" });
 }
 
 function formatBasis(value: SessionCard["top_finding_basis"]): string | null {
@@ -156,6 +158,7 @@ function TriageBoard({ projects, sessions, loading, onOpenSession }: Props) {
                 <tr>
                   <th>Session</th>
                   {header("first_ts", "Started")}
+                  {header("last_ts", "Ended")}
                   {header("finding_count", "Supported finding")}
                   <th>Impact</th>
                   {header("cost_usd", "Cost")}
@@ -181,7 +184,12 @@ function TriageBoard({ projects, sessions, loading, onOpenSession }: Props) {
                       </td>
                       <td className="cell-started">
                         {session.first_ts ? (
-                          <time dateTime={session.first_ts}>{formatSessionStart(session.first_ts)}</time>
+                          <time dateTime={session.first_ts}>{formatTimestamp(session.first_ts)}</time>
+                        ) : "—"}
+                      </td>
+                      <td className="cell-ended">
+                        {session.last_ts ? (
+                          <time dateTime={session.last_ts}>{formatTimestamp(session.last_ts)}</time>
                         ) : "—"}
                       </td>
                       <td className={`cell-issue issue-${finding.tone}`}>


### PR DESCRIPTION
Ported from PR #46 onto the rewritten triage board, with a compact short date format shared by the Started and Ended cells.